### PR TITLE
fix: wrap the QR sign-in messages instead of overrunning the panel

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -10,6 +10,7 @@
 #include <Utf8.h>
 
 #include <algorithm>
+#include <string_view>
 
 #include "FontCacheManager.h"
 
@@ -878,6 +879,59 @@ void GfxRenderer::drawCenteredText(const int fontId, const int y, const char* te
                                    const EpdFontFamily::Style style, const BidiUtils::BidiBaseDir baseDir) const {
   const int x = (getScreenWidth() - getTextWidth(fontId, text, style, baseDir)) / 2;
   drawText(fontId, x, y, text, black, style, baseDir);
+}
+
+int GfxRenderer::drawCenteredTextWrapped(const int fontId, const int y, const int maxWidth, const char* text,
+                                         const int maxLines, const bool black, const EpdFontFamily::Style style) const {
+  if (text == nullptr || *text == '\0' || maxWidth <= 0 || maxLines <= 0) return 0;
+
+  const int lineHeight = getLineHeight(fontId);
+  std::string_view remaining{text};
+  // Reused across every line so a wrapped message costs one buffer, not one per row.
+  std::string line;
+  int linesDrawn = 0;
+
+  while (linesDrawn < maxLines) {
+    const auto firstNonSpace = remaining.find_first_not_of(' ');
+    if (firstNonSpace == std::string_view::npos) break;  // only trailing spaces left
+    remaining.remove_prefix(firstNonSpace);
+
+    // Final permitted row: hand the whole remainder to truncatedText, which either fits it
+    // or ellipsizes. Keeps "there is more text" visible rather than dropping it silently.
+    if (linesDrawn == maxLines - 1) {
+      line = truncatedText(fontId, std::string(remaining).c_str(), maxWidth, style);
+      drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
+      return ++linesDrawn * lineHeight;
+    }
+
+    // Extend one word at a time and keep the longest prefix that still fits.
+    size_t bestEnd = 0;
+    size_t scan = 0;
+    while (true) {
+      const size_t nextSpace = remaining.find(' ', scan);
+      const size_t end = nextSpace == std::string_view::npos ? remaining.size() : nextSpace;
+      line.assign(remaining.substr(0, end));
+      if (getTextWidth(fontId, line.c_str(), style) > maxWidth) break;
+      bestEnd = end;
+      if (nextSpace == std::string_view::npos) break;
+      scan = nextSpace + 1;
+    }
+
+    if (bestEnd == 0) {
+      // First word alone overruns the width -- ellipsize it so the row is still legible.
+      const size_t firstSpace = remaining.find(' ');
+      bestEnd = firstSpace == std::string_view::npos ? remaining.size() : firstSpace;
+      line = truncatedText(fontId, std::string(remaining.substr(0, bestEnd)).c_str(), maxWidth, style);
+    } else {
+      line.assign(remaining.substr(0, bestEnd));
+    }
+
+    drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
+    ++linesDrawn;
+    remaining.remove_prefix(bestEnd);
+  }
+
+  return linesDrawn * lineHeight;
 }
 
 void GfxRenderer::drawTextInWidth(const int fontId, const int x, const int y, const int width, const char* text,

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -339,6 +339,22 @@ class GfxRenderer {
   void drawCenteredText(int fontId, int y, const char* text, bool black = true,
                         EpdFontFamily::Style style = EpdFontFamily::REGULAR,
                         BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  /// Greedy word-wrap of `text` to `maxWidth`, drawn centered, one line per row from `y`
+  /// down. Returns the total height consumed, so a caller can lay out whatever follows
+  /// without assuming a line count.
+  ///
+  /// The wrapping counterpart to truncatedText(): use that when a label must stay on one
+  /// row (list rows, grid captions), this when losing the tail would lose meaning -- a
+  /// sentence telling the user what went wrong and what to do about it. drawCenteredText()
+  /// alone does neither and simply overruns the panel, which clips the text at *both*
+  /// edges once it is wider than the screen, since the draw is centered.
+  ///
+  /// Breaks on ASCII spaces only, so it can never split a UTF-8 sequence. A single word
+  /// too wide to fit is ellipsized via truncatedText() rather than dropped. On reaching
+  /// `maxLines` the remaining text is ellipsized into the final line, so overflow is
+  /// always visible as "..." instead of silently vanishing.
+  int drawCenteredTextWrapped(int fontId, int y, int maxWidth, const char* text, int maxLines, bool black = true,
+                              EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// kashidaExtraPx: extra width (already floored to a whole tatweel-glyph multiple by
   /// the caller) to insert via kashida when this call ends up on the Arabic path --
   /// see ParsedText::computeJustifyPlan. Ignored on the non-Arabic path; Latin

--- a/src/activities/browser/FouladQrLoginActivity.cpp
+++ b/src/activities/browser/FouladQrLoginActivity.cpp
@@ -150,19 +150,29 @@ void FouladQrLoginActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_FOULAD_EBOOKS));
 
   const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
+  // Every message on this screen is a full sentence, and the two failure ones are wider
+  // than the panel at UI_12. drawCenteredText would overrun and, because it centers,
+  // clip them at *both* edges -- the middle of the sentence survives and the start and
+  // end are lost. So they wrap instead. See GfxRenderer::drawCenteredTextWrapped.
+  const int textWidth = pageWidth - metrics.contentSidePadding * 2;
 
   switch (state) {
     case State::ConnectingWifi:
     case State::Starting:
-      renderer.drawCenteredText(UI_12_FONT_ID, contentTop + 40, tr(STR_QR_LOGIN_PREPARING), true);
+      renderer.drawCenteredTextWrapped(UI_12_FONT_ID, contentTop + 40, textWidth, tr(STR_QR_LOGIN_PREPARING),
+                                       /*maxLines=*/3);
       break;
 
     case State::ShowingQr: {
-      renderer.drawCenteredText(UI_10_FONT_ID, contentTop, tr(STR_QR_LOGIN_SCAN_HINT), true);
+      // Height is measured rather than assumed: the hint fits one line in English but
+      // wraps in longer translations, and the QR has to start below wherever it ends.
+      const int hintHeight =
+          renderer.drawCenteredTextWrapped(UI_10_FONT_ID, contentTop, textWidth, tr(STR_QR_LOGIN_SCAN_HINT),
+                                           /*maxLines=*/2);
 
       // Leave room under the QR for the pairing code and its caption.
       const int codeBlockHeight = renderer.getLineHeight(UI_12_FONT_ID) + renderer.getLineHeight(UI_10_FONT_ID) + 24;
-      const int qrTop = contentTop + renderer.getLineHeight(UI_10_FONT_ID) + metrics.verticalSpacing;
+      const int qrTop = contentTop + hintHeight + metrics.verticalSpacing;
       const int qrHeight = pageHeight - qrTop - codeBlockHeight - metrics.buttonHintsHeight - metrics.verticalSpacing;
       const int qrWidth = pageWidth - 40;
       if (qrHeight > 40) {
@@ -183,11 +193,13 @@ void FouladQrLoginActivity::render(RenderLock&&) {
     }
 
     case State::Denied:
-      renderer.drawCenteredText(UI_12_FONT_ID, contentTop + 40, tr(STR_QR_LOGIN_DENIED), true);
+      renderer.drawCenteredTextWrapped(UI_12_FONT_ID, contentTop + 40, textWidth, tr(STR_QR_LOGIN_DENIED),
+                                       /*maxLines=*/4);
       break;
 
     case State::Failed:
-      renderer.drawCenteredText(UI_12_FONT_ID, contentTop + 40, tr(STR_QR_LOGIN_FAILED), true);
+      renderer.drawCenteredTextWrapped(UI_12_FONT_ID, contentTop + 40, textWidth, tr(STR_QR_LOGIN_FAILED),
+                                       /*maxLines=*/4);
       break;
   }
 


### PR DESCRIPTION
## The bug

Every message on the QR sign-in screen is a full sentence, and the two failure ones are wider than the panel at UI_12:

- `"Could not reach Foulad eBooks. Try again or use a password."`
- `"Sign-in was rejected. Try again or use a password."`

`drawCenteredText` neither wraps nor truncates, so they overran the framebuffer. Because the draw is **centered**, the overrun clips at *both* edges — the middle survives, the start and end are lost:

| | |
|---|---|
| Before | `reach Foulad eBooks. Try again or use a` |
| After | `Could not reach Foulad eBooks. Try` / `again or use a password.` |

The user was told neither what failed nor what to do about it. The renderer logged **1622 `Outside range` errors per frame** while drawing it.

## Fix

Adds `GfxRenderer::drawCenteredTextWrapped` — the wrapping counterpart to the existing `truncatedText`. Greedy word-wrap to a width, drawn centered, returning the height consumed.

`truncatedText` stays correct for labels that must hold one row (list rows, grid captions); this is for text where losing the tail loses the meaning.

Safety properties:
- Breaks on **ASCII spaces only**, so it can never split a UTF-8 sequence.
- A single over-wide word is ellipsized via `truncatedText`, not dropped.
- On reaching `maxLines` the remainder is ellipsized into the final line — overflow stays visible as `...` rather than silently vanishing.
- One reused `std::string` buffer per call, not one per line.

The QR screen now **measures** the hint rather than assuming one line: it fits on one in English but won't in longer translations, and the QR must start below wherever it actually ends.

## Verification

Simulator, both affected states, captured via framebuffer dump:

| State | Result |
|---|---|
| `Failed` | wraps to two centered lines, reads in full |
| `ShowingQr` | hint/code placement unchanged |
| `Outside range` errors | **1622 → 0** |

Firmware builds clean; `clang-format` clean.

## Not in scope

`FullScreenMessageActivity` has the same latent bug — it doesn't even truncate. Left alone to keep this to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
