### PR TITLE
fix: Down scrolls the font list instead of flipping the language

### DIFF
--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -500,20 +500,27 @@ void FontDownloadActivity::loop() {
       requestUpdate();
     });
 
-    // Language tab bar: Left/Right (NavNext/NavPrevious) are otherwise idle on
-    // this screen -- Up/Down (ScrollNext/ScrollPrevious) own the list -- same
-    // free-button reasoning as SettingsActivity's own category tabs, which
-    // switch the same way. Only 2 tabs, so next/prev both just flip.
-    auto toggleLanguage = [this] {
+    // Language tab bar, bound to the FRONT Left/Right buttons directly.
+    //
+    // Not NavNext/NavPrevious, which is what this used to do and was the bug:
+    // those are not "Left/Right" at all. NavNext resolves to side Down + front
+    // Right, and ScrollNext -- which the list navigation above uses -- resolves to
+    // side Down + front Right as well (see MappedInputManager). Both fired on the
+    // same physical Down press, so every press advanced the selection and then
+    // immediately flipped the language, and rebuildVisibleList() reset
+    // selectedIndex_ to 0. The list could never be scrolled: Down only ever
+    // toggled Arabic/English and snapped back to the top.
+    //
+    // Only 2 tabs, so either direction just flips.
+    if (mappedInput.wasPressed(MappedInputManager::Button::Left) ||
+        mappedInput.wasPressed(MappedInputManager::Button::Right)) {
       {
         RenderLock lock(*this);
         showArabic_ = !showArabic_;
         rebuildVisibleList();
       }
       requestUpdate();
-    };
-    buttonNavigator_.onNext(toggleLanguage);
-    buttonNavigator_.onPrevious(toggleLanguage);
+    }
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
       if (!families_.empty()) {


### PR DESCRIPTION
In Manage Fonts, Down never moved through the fonts — it toggled Arabic/English and the selection snapped back to the top.

## Cause

Two handlers fired on the same physical press.

The list used `onScrollNextRelease` (`Button::ScrollNext`); the language tabs used `onNext` (`Button::NavNext`). The comment there asserted that `NavNext`/`NavPrevious` were the front Left/Right buttons, leaving Up/Down to the list. **They aren't.** In `MappedInputManager`:

| | resolves to |
|---|---|
| `NavNext` | side **Down** + front Right |
| `ScrollNext` | side **Down** + front Right |

The side buttons are in both. `ScrollNext` exists to skip `NavNext`'s RTL horizontal flip — not to use different physical buttons.

## Trace for one press of Down

1. `onScrollNextRelease` → `selectedIndex_` 0 → 1
2. `onNext(toggleLanguage)` → fires on the **same** press
3. `rebuildVisibleList()` → **`selectedIndex_ = 0`**

Language flips, cursor returns to the top. Every time. The list can never be scrolled.

## Fix

Bind the tabs to `Button::Left` / `Button::Right` directly — what the original comment intended, and unambiguous: front buttons only, no side-button aliasing. Two tabs, so either direction flips.

## Scope

`FontDownloadActivity` is the **only** screen mixing both navigator families — I checked every file using `onScrollNext`. Everywhere else `onNext()` is ordinary list navigation with nothing competing for the button.

## Testing

- `pio run -e gh_release_rc` clean; clang-format verified.
- Traced rather than run in the simulator — the mechanism is deterministic from the button mapping, and reproduces the reported symptom exactly. Say the word if you want it driven in the simulator for visual confirmation; it needs the local libdeps patches from CLAUDE.md first.

Needs hardware:
- [ ] Settings → Fonts: Up/Down moves through the font list
- [ ] Left/Right switches Arabic ↔ English
- [ ] Confirm still downloads the selected font
- [ ] Same in an RTL (Arabic) UI, where `ScrollNext` deliberately skips the horizontal flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)