### PR TITLE
fix: cover the nested requirements.txt files in paths-ignore

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -44,6 +44,13 @@ on:
       - '.skills/**'
       - 'docs/**'
       - '**.md'
+      # Three of these exist -- ./requirements.txt, ./scripts/requirements.txt and
+      # ./lib/EpdFont/scripts/requirements.txt -- and GitHub matches path filters against
+      # the full path from the repo root, so a bare 'requirements.txt' silently covers
+      # only the first. The two nested ones each cut a needless RC before this was
+      # widened. Glob rather than a list of the three, so a fourth is covered on the day
+      # it appears.
+      - '**/requirements.txt'
       - 'requirements.txt'
 
 permissions:


### PR DESCRIPTION
## The miss

The previous commit's `paths-ignore` listed a bare `requirements.txt`. GitHub matches path filters against the **full path from the repo root**, so that covers `./requirements.txt` and nothing else.

This repo has three:

```
./requirements.txt                     ← covered
./scripts/requirements.txt             ← missed  (pillow)
./lib/EpdFont/scripts/requirements.txt ← missed  (fonttools)
```

Both nested ones cut a release for a pip-constraint change that cannot alter the firmware — precisely what the previous commit was meant to prevent. **The filter looked correct and I verified it against the wrong file.**

## Fix

Globbed (`**/requirements.txt`) rather than listing all three, so a fourth is covered the day it appears rather than the day someone notices.

Touches only `.github/`, so this PR cuts no release itself — consistent with what it's fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
