### PR TITLE
fix: close the connection before following a redirect

### DIFF
--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -247,6 +247,26 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   int64_t contentLength = esp_http_client_fetch_headers(client);
   int status = esp_http_client_get_status_code(client);
   for (int hop = 0; isRedirect(status) && hop < 5; ++hop) {
+    // Close before following. The redirect response carries a body of its own
+    // (GitHub's API answers a renamed repository with 301 + a 215-byte JSON
+    // payload), and keep_alive_enable means the socket is reused -- so reopening
+    // without consuming that body left it queued in front of the next response.
+    // The header parser then read the leftovers instead of the status line,
+    // fetch_headers() failed, and the status code was never populated: the caller
+    // saw FailStage::STATUS with a nonsensical detail of -1.
+    //
+    // That path had simply never run before. Nothing this firmware talks to
+    // redirected on the check endpoint until the GitHub repository was renamed,
+    // at which point every device on a build predating the new URL began failing
+    // its update check outright, reporting "http 5:-1".
+    //
+    // Closing rather than draining is deliberate: it costs a fresh handshake on a
+    // redirect (rare, and unavoidable anyway when the host changes, as it does on
+    // the release CDN hop), and in exchange the next response is parsed on a
+    // connection that cannot be carrying anything stale -- correct regardless of
+    // whether a body was present, chunked, or truncated.
+    LOG_DBG("HTTP", "following redirect %d (status %d)", hop + 1, status);
+    esp_http_client_close(client);
     if (esp_http_client_set_redirection(client) != ESP_OK) break;
     err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -39,21 +39,6 @@ constexpr char latestReleaseUrl[] = "https://api.github.com/repos/sfoulad/midad-
 // /releases/latest is a single object.
 constexpr char allReleasesUrl[] = "https://api.github.com/repos/sfoulad/midad-by-foulad/releases?per_page=1";
 
-// The pre-rename repository path, tried only if the one above answers 404.
-//
-// GitHub redirects a renamed repository's API path to its new one and
-// HttpDownloader follows redirects, so firmware already in the field keeps
-// updating through the old path without help. This pair covers the other
-// direction and the gap in between: firmware built after the rename but
-// installed while the repository is still called foulad-eink, which is exactly
-// the window this release ships into.
-//
-// Only a 404 falls back. A 403 must not, because that is the rate limit
-// (see checkForUpdate) and a second request cannot succeed either -- it would
-// just spend another of the 60 per hour that failure is already about.
-constexpr char legacyLatestReleaseUrl[] = "https://api.github.com/repos/sfoulad/foulad-eink/releases/latest";
-constexpr char legacyAllReleasesUrl[] = "https://api.github.com/repos/sfoulad/foulad-eink/releases?per_page=1";
-
 esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
   return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
 }
@@ -126,7 +111,7 @@ void saveCheckCache(bool prerelease, const std::string& etag, const std::string&
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   const bool prerelease = SETTINGS.otaPrereleaseEnabled != 0;
-  const char* url = prerelease ? allReleasesUrl : latestReleaseUrl;
+  const char* const url = prerelease ? allReleasesUrl : latestReleaseUrl;
   LOG_DBG("OTA", "Checking for update (current: %s, channel: %s)", CROSSPOINT_VERSION,
           prerelease ? "pre-release" : "stable");
 
@@ -154,19 +139,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
     return true;
   };
 
-  bool ok = HttpDownloader::fetchUrl(url, feed, conditional);
-
-  if (!ok && HttpDownloader::getLastFailure().stage == HttpDownloader::FailStage::STATUS &&
-      HttpDownloader::getLastFailure().detail == 404) {
-    // Repository not found under the Midad name -- it has not been renamed yet.
-    // Fall back to the old path for this check. Deliberately narrow: only a 404
-    // means "wrong path", and only then is a second request worth spending.
-    url = prerelease ? legacyAllReleasesUrl : legacyLatestReleaseUrl;
-    LOG_INF("OTA", "Midad repo path 404'd, retrying pre-rename path");
-    // The parser needs no reset: runGet() rejects a non-200 before its read loop,
-    // so the 404 body never reached it.
-    ok = HttpDownloader::fetchUrl(url, feed, conditional);
-  }
+  const bool ok = HttpDownloader::fetchUrl(url, feed, conditional);
 
   if (!ok) {
     LOG_ERR("OTA", "Release check fetch failed");


### PR DESCRIPTION
Fixes the fleet-wide update failure: `code 2  heap N  block N` / **`http 5:-1`**.

## Cause

Renaming the GitHub repository. `v1.7.76` — the last stable release, so effectively every user — requests the old path, which GitHub now answers with a redirect:

```
HTTP/2 301
location: https://api.github.com/repositories/1287699438/releases/latest
content-length: 215
```

`runGet()` followed the `Location` **without reading that 215-byte body**, and `keep_alive_enable = true` means the socket is reused. The payload stayed queued in front of the next response, so the header parser read leftovers instead of a status line, `fetch_headers()` failed, and the status code was never populated — `FailStage::STATUS` with a detail of **-1**, which is not an HTTP status at all. That `-1` was the tell.

**The bug predates the rename.** Nothing this firmware talks to had ever redirected on the check endpoint, so the path had never executed. Renaming the repo ran it, on every device simultaneously.

Everything observed fits: font downloads work (`crosspoint-fonts`, never renamed, no redirect), Library works (plain `http://`), no `ota_check.txt` exists (v1.7.76 has no such feature), and CrossPoint is unaffected — its repo was never renamed.

## Fix

`esp_http_client_close()` before `set_redirection()` + `open()`.

Closing rather than draining is deliberate: a redirect costs a fresh handshake anyway whenever the host changes (as on the release CDN hop), and in exchange the next response is parsed on a connection that cannot be carrying anything stale — correct whether the body was present, chunked, or truncated. Robust to the mechanism rather than assuming this one, which matters given how the diagnosis went.

## Also removed

The `foulad-eink` fallback URLs. They covered the window around the rename, only ever fired on a 404, and would now redirect themselves — dead weight pointing at a name that isn't coming back.

## Who this reaches

**Not the devices already stuck.** The updater is what's broken, so they can't pull the fix. Re-flash over USB or `Settings → System → SD firmware update` is the only route for them.

It does mean the next rename, CDN change or endpoint move won't do this again.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.
- The 301 and its body length confirmed against the live API.

Needs hardware:
- [ ] Re-flashed device: update check succeeds
- [ ] Font download still works (same redirect path, different host)
- [ ] Library, OPDS downloads and covers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)