### PR TITLE
perf: fetch one release, not thirty, on the pre-release check

### DIFF
--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -27,9 +27,17 @@ namespace {
 constexpr char latestReleaseUrl[] = "https://api.github.com/repos/sfoulad/midad-by-foulad/releases/latest";
 // Every release, newest-first, pre-releases included (GitHub does not surface
 // unpublished drafts to an unauthenticated request like this one either way).
-// Used when Settings -> System -> Pre-release is on -- ReleaseJsonParser
-// parses only the first (newest) array element, whichever channel it's on.
-constexpr char allReleasesUrl[] = "https://api.github.com/repos/sfoulad/midad-by-foulad/releases";
+// Used when Settings -> System -> Pre-release is on.
+//
+// per_page=1 because ReleaseJsonParser reads only the FIRST (newest) array
+// element and discards everything after it. Without the parameter GitHub sends
+// its default page of 30 full release objects -- measured at 114,887 bytes
+// against this repo's 190 releases, versus 3,908 with it. That whole payload was
+// being streamed over TLS and parsed on a 160MHz single core so that 96% of it
+// could be thrown away, which is most of the wait between pressing Check for
+// updates and getting an answer. The stable channel never had this:
+// /releases/latest is a single object.
+constexpr char allReleasesUrl[] = "https://api.github.com/repos/sfoulad/midad-by-foulad/releases?per_page=1";
 
 // The pre-rename repository path, tried only if the one above answers 404.
 //
@@ -44,7 +52,7 @@ constexpr char allReleasesUrl[] = "https://api.github.com/repos/sfoulad/midad-by
 // (see checkForUpdate) and a second request cannot succeed either -- it would
 // just spend another of the 60 per hour that failure is already about.
 constexpr char legacyLatestReleaseUrl[] = "https://api.github.com/repos/sfoulad/foulad-eink/releases/latest";
-constexpr char legacyAllReleasesUrl[] = "https://api.github.com/repos/sfoulad/foulad-eink/releases";
+constexpr char legacyAllReleasesUrl[] = "https://api.github.com/repos/sfoulad/foulad-eink/releases?per_page=1";
 
 esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
   return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
@@ -56,7 +64,7 @@ esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
 constexpr char checkCachePath[] = "/.crosspoint/ota_check.txt";
 // Bumped if the line layout below changes; a mismatch just discards the cache and
 // costs one ordinary conditional-less fetch.
-constexpr char checkCacheVersion[] = "1";
+constexpr char checkCacheVersion[] = "2";
 
 struct CheckCache {
   std::string etag;


### PR DESCRIPTION
Reported as the update screen going slow again.

The earlier work (#24) fixed the **dead wait before the first paint** — the screen not changing after you press the button. That's still in place; I verified all three parts of it survived the later merges. This is the other half: how long the check itself takes once that screen is up.

## Measured

The pre-release channel fetches `/releases`, and GitHub's default page is **30 full release objects**:

| Request | Bytes |
|---|---|
| `/releases` (default) | **114,887** |
| `/releases?per_page=1` | **3,908** |

190 releases in this repo now. `ReleaseJsonParser` reads only the **first** array element and discards everything after it — so ~96% of that payload was being streamed over TLS and parsed on a 160 MHz single core in order to be thrown away.

## Why only now, and only for you

The **stable channel was never affected**: it uses `/releases/latest`, a single object. Only pre-release devices fetch the list, which is why this tracked release count rather than being there from day one — and why it's felt worse as today's RCs piled up.

It also compounds with the heap situation the OTA flow already works around: 115 KB streamed through a TLS session is exactly the pressure `silentRestartToOtaCheck` reboots to avoid.

## Also

Cache version bumped to `2`, so ETags stored against the un-paginated URL are discarded outright rather than spending a request to discover they no longer match. One full fetch on the first check after updating, conditional from then on.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.
- Payload sizes measured against the live API, not estimated.

Needs hardware:
- [ ] Time from the "Checking for update…" screen to the answer, before vs after
- [ ] Confirm the correct newest RC is still offered — `per_page=1` must not change *which* release is found, only how many are downloaded
- [ ] Second check in a row should be near-instant (304, conditional cache working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)