### PR TITLE
fix: keep the catalog book id with the reading it describes

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -481,13 +481,19 @@ void reportReadingStats(const std::string& username, const std::string& password
 void flushPendingReadingStats(const std::string& username, const std::string& password) {
   if (!wifiConnected() || username.empty() || password.empty()) return;
 
+  // Driven by the stats store, not RecentBooksStore. Recents caps at 10 and
+  // evicts, so iterating it silently skipped every catalog book that had been
+  // read but pushed out of the top 10 -- those never produced a library_reading
+  // row on the server no matter how often the device reconnected
+  // (INSTRUCTIONS-14). The stats store holds up to MAX_BOOKS and now carries the
+  // id itself, so the two lists can no longer disagree about what is reportable.
+  READING_STATS.ensureLoaded();
   int flushed = 0;
-  for (const auto& book : RECENT_BOOKS.getBooks()) {
-    if (book.fouladBookId.empty()) continue;
-    const ReadingBookStats* stats = READING_STATS.findBook(book.path);
-    if (!stats || stats->totalReadingMs == 0) continue;
-    reportReadingStats(username, password, book.fouladBookId, stats->lastProgressPercent, "",
-                       static_cast<uint32_t>(stats->totalReadingMs / 1000));
+  for (const auto& stats : READING_STATS.getBooks()) {
+    if (stats.fouladBookId.empty()) continue;  // side-loaded, or read before v3
+    if (stats.totalReadingMs == 0) continue;
+    reportReadingStats(username, password, stats.fouladBookId, stats.lastProgressPercent, "",
+                       static_cast<uint32_t>(stats.totalReadingMs / 1000));
     flushed++;
   }
   if (flushed > 0) diagLog("flush: reported " + std::to_string(flushed) + " book(s)");

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -225,6 +225,19 @@ void EpubReaderActivity::onEnter() {
   // committed and saved in onExit().
   if (SETTINGS.trackReadingStats) {
     READING_STATS.beginSession(epub->getPath(), epub->getTitle(), epub->getAuthor());
+    // Capture the catalog id into the stats entry while RecentBooksStore still
+    // holds it. That list caps at 10 and evicts, and the id used to live only
+    // there -- so a catalog book read a while ago lost its id and could never be
+    // reported to /opds/reading-stats again, leaving the server without a
+    // library_reading row and the app without a cover (INSTRUCTIONS-14). Doing it
+    // on open also backfills books that predate the v3 stats format, the moment
+    // they are next read.
+    {
+      const RecentBook recent = RECENT_BOOKS.getDataFromBook(epub->getPath());
+      if (!recent.fouladBookId.empty()) {
+        READING_STATS.setFouladBookId(epub->getPath(), recent.fouladBookId);
+      }
+    }
     // One-time cleanup of the previous stats system's per-book sidecar file.
     Storage.remove((epub->getCachePath() + "/reading_stats.bin").c_str());
     paceWarmupPending = true;

--- a/src/reading/ReadingStatsStore.cpp
+++ b/src/reading/ReadingStatsStore.cpp
@@ -16,9 +16,16 @@ namespace {
 constexpr char STATS_PATH[] = "/.crosspoint/reading_stats.bin";
 constexpr char LEGACY_GLOBAL_STATS_PATH[] = "/.crosspoint/global_stats.bin";
 // v2 adds lifetimeBooksFinished (persisted, never-decreasing books-finished
-// count) -- see that field's own comment in ReadingStatsStore.h. A v1 file
-// (or any other mismatch) starts fresh per this store's existing convention.
-constexpr uint8_t STATS_FILE_VERSION = 2;
+// count) -- see that field's own comment in ReadingStatsStore.h.
+// v3 adds ReadingBookStats::fouladBookId.
+//
+// Older files are READ, not discarded: every field added since v1 is optional on
+// load and simply absent on an older file. Being strict here would erase reading
+// history, streaks and the heatmap to gain nothing -- the ids those files lack
+// are gone regardless, so a v1/v2 book just behaves as side-loaded, which is
+// already the status quo. Only a version this build has never heard of starts
+// fresh.
+constexpr uint8_t STATS_FILE_VERSION = 3;
 // Sanity bounds for a corrupt file (counts read before any allocation).
 constexpr uint16_t MAX_FILE_BOOKS = 512;
 constexpr uint16_t MAX_FILE_DAYS = 4096;
@@ -58,8 +65,8 @@ void ReadingStatsStore::ensureLoaded() {
   // rather than discarding all existing streak/per-book history just to add
   // one counter. Anything else (0, or newer than we understand) starts fresh,
   // same as this store's existing convention.
-  if (version != 1 && version != STATS_FILE_VERSION) {
-    LOG_DBG("RSTAT", "Stats file version mismatch (%u), starting fresh", version);
+  if (version < 1 || version > STATS_FILE_VERSION) {
+    LOG_DBG("RSTAT", "Stats file version %u not understood, starting fresh", version);
     return;
   }
   serialization::readPod(f, maxStreakDays);
@@ -80,6 +87,11 @@ void ReadingStatsStore::ensureLoaded() {
     serialization::readString(f, book.path);
     serialization::readString(f, book.title);
     serialization::readString(f, book.author);
+    // Absent before v3. Left empty, so the book reports as side-loaded until it
+    // is next opened from the catalog -- see the field's comment.
+    if (version >= 3) {
+      serialization::readString(f, book.fouladBookId);
+    }
     serialization::readPod(f, book.totalReadingMs);
     serialization::readPod(f, book.sessions);
     serialization::readPod(f, book.lastSessionMs);
@@ -379,6 +391,16 @@ uint32_t ReadingStatsStore::getLatestReadingDayOrdinal() const {
   return readingDays.empty() ? 0 : readingDays.back().dayOrdinal;
 }
 
+void ReadingStatsStore::setFouladBookId(const std::string& path, const std::string& fouladBookId) {
+  if (fouladBookId.empty()) return;  // never clear a known id with an absent one
+  ensureLoaded();
+  const size_t index = findBookIndex(path);
+  if (index >= books.size()) return;
+  if (books[index].fouladBookId == fouladBookId) return;  // no needless SD write
+  books[index].fouladBookId = fouladBookId;
+  dirty = true;
+}
+
 bool ReadingStatsStore::removeBook(const std::string& path) {
   ensureLoaded();
   const size_t index = findBookIndex(path);
@@ -435,6 +457,7 @@ bool ReadingStatsStore::save() {
     serialization::writeString(f, book.path);
     serialization::writeString(f, book.title);
     serialization::writeString(f, book.author);
+    serialization::writeString(f, book.fouladBookId);
     serialization::writePod(f, book.totalReadingMs);
     serialization::writePod(f, book.sessions);
     serialization::writePod(f, book.lastSessionMs);

--- a/src/reading/ReadingStatsStore.h
+++ b/src/reading/ReadingStatsStore.h
@@ -38,6 +38,17 @@ struct ReadingBookStats {
   std::string path;
   std::string title;
   std::string author;
+  // Foulad eBooks catalog id, empty for a side-loaded file. Lives here rather
+  // than only in RecentBooksStore because that list is capped at 10 and evicts:
+  // a catalog book read a while ago used to lose its id entirely, so
+  // flushPendingReadingStats() could never report it and the server never got a
+  // library_reading row for it (see INSTRUCTIONS-14). Here it has exactly the
+  // lifetime of the reading it describes.
+  //
+  // A separate path->id map was the alternative and is worse: it can drift, and
+  // a stale entry attributes reading to the WRONG book. A missing id only costs
+  // a cover; a wrong one costs trust in the data.
+  std::string fouladBookId;
   // Ascending dayOrdinal; capped at MAX_DAYS_PER_BOOK (oldest pruned).
   std::vector<ReadingDayStats> readingDays;
   uint64_t totalReadingMs = 0;
@@ -121,6 +132,12 @@ class ReadingStatsStore {
   const std::vector<ReadingBookStats>& getBooks() const { return books; }
   const std::vector<ReadingDayStats>& getReadingDays() const { return readingDays; }
   const ReadingBookStats* findBook(const std::string& path) const;
+  // Records the catalog id for a book already known to the store. Called when a
+  // book is opened, so the id is captured while RecentBooksStore still has it --
+  // before its 10-entry cap evicts the entry (see ReadingBookStats::fouladBookId).
+  // No-op for an unknown path or an empty id, so a side-loaded book is untouched
+  // and an id already stored is never cleared.
+  void setFouladBookId(const std::string& path, const std::string& fouladBookId);
   uint32_t readingMsOnDay(uint32_t dayOrdinal) const;
   uint64_t getTotalReadingMs() const;
   uint64_t getTodayReadingMs() const;


### PR DESCRIPTION
Implements foulad-ebooks `INSTRUCTIONS-14`. No server or app change needed.

## The standing theory was wrong

The firmware had **not** moved to snapshot-only. It still posts `/opds/reading-stats` per book with `book_id`, from two places — the reader on exit, and a flush on every catalog connect. The id was simply not there to send.

## What was actually broken

`fouladBookId` lived **only** in `RecentBooksStore`, which caps at `MAX_RECENT_BOOKS = 10` and evicts. `flushPendingReadingStats()` iterated that list, so:

- A catalog book read a while ago, pushed out of the top 10, **lost its id entirely** — the mapping was gone from the device, not merely hidden.
- The flush could then never report it, no matter how often the device reconnected.

So the 34-books-0-rows device is a mix: genuinely side-loaded files (correctly excluded — they never had an id) and evicted catalog books (incorrectly excluded, and unrecoverable).

## The fix

`fouladBookId` moves into `ReadingBookStats`, where it has exactly the lifetime of the reading it describes. The flush iterates the stats store (`MAX_BOOKS = 40`) instead of recents, so the two lists can no longer disagree about what is reportable. The reader records the id at `beginSession()` — while recents still holds it — which also backfills any pre-v3 book the moment it's next opened.

**Why not a path→id map.** It saves only the format bump: the flush has to stop iterating recents either way, since that's the bug. And it adds a third store that can drift — a stale entry would attribute reading to the **wrong book**. A missing id costs a cover; a wrong one costs trust in the data.

## Migration is lenient by design

Stats file → **v3**. Older files are **read, not discarded**: `fouladBookId` is absent before v3 and stays empty, so those books behave as side-loaded — already the status quo. Being strict would erase reading history, streaks and heatmap data to gain nothing, since the ids in those files are gone regardless.

Version handling changed from an exact-match whitelist to `version < 1 || version > STATS_FILE_VERSION`, so future additions stay backward-readable by default.

## What stays broken, deliberately

Already-evicted books remain unreportable — their ids no longer exist anywhere. Re-downloading is the only recovery and it works on its own if a user ever does; nobody needs telling.

**"Books read this year" will permanently under-count** anyone whose finished books were evicted before this lands, since `completed_at` needs a row to attach to. Not fixable retroactively.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.

Needs hardware — the migration is the risk:
- [ ] **Update a device with existing stats.** Reading history, streak and heatmap must survive intact. This is the regression that would hurt most.
- [ ] Download a book from the catalog, read it, reconnect — confirm a `library_reading` row appears
- [ ] Read an already-downloaded book (pre-v3 entry), reconnect — id should backfill and a row appear
- [ ] Read 11+ books so recents evicts, then reconnect — the evicted ones should still report
- [ ] A side-loaded EPUB should still produce no row, and no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)