### PR TITLE
fix: wrap FullScreenMessageActivity's text and center it as a block

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -883,12 +883,24 @@ void GfxRenderer::drawCenteredText(const int fontId, const int y, const char* te
 
 int GfxRenderer::drawCenteredTextWrapped(const int fontId, const int y, const int maxWidth, const char* text,
                                          const int maxLines, const bool black, const EpdFontFamily::Style style) const {
+  return layoutCenteredTextWrapped(fontId, y, maxWidth, text, maxLines, black, style, /*draw=*/true);
+}
+
+int GfxRenderer::measureWrappedTextHeight(const int fontId, const int maxWidth, const char* text, const int maxLines,
+                                          const EpdFontFamily::Style style) const {
+  return layoutCenteredTextWrapped(fontId, /*y=*/0, maxWidth, text, maxLines, /*black=*/true, style, /*draw=*/false);
+}
+
+int GfxRenderer::layoutCenteredTextWrapped(const int fontId, const int y, const int maxWidth, const char* text,
+                                           const int maxLines, const bool black, const EpdFontFamily::Style style,
+                                           const bool draw) const {
   if (text == nullptr || *text == '\0' || maxWidth <= 0 || maxLines <= 0) return 0;
 
   const int lineHeight = getLineHeight(fontId);
   std::string_view remaining{text};
   // Reused across every line so a wrapped message costs one buffer, not one per row.
   std::string line;
+  // Counts laid-out rows, painted or not -- the measure path walks the same loop.
   int linesDrawn = 0;
 
   while (linesDrawn < maxLines) {
@@ -900,7 +912,7 @@ int GfxRenderer::drawCenteredTextWrapped(const int fontId, const int y, const in
     // or ellipsizes. Keeps "there is more text" visible rather than dropping it silently.
     if (linesDrawn == maxLines - 1) {
       line = truncatedText(fontId, std::string(remaining).c_str(), maxWidth, style);
-      drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
+      if (draw) drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
       return ++linesDrawn * lineHeight;
     }
 
@@ -926,7 +938,7 @@ int GfxRenderer::drawCenteredTextWrapped(const int fontId, const int y, const in
       line.assign(remaining.substr(0, bestEnd));
     }
 
-    drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
+    if (draw) drawCenteredText(fontId, y + linesDrawn * lineHeight, line.c_str(), black, style);
     ++linesDrawn;
     remaining.remove_prefix(bestEnd);
   }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -138,6 +138,11 @@ class GfxRenderer {
   mutable int _stripRows = 0;
   mutable bool _stripActive = false;
 
+  // Shared implementation of drawCenteredTextWrapped() and measureWrappedTextHeight():
+  // one greedy word-wrap loop, with drawing switched off for the measuring caller, so the
+  // measured height and the drawn height cannot drift apart.
+  int layoutCenteredTextWrapped(int fontId, int y, int maxWidth, const char* text, int maxLines, bool black,
+                                EpdFontFamily::Style style, bool draw) const;
   void renderChar(const EpdFontFamily& fontFamily, uint32_t cp, int* x, int* y, bool pixelState,
                   EpdFontFamily::Style style) const;
   // Arabic font to actually use for a caller-requested fontId: the specific
@@ -355,6 +360,14 @@ class GfxRenderer {
   /// always visible as "..." instead of silently vanishing.
   int drawCenteredTextWrapped(int fontId, int y, int maxWidth, const char* text, int maxLines, bool black = true,
                               EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  /// The height drawCenteredTextWrapped() would consume, without drawing anything. For
+  /// callers that must vertically center a wrapped block: the block's height is not known
+  /// until the wrap is computed, so the alternative is drawing it twice.
+  ///
+  /// Shares the wrap loop with the draw path, so the two can never disagree about where
+  /// the line breaks fall.
+  int measureWrappedTextHeight(int fontId, int maxWidth, const char* text, int maxLines,
+                               EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// kashidaExtraPx: extra width (already floored to a whole tatweel-glyph multiple by
   /// the caller) to insert via kashida when this call ends up on the Arabic path --
   /// see ParsedText::computeJustifyPlan. Ignored on the non-Arabic path; Latin

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -14,7 +14,6 @@
 #include "Xtc.h"
 #include "XtcReaderActivity.h"
 #include "activities/util/BmpViewerActivity.h"
-#include "activities/util/FullScreenMessageActivity.h"
 #include "components/UITheme.h"
 
 bool ReaderActivity::isXtcFile(const std::string& path) { return FsHelpers::hasXtcExtension(path); }

--- a/src/activities/util/FullScreenMessageActivity.cpp
+++ b/src/activities/util/FullScreenMessageActivity.cpp
@@ -7,10 +7,21 @@
 void FullScreenMessageActivity::onEnter() {
   Activity::onEnter();
 
-  const auto height = renderer.getLineHeight(UI_10_FONT_ID);
-  const auto top = (renderer.getScreenHeight() - height) / 2;
+  // Wrapped, not one line: this activity takes an arbitrary caller-supplied string, and
+  // drawCenteredText neither wraps nor truncates. Anything wider than the panel overruns
+  // it, and because the draw is centered the overrun clips at *both* ends -- the middle of
+  // the sentence survives with its start and finish gone. The only current caller passes a
+  // short hardcoded "SD card error" that fits, so this is latent rather than visible
+  // today; but the point of the class is that callers supply their own text, and it breaks
+  // silently the moment that string is translated or lengthened.
+  const int maxWidth = renderer.getScreenWidth() - margin * 2;
+  // Measured before drawing because the block has to be centered as a block, and its
+  // height is not known until the wrap is computed. Centering on a single line's height
+  // and then drawing two pushes the text off-center by half a line.
+  const int height = renderer.measureWrappedTextHeight(fontId, maxWidth, text.c_str(), maxLines, style);
+  const int top = (renderer.getScreenHeight() - height) / 2;
 
   renderer.clearScreen();
-  renderer.drawCenteredText(UI_10_FONT_ID, top, text.c_str(), true, style);
+  renderer.drawCenteredTextWrapped(fontId, top, maxWidth, text.c_str(), maxLines, true, style);
   renderer.displayBuffer(refreshMode);
 }

--- a/src/activities/util/FullScreenMessageActivity.h
+++ b/src/activities/util/FullScreenMessageActivity.h
@@ -6,11 +6,20 @@
 #include <utility>
 
 #include "activities/Activity.h"
+#include "fontIds.h"
 
 class FullScreenMessageActivity final : public Activity {
   std::string text;
   EpdFontFamily::Style style;
   HalDisplay::RefreshMode refreshMode;
+  // Same side margin ConfirmationActivity uses, so the two message screens agree on
+  // where text stops.
+  static constexpr int margin = 20;
+  static constexpr int fontId = UI_10_FONT_ID;
+  // Generous: this is a whole blank screen, so there is room, and the cap exists only to
+  // stop a pathological string from running past the bottom edge. Overflow past it is
+  // ellipsized rather than dropped (see drawCenteredTextWrapped).
+  static constexpr int maxLines = 6;
 
  public:
   explicit FullScreenMessageActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string text,


### PR DESCRIPTION
Same defect the QR sign-in screen had (#14), in the other activity that renders a caller-supplied sentence.

## The bug

`drawCenteredText` neither wraps nor truncates. Anything wider than the panel overruns it, and because the draw is **centered**, the overrun clips at *both* ends — the middle of the sentence survives with its start and finish gone.

**Honest scoping:** this is **latent, not visible today**. The only caller is `main.cpp`'s `"SD card error"` — short, hardcoded, fits. But the entire point of the class is that callers supply their own text, so it breaks silently the first time one is translated or lengthened. And the SD-error path is precisely one nobody exercises until it matters.

## A second bug behind the first

Vertical centring computed `top` from a **single line's** height. With one line that's correct by accident; with a wrapped block it lands off-centre by half the block. The height is now measured before drawing.

## Why the renderer changed too

Measuring needs the wrap computed *without* painting. So `drawCenteredTextWrapped` and the new `measureWrappedTextHeight` now share one private layout loop, with drawing switched off for the measuring caller.

Sharing rather than writing a second copy is deliberate: a duplicate wrap loop is exactly the kind of thing that silently desyncs from the drawing one later, and then the measured and drawn heights disagree with no visible cause.

## Also

- `margin`/`fontId` lifted to named constants matching `ConfirmationActivity`'s, so the two message screens agree on where text stops.
- `maxLines = 6` — a blank screen has room; the cap only stops a pathological string running past the bottom edge, where it ellipsizes rather than vanishing.
- Drops a stale `#include` of this activity from `ReaderActivity.cpp`, which never referenced it.

## Verification

Simulator, via framebuffer dump:

| Case | Result |
|---|---|
| 80-char string | wraps to 2 centred lines, correctly centred **as a block** |
| Existing `"SD card error"` | renders identically to before — no regression |
| `Outside range` render errors | **0** in both |

Firmware builds clean; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
