### PR TITLE
feat: fixed home footer, and a shorter wait into the update screen

### DIFF
--- a/src/ArabicFontSystem.cpp
+++ b/src/ArabicFontSystem.cpp
@@ -92,6 +92,17 @@ void ArabicFontSystem::begin(GfxRenderer& renderer) {
   LOG_DBG("ARFS", "Arabic font system ready (%d families discovered)", registry_.getFamilyCount());
 }
 
+void ArabicFontSystem::beginUiOnly(GfxRenderer& renderer) {
+  // Built-in reading font as the fallthrough default, exactly as ensureLoaded's
+  // no-SD-override branch does -- an SD override can't be honoured without the
+  // registry scan this path exists to avoid, and nothing on an OTA boot draws
+  // reading text anyway. The UI tiers (SMALL/UI_10/UI_12 -> Tajawal) are the part
+  // that matters here: without them an Arabic-language interface renders no glyphs.
+  applyArabicMappings(renderer,
+                      resolveBuiltinReadingFontId(SETTINGS.effArabicFontFamily(), SETTINGS.effArabicFontSize()));
+  LOG_DBG("ARFS", "Arabic UI mappings applied (SD registry scan skipped)");
+}
+
 void ArabicFontSystem::ensureLoaded(GfxRenderer& renderer) {
   if (registryDirty_) {
     registryDirty_ = false;

--- a/src/ArabicFontSystem.h
+++ b/src/ArabicFontSystem.h
@@ -23,6 +23,13 @@ class ArabicFontSystem {
   /// Call once during setup.
   void begin(GfxRenderer& renderer);
 
+  /// Apply only the built-in Arabic UI mappings (the 8/10/12pt tiers plus a built-in
+  /// reading default), skipping the SD-card registry scan and any SD family load.
+  /// For boot paths that only ever paint firmware UI and then reboot -- the OTA
+  /// screens -- where the reading font can never be used but Arabic UI text still
+  /// has to render. Not a substitute for begin() on any path that reaches the reader.
+  void beginUiOnly(GfxRenderer& renderer);
+
   /// Re-apply after CrossPointSettings::sdArabicFontFamilyName changes (e.g. from the
   /// Settings UI) or the SD font registry changes.
   void ensureLoaded(GfxRenderer& renderer);

--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -512,15 +512,24 @@ void uploadDebugLog(const std::string& username, const std::string& password) {
     }
   }
 
+  // Neither outcome is diagLog()'d, because diagLog() writes to DebugLog::PATH --
+  // the very file this function just uploaded (see diagLog's definition above).
+  //
+  // On failure that would get picked up on the next attempt, and a persistent
+  // failure (e.g. no signal) would spam a line into the log on every reconnect.
+  //
+  // On success it defeats server-side deduplication outright: the upload
+  // endpoint skips storing a body whose hash matches the last one it holds for
+  // this device, so an unchanged reader costs nothing to re-report. Appending
+  // "log upload -> ok" after each successful send made every subsequent body
+  // byte-different, so the hash never matched and every OPDS browse stored a
+  // fresh ~50KB copy (see foulad-ebooks EINK_DEVICE_LOG_TASKS.md 2.4/5.4).
+  //
+  // If a success marker is ever wanted, it has to live somewhere other than the
+  // file being uploaded.
   if (!ok) {
     LOG_ERR(TAG, "Debug log upload failed (status=%d)", HttpDownloader::getLastFailure().detail);
-    // Deliberately not diagLog()'d: appending a failure line to the very file
-    // that just failed to upload would just get picked up on next attempt,
-    // and a persistent failure (e.g. no signal) would otherwise spam a line
-    // into the log on every single reconnect.
-    return;
   }
-  diagLog("log upload -> ok");
 }
 
 bool uploadCrashReport(const std::string& username, const std::string& password) {

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -246,12 +246,14 @@ void ActivityManager::goToFullScreenMessage(std::string message, EpdFontFamily::
 void ActivityManager::goHome(HomeMenuItem initialMenuItem) {
   if (initialMenuItem == HomeMenuItem::NONE && currentActivity) {
     const auto& activityName = currentActivity->name;
-    // FileBrowser/CrossPointWebServer no longer have a Home row to pre-select
-    // (moved under Settings -> System), so they fall through to NONE here.
+    // CrossPointWebServer has no Home row to pre-select (it lives under Settings ->
+    // System), so it falls through to NONE here.
     if (activityName == "RecentBooks") {
       initialMenuItem = HomeMenuItem::RECENTS;
     } else if (activityName == "Settings") {
       initialMenuItem = HomeMenuItem::SETTINGS_MENU;
+    } else if (activityName == "FileBrowser") {
+      initialMenuItem = HomeMenuItem::FILE_BROWSER;
     }
   }
   replaceActivity(std::make_unique<HomeActivity>(renderer, mappedInput, initialMenuItem));

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -17,8 +17,8 @@
 class Activity;    // forward declaration
 class RenderLock;  // forward declaration
 
-// FILE_BROWSER/FILE_TRANSFER are kept for source compatibility with any saved/serialized
-// state, but Home no longer renders or navigates to them directly (moved under Settings ->
+// FILE_TRANSFER and CHECK_UPDATE are kept for source compatibility with any saved/serialized
+// state, but Home no longer renders or navigates to them directly (both live under Settings ->
 // System); see HomeActivity's menuItemToIndex/indexToMenuItem.
 enum class HomeMenuItem {
   NONE,

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -14,9 +14,7 @@
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
-#include "FouladEbooksConfig.h"
 #include "MappedInputManager.h"
-#include "OpdsServerStore.h"
 #include "RecentBooksStore.h"
 #include "SilentRestart.h"
 #include "activities/stats/StatsActivity.h"
@@ -25,22 +23,8 @@
 #include "reading/ReadingStatsStore.h"
 #include "util/CoverThumbs.h"
 
-namespace {
-// The first menu slot is "eBooks" only while a Foulad eBooks account is
-// configured; logged out it becomes "Files" (SD card browser) so users who
-// don't use the catalog aren't shown its icon. The store is a boot-loaded
-// in-RAM vector of at most 8 servers, so this check is effectively free --
-// no SD or network access -- and can run on every render/dispatch.
-bool fouladEbooksLoggedIn() {
-  for (const auto& server : OPDS_STORE.getServers()) {
-    if (server.url == FOULAD_EBOOKS_URL) return true;
-  }
-  return false;
-}
-}  // namespace
-
 int HomeActivity::getMenuItemCount() const {
-  int count = 4;  // eBooks-or-Files, Stats, Update, Settings
+  int count = 4;  // eBooks, Stats, Files, Settings
   if (!recentBooks.empty()) {
     count += recentBooks.size();
   }
@@ -311,26 +295,16 @@ void HomeActivity::loop() {
       const int menuIndex = selectorIndex - static_cast<int>(recentBooks.size());
       switch (indexToMenuItem(menuIndex)) {
         case HomeMenuItem::FOULAD_EBOOKS:
-          // Slot 0 is dual-purpose: "eBooks" with a Foulad eBooks account,
-          // "Files" (SD browser) without one -- see fouladEbooksLoggedIn().
-          if (fouladEbooksLoggedIn()) {
-            onFouladEbooksOpen();
-          } else {
-            activityManager.goToFileBrowser("/");
-          }
+          // Signed out is not a separate destination: goToFouladEbooks() sends an
+          // unconfigured device to FouladEbooksSetupActivity, whose onEnter() opens
+          // the QR sign-in, and a configured one straight to the catalog.
+          onFouladEbooksOpen();
           break;
         case HomeMenuItem::SETTINGS_MENU:
           onSettingsOpen();
           break;
-        case HomeMenuItem::CHECK_UPDATE:
-          // Slot 2 is dual-purpose like slot 0: "Files" when a Foulad eBooks
-          // account is configured (Update moves to Settings > System), the
-          // OTA update flow when not -- see the menuItems comment in render().
-          if (fouladEbooksLoggedIn()) {
-            activityManager.goToFileBrowser("/");
-          } else {
-            onCheckUpdateOpen();
-          }
+        case HomeMenuItem::FILE_BROWSER:
+          activityManager.goToFileBrowser("/");
           break;
         case HomeMenuItem::STATS:
           onStatsOpen();
@@ -366,20 +340,18 @@ void HomeActivity::render(RenderLock&&) {
                           recentBooks, selectorIndex, coverRendered, coverBufferStored, bufferRestored,
                           std::bind(&HomeActivity::storeCoverBuffer, this));
 
-  // Build menu items dynamically. Order: Foulad eBooks, Recent Books, Check for
-  // Update, Settings -- matches menuItemToIndex/indexToMenuItem.
+  // Order: eBooks, Stats, Files, Settings -- matches menuItemToIndex/indexToMenuItem.
   // Short labels chosen to fit the bottom icon bar tiles. Recent Books has no
   // menu entry anymore: the recents covers row (and its stacked +N tile, which
   // opens the full grid) took over that job.
-  // Slot 0 and slot 2 both follow the Foulad eBooks login state (user-specified):
-  // logged in  -> eBooks, Stats, Files,  Settings (Update lives in Settings > System)
-  // logged out -> Files,  Stats, Update, Settings (no catalog, so no eBooks icon)
-  // Files (the SD browser) is always one tap away either way.
-  const bool ebooksAccount = fouladEbooksLoggedIn();
-  std::vector<const char*> menuItems = {ebooksAccount ? tr(STR_EBOOKS) : tr(STR_FILES), tr(STR_STATS),
-                                        ebooksAccount ? tr(STR_FILES) : tr(STR_UPDATE), tr(STR_SETTINGS_TITLE)};
-  std::vector<UIIcon> menuIcons = {ebooksAccount ? Library : Folder, Stats, ebooksAccount ? Folder : Transfer,
-                                   Settings};
+  // Fixed, not login-dependent (user-specified). The slots used to swap on Foulad
+  // eBooks login state -- eBooks/Files in slot 0, Files/Update in slot 2 -- which
+  // moved two icons the moment an account was added or removed, and made eBooks
+  // undiscoverable to exactly the people who had not signed in yet. Signed out,
+  // eBooks now opens the QR sign-in (see loop()). Update keeps its permanent home
+  // under Settings > System, where it already lived for signed-in devices.
+  std::vector<const char*> menuItems = {tr(STR_EBOOKS), tr(STR_STATS), tr(STR_FILES), tr(STR_SETTINGS_TITLE)};
+  std::vector<UIIcon> menuIcons = {Library, Stats, Folder, Settings};
 
   if (metrics.homeContinueReadingInMenu && !recentBooks.empty()) {
     // Insert Continue Reading at the top if enabled in theme
@@ -433,11 +405,4 @@ void HomeActivity::onFouladEbooksOpen() {
   // browsing from a fragmented session heap ended in OOM aborts on-device.
   // Does not return.
   silentRestartToFouladEbooks();
-}
-
-void HomeActivity::onCheckUpdateOpen() {
-  // Reboot into the OTA flow instead of opening it in this session: after
-  // Home/library browsing the heap is fragmented below what the GitHub TLS
-  // handshakes need (see silentRestartToOtaCheck). Does not return.
-  silentRestartToOtaCheck();
 }

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -35,17 +35,17 @@ class HomeActivity final : public Activity {
   const HomeMenuItem initialMenuItem;
 
   // Convert HomeMenuItem to menu index (used in onEnter). Order matches render()'s
-  // menuItems construction: Foulad eBooks, Recent Books, Check for Update, Settings
-  // ("Continue Reading" isn't a HomeMenuItem -- it's a prepended label tied to the
-  // recentBooks selection range, handled separately in loop()).
+  // menuItems construction: eBooks, Stats, Files, Settings ("Continue Reading" isn't
+  // a HomeMenuItem -- it's a prepended label tied to the recentBooks selection range,
+  // handled separately in loop()). Every slot is one fixed destination; the pair that
+  // used to swap on Foulad eBooks login state no longer does.
   static int menuItemToIndex(HomeMenuItem item) {
     int i = 0;
-    // Slot 0 shows eBooks (logged in) or Files (logged out) -- same index.
-    if (item == HomeMenuItem::FOULAD_EBOOKS || item == HomeMenuItem::FILE_BROWSER) return i;
+    if (item == HomeMenuItem::FOULAD_EBOOKS) return i;
     ++i;
     if (item == HomeMenuItem::STATS) return i;
     ++i;
-    if (item == HomeMenuItem::CHECK_UPDATE) return i;
+    if (item == HomeMenuItem::FILE_BROWSER) return i;
     ++i;
     if (item == HomeMenuItem::SETTINGS_MENU) return i;
     return 0;
@@ -56,7 +56,7 @@ class HomeActivity final : public Activity {
     int i = 0;
     if (idx == i++) return HomeMenuItem::FOULAD_EBOOKS;
     if (idx == i++) return HomeMenuItem::STATS;
-    if (idx == i++) return HomeMenuItem::CHECK_UPDATE;
+    if (idx == i++) return HomeMenuItem::FILE_BROWSER;
     if (idx == i) return HomeMenuItem::SETTINGS_MENU;
     return HomeMenuItem::NONE;
   }
@@ -65,7 +65,6 @@ class HomeActivity final : public Activity {
   void onStatsOpen();
   void onSettingsOpen();
   void onFouladEbooksOpen();
-  void onCheckUpdateOpen();
 
   int getMenuItemCount() const;
   bool storeCoverBuffer();    // Store frame buffer for cover image

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -44,8 +44,10 @@ void WifiSelectionActivity::onEnter() {
            mac[3], mac[4], mac[5]);
   cachedMacAddress = std::string(macStr);
 
-  // Trigger first update to show scanning message
-  requestUpdate();
+  // No requestUpdate() here: it only sets a flag that ActivityManager::loop() acts on
+  // after onEnter() returns, so the paint landed *after* whichever blocking radio path
+  // below ran, not before it. Both attemptConnection() and startWifiScan() now paint
+  // their own screen ahead of their blocking work instead.
 
   // Attempt to auto-connect to the last network
   if (allowAutoConnect) {
@@ -59,8 +61,7 @@ void WifiSelectionActivity::onEnter() {
         selectedRequiresPassword = !cred->password.empty();
         usedSavedPassword = true;
         autoConnecting = true;
-        attemptConnection();
-        requestUpdate();
+        attemptConnection();  // paints "Connecting to <ssid>" itself, before the radio work
         return;
       }
     }
@@ -91,7 +92,11 @@ void WifiSelectionActivity::startWifiScan() {
   autoConnecting = false;
   state = WifiSelectionState::SCANNING;
   networks.clear();
-  requestUpdate();
+  // Blocking paint, not requestUpdate(): everything below stalls the calling task for
+  // roughly a second (WiFi stack bring-up on a cold radio, plus the explicit delay), and
+  // a deferred update wouldn't reach the panel until after that, leaving the previous
+  // screen up with no sign the scan had started.
+  requestUpdateAndWait();
 
   // Set WiFi mode to station
   WiFi.mode(WIFI_STA);
@@ -209,7 +214,13 @@ void WifiSelectionActivity::attemptConnection() {
   connectionStartTime = millis();
   connectedIP.clear();
   connectionError.clear();
-  requestUpdate();
+  // Paint "Connecting to <ssid>" before the radio work below, not after. requestUpdate()
+  // only sets a flag consumed once ActivityManager::loop() regains control, so with
+  // WiFi.mode() + disconnect + delay(100) + WiFi.begin() in between, the panel kept
+  // showing the previous screen for the whole bring-up. Worst on the OTA path, where
+  // this is the first paint after a reboot and the user has already been staring at a
+  // static frame since pressing the menu item.
+  requestUpdateAndWait();
 
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
   WiFi.mode(WIFI_STA);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,11 @@ void silentRestartToOtaCheck() {
   silentRebootTarget = SILENT_REBOOT_TARGET_OTA_CHECK;
   silentRebootMagic = SILENT_REBOOT_MAGIC;
   LOG_DBG("MAIN", "Silent restart (target=ota_check)");
-  GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
+  // Names the operation rather than showing the generic "Loading" popup: this frame is
+  // what the panel retains for the whole reboot + WiFi + GitHub TLS wait, which is by
+  // far the longest of the silent-restart targets. "Loading" for that long reads as a
+  // hang; "Checking for update..." reads as progress.
+  GUI.drawPopup(renderer, tr(STR_CHECKING_UPDATE));
   delay(50);
   ESP.restart();
 }
@@ -456,7 +460,12 @@ void enterDeepSleep(bool fromTimeout = false) {
   powerManager.startDeepSleep(gpio);
 }
 
-void setupDisplayAndFonts(bool seamless = false) {
+// uiOnlyFonts: skip the SD-card reading-font discovery and the Quran self-heal, keeping
+// only what firmware UI needs to paint. For boot paths whose target activity can never
+// show book text and always ends in another reboot (the OTA screens) -- see setup()'s
+// otaBoot. Everything skipped here is reachable on demand later (ensureLoaded /
+// ensureExtracted), so this is a latency trade, not a functional one.
+void setupDisplayAndFonts(bool seamless = false, bool uiOnlyFonts = false) {
   display.begin(seamless);
   renderer.begin();
   activityManager.begin();
@@ -503,6 +512,15 @@ void setupDisplayAndFonts(bool seamless = false) {
   renderer.insertFont(TAJAWAL_18_FONT_ID, tajawal18FontFamily);
   renderer.insertFont(QURANCOMMON_18_FONT_ID, quranCommon18FontFamily);
   renderer.insertFont(SURAHBANNER_24_FONT_ID, surahBanner24FontFamily);
+
+  if (uiOnlyFonts) {
+    // Two SD directory walks (Latin + Arabic font roots) and a Quran integrity check
+    // stand between the reboot and the first OTA paint, for fonts that screen cannot
+    // draw. Arabic UI text still needs its mappings, so that much is kept.
+    arabicFontSystem.beginUiOnly(renderer);
+    LOG_DBG("MAIN", "UI-only font setup (SD font discovery and Quran self-heal skipped)");
+    return;
+  }
 
   // Discover and load SD card fonts
   sdFontSystem.begin(renderer);
@@ -632,7 +650,18 @@ void setup() {
                             : !APP_STATE.showBootScreen ? BootResume::QuickResume
                                                         : BootResume::Splash;
 
-  setupDisplayAndFonts(resume != BootResume::Splash);
+  // The OTA boot targets only ever paint the update screen and then restart again --
+  // every exit path out of OtaUpdateActivity ends in a reboot (success restarts into
+  // the new firmware, back-out goes through onExit's silentRestart) -- so no reader
+  // font loaded on this boot could ever be used. Skip that work to shorten the wait
+  // between pressing "Check for updates" and the first OTA paint. Guarded on the two
+  // routing conditions checked ahead of the OTA branch below, so a panic reboot or a
+  // recovery-mode boot that happens to carry an OTA target still gets full fonts.
+  const bool otaBoot =
+      resume == BootResume::Silent && !recoveryFirmwareMode && !HalSystem::isRebootFromPanic() &&
+      (snapshotTarget == SILENT_REBOOT_TARGET_OTA_CHECK || snapshotTarget == SILENT_REBOOT_TARGET_OTA_INSTALL);
+
+  setupDisplayAndFonts(resume != BootResume::Splash, otaBoot);
 
   switch (resume) {
     case BootResume::Silent:


### PR DESCRIPTION
Two changes to the same complaint — "when I click update the foulad-eink it takes long time to open" — plus the footer restructure requested on top of it.

---

# 1. `perf`: cut the dead wait before the update screen paints

`Check for updates` deliberately reboots before doing anything — `SettingsActivity.cpp:387-391` calls `silentRestartToOtaCheck()` so the GitHub TLS handshake gets an unfragmented heap. That stays. What changes is the three things that made the wait longer and blanker than it had to be.

### First paint happens before the radio work, not after

`WifiSelectionActivity` asked for its `Connecting…` / `Scanning…` screen with `requestUpdate()`, which only sets a flag that `ActivityManager::loop()` consumes once the whole call chain returns (`ActivityManager.cpp:149-155`). With `WiFi.mode()` + `disconnect` + `delay(100)` + `WiFi.begin()` in between, the paint landed after the stall instead of before it, leaving the previous screen up with no sign anything had started.

`attemptConnection()` and `startWifiScan()` now call `requestUpdateAndWait()` right after setting their state and before touching the radio. The now-redundant `requestUpdate()` in `onEnter()` is removed, so this relocates the existing refresh rather than adding a second one.

### OTA boots skip fonts they cannot use

The OTA boot targets ran two SD directory walks for reading fonts plus the Quran integrity check, all for a screen that only draws `UI_10_FONT_ID` / `SMALL_FONT_ID`. Every exit path out of `OtaUpdateActivity` ends in a reboot — success restarts into the new firmware, back-out goes through `onExit`'s `silentRestart()` — so nothing loaded on that boot is reachable.

`setupDisplayAndFonts()` takes a `uiOnlyFonts` flag for those targets. A naive skip would break the Arabic UI: `applyArabicMappings()` maps the 8/10/12pt tiers to Tajawal, and without it an Arabic interface renders no glyphs, so `ArabicFontSystem::beginUiOnly()` applies just those mappings with a built-in reading default and no SD scan. Gated on `!recoveryFirmwareMode && !isRebootFromPanic()`, matching the two routing conditions checked ahead of the OTA branch, so a panic or recovery boot carrying a stale OTA target still gets full fonts.

### The popup names what it is doing

`silentRestartToOtaCheck()` drew the generic `STR_LOADING_POPUP`. That frame is what the panel retains for the entire reboot + WiFi + TLS wait — the longest of the silent-restart targets by a wide margin — and "Loading" held that long reads as a hang. Now `STR_CHECKING_UPDATE` ("Checking for update...").

**Not touched:** the reboot itself, and `HalClock::quickSyncSystemTime()` — its 5s is a cap, not a fixed cost; it returns as soon as SNTP completes.

---

# 2. `feat`: fix the home footer instead of swapping it on login state

The bottom row swapped two of its four slots on Foulad eBooks login state:

| | slot 0 | slot 1 | slot 2 | slot 3 |
|---|---|---|---|---|
| signed in | eBooks | Stats | Files | Settings |
| signed out | Files | Stats | Update | Settings |

Two icons moved the moment an account was added or removed, and the eBooks tile — the way in to the catalog — was hidden from exactly the people who had not signed in yet. It is now always **eBooks, Stats, Files, Settings**.

Signed out, eBooks opens the QR sign-in. That needed no new routing: `goToFouladEbooks()` already sends an unconfigured device to `FouladEbooksSetupActivity`, whose `onEnter()` launches `FouladQrLoginActivity`, and a configured one straight to the catalog. Only `HomeActivity`'s dual-purpose slot check stood in the way, so this deletes it — along with the now-callerless `onCheckUpdateOpen()` and the `fouladEbooksLoggedIn()` helper. Slot 2 becomes `HomeMenuItem::FILE_BROWSER`, which is what it now always is.

Update leaves the footer entirely and keeps its permanent home under Settings > System, where signed-in devices already had it.

The existing sign-out message already read *"Signed out. Open Foulad eBooks again to sign in."* — which only worked as instructions once the tile stopped disappearing on logout.

Backing out of the file browser now re-selects the Files tile, matching Recents and Settings. The comment claiming FileBrowser had no home row to select was already stale; leaving it would have made Files the one tile that drops you back onto eBooks when you leave it.

---

## Testing

- `pio run -e gh_release_rc` clean, no warnings, against both the develop-pinned SDK (`e62f6c16`) and a newer local one.
- clang-format verified on all eight files.
- Not run in the simulator: flat heap and instant refresh mean it cannot show the latency half at all.

Needs hardware:
- [ ] Time from pressing "Check for updates" to the `Connecting…` screen, before vs after
- [ ] Arabic UI language — the OTA and WiFi screens still render text (the one path the font skip could regress)
- [ ] Quran toggle on — still opens after an OTA check; its self-heal now runs on the next normal boot instead
- [ ] Footer in all four orientations — labels are short but vary by language
- [ ] Signed-out eBooks tap reaches the QR screen (device-only: the simulator stubs `qrcode_getModule()` to 0, so QR codes always render blank there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)