### PR TITLE
feat: sign out via a device-facing endpoint, falling back to the app API

### DIFF
--- a/docs/ebooks-device-signout-endpoint.md
+++ b/docs/ebooks-device-signout-endpoint.md
@@ -1,0 +1,130 @@
+# Foulad eBooks — let a device sign itself out
+
+Spec for the **foulad-ebooks** server. Written 2026-07-26, after testing the
+deployed soft-delete work against production.
+
+One endpoint. Everything else it depends on already exists and works.
+
+## Why
+
+Signing out on the device now removes it from the account
+(`docs/device-logout-keep-stats-tasks.md`, shipped in `v1.7.89-rc`). It does that
+by calling `GET /api/app/devices` then `DELETE /api/app/devices/{id}`.
+
+That works only for installs that signed in with the **account password**. Every
+QR-paired device holds a **device token**, and the app API is behind
+`RejectDeviceTokenAuth`, which rejects tokens with a 403:
+
+> A device token is a convenience credential that lives on an e-ink reader and
+> travels over plain HTTP. The app API can delete devices, change settings and
+> manage fonts, so a token lifted off a device must not reach it.
+
+That reasoning is right and the middleware should stay. The problem is the shape
+of the request, not the control: the firmware does not need "delete any device by
+id" — it needs "remove *me*". That is a far narrower capability, and it is safe
+to expose to a token in a way the app API is not.
+
+Confirmed against production: `GET /api/app/devices` with a QR-issued token
+returns `403 {"message":"This endpoint requires an account password, not a device
+token."}`, while the same call with the account password returns 200. So QR
+devices — the primary sign-in path — currently cannot sign themselves out at all.
+
+## The endpoint
+
+```
+POST /opds/device/signout
+```
+
+On the **OPDS** surface (`routes/opds.php`), behind `opds.auth` and deliberately
+**not** behind `RejectDeviceTokenAuth` — reaching it with a device token is the
+entire point.
+
+Request:
+
+```json
+{ "serial_number": "XTE-A1B2C3D4" }
+```
+
+Behaviour: find the authenticated user's device with that serial and remove it,
+by exactly the same path the app API's delete uses — `$device->delete()`, now a
+soft-delete. `Device::booted()`'s `deleted` hook then revokes the tokens and
+writes the `RevokedDevice` tombstone as it already does. **No new removal logic,
+and no second code path that could drift from the first.**
+
+Responses:
+
+| Status | Meaning | Firmware does |
+|---|---|---|
+| `200` | Removed | clears the stored credential |
+| `404` | No such device for this user | clears it too — the end state already holds |
+| `403` | Serial does not match the caller (see below) | keeps the credential, reports failure |
+| `401` | Bad credential | keeps it |
+
+## The security property that makes this safe
+
+**A device token must only be able to sign out its own device.**
+
+Without that, a token lifted off one reader could remove any other device on the
+account — which is precisely the escalation `RejectDeviceTokenAuth` exists to
+prevent, reintroduced through a side door.
+
+The pieces are already there. `OpdsBasicAuth` sets `auth_via` and
+`device_token_id` (lines ~96-97), and `device_tokens` carries `serial_number`
+(migration `2026_07_25_000003`). So:
+
+- if `auth_via === 'device_token'`, require the token's own `serial_number` to
+  equal the request's `serial_number`, and `403` otherwise;
+- if authenticating with the account password, allow any serial the user owns —
+  same authority the app API already grants.
+
+Please cover the mismatch case in a test. It is the one that matters and the one
+that will look like it works if it is missing.
+
+## Not in scope
+
+Nothing else changes. Soft-delete, the tombstone, token revocation, the
+`X-Device-Serial` 401 path and the QR re-pair restore are all deployed and were
+verified end-to-end on production before this was written:
+
+- register throwaway device -> `device_id: 17`
+- delete it -> gone from `GET /api/app/devices`
+- `GET /opds` with `X-Device-Serial` for that serial -> **401**
+- `POST /opds/device` for it -> **403**, "This device was removed from your account."
+- QR re-pair -> lifts the tombstone
+- re-register -> **`device_id: 17` again**
+
+That last line is the proof soft-delete is live: the row was restored rather than
+recreated, so `cascadeOnDelete` never fired and the reading stats survived.
+
+## Verifying
+
+```bash
+# As a QR-issued device token, sign out that device.
+curl -s -o /dev/null -w '%{http_code}\n' -u 'USER:DEVICE_TOKEN' \
+     -X POST http://foulad.one/opds/device/signout \
+     -H 'Content-Type: application/json' \
+     -d '{"serial_number":"ITS_OWN_SERIAL"}'          # expect 200
+
+# The same token must NOT be able to remove a different device.
+curl -s -o /dev/null -w '%{http_code}\n' -u 'USER:DEVICE_TOKEN' \
+     -X POST http://foulad.one/opds/device/signout \
+     -H 'Content-Type: application/json' \
+     -d '{"serial_number":"SOME_OTHER_DEVICE"}'       # expect 403
+
+# Access is cut, and the stats survive.
+curl -s -o /dev/null -w '%{http_code}\n' -u 'USER:DEVICE_TOKEN' \
+     -H 'X-Device-Serial: ITS_OWN_SERIAL' http://foulad.one/opds   # expect 401
+```
+
+## Firmware side
+
+Already written and shipping in the same release as this spec. `FouladDeviceLogout`
+tries `POST /opds/device/signout` first and falls back to the old
+list-then-delete path on **404**, so it works before and after this endpoint is
+deployed with no coordination between the two releases:
+
+- **before**: signout 404s, falls back, password logins work, QR devices fail as they do today
+- **after**: signout succeeds for both, and the fallback stops being reached
+
+The fallback can be deleted once every install is past that release; it is marked
+in the source as removable.

