### PR TITLE
fix: go back to QR sign-in when a device is removed remotely

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -755,6 +755,31 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
     }
     state = BrowserState::ERROR;
     errorMessage = tr(STR_OPDS_SIGNED_OUT);
+
+    if (server.url == FOULAD_EBOOKS_URL) {
+      // Removing this device from the Foulad One app revokes its credential, so the
+      // next fetch 401s and arrives here. Ending on the message alone left the user
+      // to work out for themselves that signing in again meant backing out to Home
+      // and re-entering Foulad eBooks -- reported as the device looking broken after
+      // a removal that was deliberate. Take them to the QR sign-in instead.
+      //
+      // The message is painted first, and held long enough to read, so the sign-in
+      // prompt doesn't simply appear with no explanation of what happened.
+      //
+      // Restart rather than a direct transition, for the same reason
+      // ActivityManager::goToFouladEbooks() restarts on the way in: the QR flow runs
+      // WiFi, TLS and polling, and this session's heap has already been fragmented by
+      // a browse. removeServer() above persists immediately, so the reboot cannot
+      // bring back the credential just dropped and loop straight back here.
+      //
+      // Only for Foulad eBooks. A user-added OPDS server has no QR flow to send
+      // anyone to, so it keeps the plain message.
+      requestUpdateAndWait();
+      delay(1500);
+      silentRestartToFouladEbooks();  // does not return
+      return;
+    }
+
     requestUpdate();
     return;
   }


### PR DESCRIPTION
Reported from a device: signing out **on the reader** works fine, but removing the device **from the Foulad One app** leaves the reader stuck on this:

> **Error:**
> Signed out. Open Foulad eBooks again to sign in.
> `« Back`  `Retry`

## What was happening

The removal revokes the device's credential, so its next OPDS fetch 401s. That path already does the right thing internally — it drops the stored credential so the next entry lands on the sign-in screen (`OpdsBookBrowserActivity.cpp:741-760`) — and then stops on an error screen.

The message is accurate, but the device looks broken sitting on it. `Retry` cannot succeed. `Back` gives no hint that signing in again means leaving, returning to Home, and re-entering Foulad eBooks. So the same operation behaved completely differently depending on which end started it: device-initiated sign-out was clean, server-initiated removal dead-ended.

## What it does now

Paints the message, holds it long enough to read, then goes to the QR sign-in on its own.

No new routing was needed — the credential has just been removed from the store, so `goToFouladEbooks()` already resolves to `FouladEbooksSetupActivity`, whose `onEnter()` opens `FouladQrLoginActivity`. The only thing missing was actually going there.

**Via a restart, not a direct transition**, for the same reason `goToFouladEbooks()` restarts on the way in: the QR flow runs WiFi, TLS and polling, on a heap this session's browsing has already fragmented. `removeServer()` persists before the reboot (it calls `saveToFile()`), so the credential just dropped cannot reappear and loop straight back into the same 401.

**Foulad eBooks only.** A user-added OPDS server has no QR flow to send anyone to, so it keeps the plain message.

## Note on re-pairing

Re-pairing after a removal works because approving the QR sign-in in the app is the account holder acting directly, which the server treats as consent to re-authorise — `RevokedDevice` blocks a revoked *token* re-registering itself, not an owner-approved pairing. Worth confirming on hardware as part of the check below, since it's the server behaviour this fix depends on.

## Testing

- `pio run -e gh_release_rc` clean, no warnings.
- clang-format verified.

Needs hardware:
- [ ] Sign in, browse, then remove the device in the Foulad One app; back on the reader, open Foulad eBooks — expect the signed-out message, then the QR screen
- [ ] Scan and approve — confirm re-pairing succeeds after a removal
- [ ] Confirm device-initiated sign-out is unchanged
- [ ] With a user-added (non-Foulad) OPDS server, confirm a 401 still shows the plain message and does not reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)