### PR TITLE
ci: publish every develop change as a pre-release automatically

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,128 @@
+name: Auto Release Candidate
+
+# Publishes a pre-release automatically for every change that lands on develop,
+# replacing the manual bump -> branch -> `gh workflow run` sequence.
+#
+# Why no release/X.Y.Z branch any more: that branch only ever existed as
+# something for the manual workflow_dispatch to point at. Chaining it from CI is
+# not possible anyway -- a push made with GITHUB_TOKEN deliberately does not
+# trigger other workflows, so pushing release/X.Y.Z from here would never have
+# started the RC build. Tags are the real record of what shipped, and this
+# workflow creates them. release_candidate.yml is kept as a manual escape hatch.
+#
+# Nothing is committed or pushed to develop. Required status checks apply to
+# direct pushes, so a bookkeeping commit from CI would be rejected by branch
+# protection; instead the version is computed from tags and written into the
+# working tree for the build only.
+#
+# Scope: pre-releases only. Promoting one to a stable release stays deliberate --
+# it means pushing a plain vX.Y.Z tag, which release.yml already handles. That
+# boundary is intentional: an RC exists to be tested on hardware, and CI cannot
+# verify e-ink refresh behaviour, heap fragmentation, or anything else on the
+# device-only half of the testing checklist.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+# Two releases racing would compute the same next version and collide on the
+# tag. Queue them instead of cancelling: every landed change deserves its own RC.
+concurrency:
+  group: auto-release-candidate
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish RC
+    # `[skip release]` anywhere in the commit subject opts a change out, for
+    # doc-only or workflow-only pushes that do not warrant a firmware build.
+    if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          # Full history + tags: the next version is derived from existing tags,
+          # which a shallow clone would not have.
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+          # Highest already-released version, from tags. Matches both stable
+          # (v1.7.76) and RC (v1.7.81-rc+a82c3bd) tags, taking just X.Y.Z.
+          LATEST=$(git tag | sed -nE 's/^v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' | sort -V | tail -1)
+          # platformio.ini acts as a floor, so a deliberate manual bump to a new
+          # minor/major is respected rather than silently overwritten.
+          INI=$(grep -m1 '^version = ' platformio.ini | cut -d' ' -f3)
+          BASE=$(printf '%s\n%s\n' "${LATEST:-0.0.0}" "$INI" | sort -V | tail -1)
+          NEXT=$(echo "$BASE" | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEXT-rc+$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Latest tag: ${LATEST:-none} | platformio.ini: $INI | building: $NEXT" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stamp version for this build
+        # Working tree only -- never committed. gh_release_rc reads
+        # ${crosspoint.version} from here.
+        run: |
+          set -euo pipefail
+          sed -i "s/^version = .*/version = ${{ steps.version.outputs.next }}/" platformio.ini
+          grep -m1 '^version = ' platformio.ini
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: false
+
+      - name: Install PlatformIO Core
+        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: pio-${{ runner.os }}-
+
+      - name: Build CrossPoint Release Candidate
+        env:
+          CROSSPOINT_RC_HASH: ${{ steps.version.outputs.short_sha }}
+        run: pio run -e gh_release_rc
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: CrossPoint-RC-${{ steps.version.outputs.next }}
+          path: |
+            .pio/build/gh_release_rc/bootloader.bin
+            .pio/build/gh_release_rc/firmware.bin
+            .pio/build/gh_release_rc/firmware.elf
+            .pio/build/gh_release_rc/firmware.map
+            .pio/build/gh_release_rc/partitions.bin
+
+      - name: Publish GitHub Pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          # firmware.bin only, matching release.yml, so ReleaseJsonParser and
+          # OtaUpdater need no per-channel special-casing. Devices with
+          # Settings -> System -> Pre-release enabled check the full /releases
+          # list and will see this; everyone else stays on /releases/latest,
+          # which GitHub documents as excluding pre-releases.
+          tag_name: ${{ steps.version.outputs.tag }}
+          prerelease: true
+          generate_release_notes: true
+          files: .pio/build/gh_release_rc/firmware.bin

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,51 @@
+name: Dependabot auto-merge
+
+# Dependabot opens the PR, CI proves it builds, and this merges it -- so routine
+# dependency traffic never needs a human. Branch protection still applies: the
+# merge is queued via GitHub's auto-merge and only completes once the required
+# `Test Status` check passes, so a bump that breaks the build stays open.
+#
+# Deliberately limited to minor and patch. A major bump changes behaviour by
+# definition and gets left for a person to read -- that is exactly the class of
+# change that should not land unattended on the branch releases are cut from.
+# The SDK submodule is excluded outright for the same reason, only stronger: it
+# moves the display/input/storage layer under the whole firmware and needs
+# testing on real hardware, which no CI job here can do.
+
+on: pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: >-
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+           steps.meta.outputs.update-type == 'version-update:semver-patch') &&
+          steps.meta.outputs.package-ecosystem != 'submodules'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Explain why a major update was left alone
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Left for manual review: major version bump (\`${{ steps.meta.outputs.dependency-names }}\` to ${{ steps.meta.outputs.new-version }}). Auto-merge covers minor and patch only."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removes the manual **bump → release branch → `gh workflow run`** sequence. A change landing on `develop` now builds and publishes its own RC with no human step.

## Design constraints that shaped this

Two GitHub behaviours ruled out the obvious approaches:

1. **A push made with `GITHUB_TOKEN` does not trigger other workflows.** So pushing `release/X.Y.Z` from CI would never have started the RC build — the chain the manual process relied on cannot be automated as-is.
2. **Required status checks apply to direct pushes**, not just merges. So a version-bump commit from CI would be rejected by the branch protection just enabled.

Hence: no release branch, and nothing committed to `develop`. **Tags become the authoritative version record**, derived at build time, with `platformio.ini` as a floor so a deliberate minor/major bump is honoured rather than overwritten.

## Scope boundary — deliberate

Pre-releases only. Promoting to stable still means pushing a plain `vX.Y.Z` tag (`release.yml` already handles that). An RC exists *to be tested on hardware*, and CI cannot judge e-ink refresh, ghosting, or heap fragmentation — the device-only half of the testing checklist. That promotion should stay a decision, not a side effect.

## Also included

**Dependabot auto-merge**, minor/patch only. Queued via GitHub auto-merge so branch protection still gates it — a bump failing `Test Status` stays open. Majors are left for a human with an explanatory comment; the SDK submodule is excluded outright since it moves the display/input/storage layer under the whole firmware.

## Escape hatch

`[skip release]` in a commit subject suppresses the RC, for doc- or workflow-only pushes.

## Verification

Version derivation tested against the real tag list → `1.7.81` → `1.7.82`. Note the first attempt used `\+` in a basic-regex `sed`, which silently produced an empty result on BSD sed; corrected to a portable `sed -E`. Merging this PR is itself the live test — it should produce `v1.7.82-rc+<sha>` with no intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
