### PR TITLE
ci: do not cut a release for changes that cannot alter the firmware

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,6 +28,23 @@ name: Auto Release Candidate
 on:
   push:
     branches: [develop]
+    # A release is only meaningful when the firmware binary can differ. These paths
+    # cannot change it, so cutting an RC for them burns ~6 minutes of CI to publish a
+    # build identical in behaviour to the one before it, and pushes a pointless update
+    # at every device with the Pre-release channel enabled.
+    #
+    # Dependabot is what makes this matter rather than a nicety: it opens a steady
+    # stream of PRs that touch only .github/ or requirements.txt, and with auto-merge
+    # on, each one would otherwise mint its own version number.
+    #
+    # Note platformio.ini is deliberately NOT here -- build flags, partition layout and
+    # the version floor all live in it and all reach the binary.
+    paths-ignore:
+      - '.github/**'
+      - '.skills/**'
+      - 'docs/**'
+      - '**.md'
+      - 'requirements.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `paths-ignore` to the auto-release trigger for `.github/`, `.skills/`, `docs/`, markdown and `requirements.txt`.

## Why

None of these can change the firmware binary. Releasing on them spends ~6 minutes of CI to publish a build **identical in behaviour** to the previous one, and pushes a pointless update to every device with the Pre-release channel enabled.

Surfaced by real traffic, not theory: Dependabot opened 5 PRs, and with auto-merge enabled each would have minted its own version number for a change touching only a workflow file or a pip constraint.

## Deliberately excluded from the ignore list

`platformio.ini` — build flags, partition layout and the version floor all live there, and all reach the binary.

## Relationship to `[skip release]`

Complementary, not a replacement. `paths-ignore` is structural and can't be forgotten; the subject marker still covers a firmware-touching change that deliberately shouldn't ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