--- a/src/FouladDeviceLogout.cpp
+++ b/src/FouladDeviceLogout.cpp
@@ -10,13 +10,36 @@
 
 namespace {
 
-// The device list is the fattest response this firmware asks for: the server sends
-// every device with its full settings and reading-stats blobs (six devices on the
-// test account came to well over a KB each). Deserializing all of that on a 380KB
-// part to read two fields would be reckless, so ArduinoJson is given a filter and
-// keeps only id and serial_number -- everything else is skipped while streaming and
-// never allocated.
-constexpr size_t DEVICE_LIST_DOC_BYTES = 4096;
+// "Remove me", by serial. The only path a QR-paired device can use: the app API that
+// the fallback in removeThisDevice() calls sits behind RejectDeviceTokenAuth and
+// answers a device token 403, so for every QR install -- the primary sign-in path --
+// that fallback can never succeed.
+//
+// Returns Failed on a 404 so the caller can fall back, since a 404 here means the
+// endpoint is not deployed yet rather than "no such device". The two are told apart by
+// the caller: see removeThisDevice().
+FouladDeviceLogout::Result signOutViaDeviceEndpoint(const std::string& username, const std::string& password,
+                                                    const std::string& serial, int& outStatus) {
+  outStatus = 0;
+
+  JsonDocument requestDoc;
+  requestDoc["serial_number"] = serial;
+  std::string body;
+  serializeJson(requestDoc, body);
+
+  std::string response;
+  const auto err = HttpDownloader::postJson(FOULAD_EBOOKS_DEVICE_SIGNOUT_URL, body, username, password, response);
+  if (err == HttpDownloader::OK) {
+    LOG_INF("LOGOUT", "signed out via /opds/device/signout");
+    return FouladDeviceLogout::Result::Removed;
+  }
+
+  const auto failure = HttpDownloader::getLastFailure();
+  if (failure.stage == HttpDownloader::FailStage::STATUS) {
+    outStatus = failure.detail;
+  }
+  return FouladDeviceLogout::Result::Failed;
+}
 
 }  // namespace
 
@@ -31,6 +54,31 @@ FouladDeviceLogout::Result FouladDeviceLogout::removeThisDevice(const std::strin
     return Result::Failed;
   }
 
