### PR TITLE
chore: set version to 1.8.1 for the redirect fix release

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.8.0
+version = 1.8.1
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
Prerequisite for tagging `v1.8.1`, same as #35 was for 1.8.0.

`release.yml` has no version-stamping step — `gh_release` reads `CROSSPOINT_VERSION` straight from `platformio.ini`. Left at 1.8.0, a `v1.8.1` tag would publish firmware reporting **1.8.0**, and devices would be re-offered the same update forever.

`[skip release]` in the subject so this doesn't cut an RC of its own — the commit exists to be what the tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)