### PR TITLE
fix: stop an Arabic filename drawing over its row icon

### DIFF
--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -284,17 +284,27 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   // layout anchoring only. The scroll bar deliberately stays on the right edge.
   const bool rtl = I18N.isRtl();
 
-  int textX = rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection;
-  int textWidth = contentWidth - LyraMetrics::values.contentSidePadding * 2 - hPaddingInSelection * 2;
   int iconSize = 0;
   if (rowIcon != nullptr) {
     iconSize = (rowSubtitle != nullptr) ? mainMenuIconSize : listIconSize;
-    textX += iconSize + hPaddingInSelection;
-    textWidth -= iconSize + hPaddingInSelection;
   }
-  // Right edge of the text area (mirror of textX): where RTL titles right-align.
-  const int textRightEdge = rect.x + contentWidth - LyraMetrics::values.contentSidePadding - hPaddingInSelection -
-                            (rowIcon != nullptr ? iconSize + hPaddingInSelection : 0);
+  // The icon column follows the UI language and stays put for every row, so the
+  // icons line up whatever each row's own script is. The gutter is therefore
+  // reserved on THAT side only.
+  //
+  // Reserving it on both (which is what "mirror of textX" used to do) is what put
+  // an Arabic filename on top of the icon in an English UI: rowRtl right-aligns a
+  // row containing Arabic even when the UI is LTR, so the title ran leftwards from
+  // a right edge that had been pulled in for an icon sitting on the left. Its left
+  // end landed exactly on the icon. Subtracting the gutter from the correct side
+  // also stops wasting a column's width on every row of a plain LTR list.
+  const int iconGutter = (rowIcon != nullptr) ? iconSize + hPaddingInSelection : 0;
+  const int textLeftEdge =
+      rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection + (rtl ? 0 : iconGutter);
+  const int textRightEdge =
+      rect.x + contentWidth - LyraMetrics::values.contentSidePadding - hPaddingInSelection - (rtl ? iconGutter : 0);
+  int textX = textLeftEdge;
+  int textWidth = std::max(0, textRightEdge - textLeftEdge);
 
   // Draw all items
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;


### PR DESCRIPTION
Reported from the SD file browser: Arabic `.epub` names run across the file-type icon.

## Cause

`LyraTheme::drawList` positions the two things by different rules:

| | positioned by |
|---|---|
| row **icon** | `rtl` — the UI language |
| row **title** | `rowRtl` — `rtl` **or** the row contains Arabic |

An Arabic filename in an English UI therefore right-aligns while the icon stays on the left.

On top of that, the text area subtracted the icon gutter from **both** edges — `textX` gained it on the left, and `textRightEdge` lost it on the right, described in the comment as a "mirror of textX". Right-aligning against a right edge that had been pulled in for an icon actually sitting on the *left* let the title's left end land at exactly the icon's left edge, covering it completely.

## Fix

Reserve the gutter on the side the icon is really on. That side follows the UI language, so icons stay in one straight column no matter what script each row happens to contain — mixed Arabic/English listings, which is the normal case here, keep a tidy icon column.

Side benefit: every row of a plain LTR list gets back a column's width that was being reserved twice.

## Scope

Affects the shipped theme — `FouladTheme` inherits `drawList` from `LyraTheme`, and `showsFileIcons()` is `true`. `BaseTheme::drawList` draws no row icons, so it was never affected.

## Testing

- `pio run -e gh_release_rc` clean; clang-format verified.

Needs hardware:
- [ ] SD browser, **English UI**, folder with Arabic `.epub` names — names right-aligned, icon clear, no overlap
- [ ] Same list, **Arabic UI** — icon moves to the right, names still clear
- [ ] Mixed Arabic/English rows — icons stay in one column
- [ ] Rows with a value on the right (Settings lists) still lay out correctly, and subtitles too

🤖 Generated with [Claude Code](https://claude.com/claude-code)