+  const std::string ownSerial = FouladDeviceTracking::getSerialNumber();
+
+  // Preferred path. Tried first because it is the only one a device token can use.
+  int status = 0;
+  if (signOutViaDeviceEndpoint(username, password, ownSerial, status) == Result::Removed) {
+    return Result::Removed;
+  }
+  if (status == 404) {
+    // Two different 404s share this status: the endpoint not being deployed yet, and the
+    // device already being absent. Falling back distinguishes them without guessing --
+    // the list below will simply not contain this serial in the second case, which the
+    // caller already treats as success.
+    LOG_DBG("LOGOUT", "signout endpoint unavailable; falling back to the app API");
+  } else if (status != 0) {
+    // A real refusal (401 bad credential, 403 serial mismatch). The fallback authenticates
+    // identically, so retrying it would only repeat the rejection.
+    LOG_ERR("LOGOUT", "signout refused with status %d", status);
+    return Result::Failed;
+  } else {
+    LOG_ERR("LOGOUT", "signout transport failure");
+    return Result::Failed;
+  }
+
+  // FALLBACK -- removable once every install is past the release that added the endpoint
+  // above. Only reachable for account-password logins; a device token gets 403 here.
   std::string response;
   if (!HttpDownloader::fetchUrl(FOULAD_EBOOKS_APP_DEVICES_URL, response, username, password)) {
     const auto failure = HttpDownloader::getLastFailure();
@@ -53,10 +101,9 @@ FouladDeviceLogout::Result FouladDeviceLogout::removeThisDevice(const std::strin
   response.clear();
   response.shrink_to_fit();
 
-  const std::string serial = FouladDeviceTracking::getSerialNumber();
   long deviceId = -1;
   for (JsonObject device : doc["data"].as<JsonArray>()) {
-    if (serial == device["serial_number"].as<std::string>()) {
+    if (ownSerial == device["serial_number"].as<std::string>()) {
       deviceId = device["id"] | -1L;
       break;
     }
@@ -65,7 +112,7 @@ FouladDeviceLogout::Result FouladDeviceLogout::removeThisDevice(const std::strin
   if (deviceId < 0) {
     // Already removed elsewhere (phone app, web). The end state the caller wants
     // already holds, so this is success, not an error.
-    LOG_INF("LOGOUT", "serial %s not listed on the account; nothing to remove", serial.c_str());
+    LOG_INF("LOGOUT", "serial %s not listed on the account; nothing to remove", ownSerial.c_str());
     return Result::NotFound;
   }
 
@@ -73,7 +120,7 @@ FouladDeviceLogout::Result FouladDeviceLogout::removeThisDevice(const std::strin
   snprintf(url, sizeof(url), "%s/%ld", FOULAD_EBOOKS_APP_DEVICES_URL, deviceId);
 
   if (HttpDownloader::deleteRequest(url, username, password, response) == HttpDownloader::OK) {
-    LOG_INF("LOGOUT", "device %ld (%s) removed from the account", deviceId, serial.c_str());
+    LOG_INF("LOGOUT", "device %ld (%s) removed from the account", deviceId, ownSerial.c_str());
     return Result::Removed;
   }
 

--- a/src/FouladEbooksConfig.h
+++ b/src/FouladEbooksConfig.h
@@ -37,6 +37,14 @@ constexpr char FOULAD_EBOOKS_FONT_CONVERT_URL[] = "http://foulad.one/api/fonts/c
 constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_START_URL[] = "http://foulad.one/api/device-login/start";
 constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_POLL_URL[] = "http://foulad.one/api/device-login/poll";
 
+// Device-facing sign-out: "remove me", identified by this device's own serial.
+// On the OPDS surface rather than the app API below, because that one sits behind
+// RejectDeviceTokenAuth and answers a QR-issued device token 403 -- deliberately, since
+// it can delete any device, change settings and manage fonts. Removing only itself is a
+// far narrower capability, so a token may reach this. Contract:
+// docs/ebooks-device-signout-endpoint.md.
+constexpr char FOULAD_EBOOKS_DEVICE_SIGNOUT_URL[] = "http://foulad.one/opds/device/signout";
+
 // Foulad One's app JSON API, used by signing out to remove this device from the
 // account (see FouladDeviceLogout). Behind the SAME opds.auth Basic-Auth middleware
 // as the OPDS routes above, so the credential already stored for Foulad eBooks


### PR DESCRIPTION
Fixes the gap found by testing `v1.7.89-rc` against production: **signing out could never work on a QR-paired device.**

## Why

The app API it called is behind `RejectDeviceTokenAuth`, which answers a device token **403** — deliberately:

> *A device token ... travels over plain HTTP. The app API can delete devices, change settings and manage fonts, so a token lifted off a device must not reach it.*

Verified on production: same call → **200** with the account password, **403** with a QR-issued token.

The control is right; my request shape was wrong. The firmware never needed *"delete any device by id"* — only *"remove me"*, which is narrow enough to expose to a token.

## Change

`FouladDeviceLogout` now POSTs its own serial to `POST /opds/device/signout`.

Server spec: **`docs/ebooks-device-signout-endpoint.md`**.

The part worth reviewing there is the security property: **a device token must only be able to sign out its own device.** Otherwise a token lifted off one reader could remove any other device on the account — reintroducing through a side door the exact escalation `RejectDeviceTokenAuth` prevents. The pieces already exist (`OpdsBasicAuth` sets `auth_via` + `device_token_id`; `device_tokens` carries `serial_number`), so it's an equality check, not new machinery.

## Deployment-order independent — on purpose

The endpoint 404s today, so the old list-then-delete path is kept as a fallback, reached **on 404 only**:

| | Behaviour |
|---|---|
| Before server deploy | signout 404s → falls back → password logins work, QR fails as now |
| After server deploy | signout succeeds for both → fallback stops being reached |

**No coordination needed between this release and the server release.**

A `401`/`403` from signout is deliberately **not** retried through the fallback — it authenticates identically, so retrying would just repeat the rejection. The fallback is marked removable once every install is past this release.

## Verification

`POST /opds/device/signout` → **404** on production right now. That's the path this release actually takes, so behaviour is unchanged from `v1.7.89-rc` until the server side lands.

Also drops an unused constant and stops the fallback re-deriving a serial the caller already computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
