### PR TITLE
fix: upload crash reports without waiting to be asked

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -504,7 +504,8 @@ void uploadDebugLog(const std::string& username, const std::string& password) {
   if (!Storage.exists(DebugLog::PATH)) return;
 
   const std::vector<std::pair<std::string, std::string>> files = {{"log", DebugLog::PATH}};
-  const std::vector<std::pair<std::string, std::string>> fields = {{"serial_number", getSerialNumber()}};
+  const std::vector<std::pair<std::string, std::string>> fields = {{"serial_number", getSerialNumber()},
+                                                                   {"firmware_version", CROSSPOINT_VERSION}};
   std::string response;
   bool ok = HttpDownloader::postFilesMultipart(deviceLogEndpoint(), files, fields, response, 20000, username, password);
 
@@ -543,8 +544,8 @@ bool uploadCrashReport(const std::string& username, const std::string& password)
   if (!Storage.exists(CRASH_REPORT_PATH)) return false;
 
   const std::vector<std::pair<std::string, std::string>> files = {{"log", CRASH_REPORT_PATH}};
-  const std::vector<std::pair<std::string, std::string>> fields = {{"serial_number", getSerialNumber()},
-                                                                   {"type", "crash"}};
+  const std::vector<std::pair<std::string, std::string>> fields = {
+      {"serial_number", getSerialNumber()}, {"type", "crash"}, {"firmware_version", CROSSPOINT_VERSION}};
   std::string response;
   bool ok = HttpDownloader::postFilesMultipart(deviceLogEndpoint(), files, fields, response, 20000, username, password);
 
@@ -566,6 +567,17 @@ bool uploadCrashReport(const std::string& username, const std::string& password)
   diagLog(ok ? "crash report upload -> ok"
              : "crash report upload -> FAIL status=" + std::to_string(HttpDownloader::getLastFailure().detail));
   return ok;
+}
+
+void flushPendingCrashReport(const std::string& username, const std::string& password) {
+  if (!Storage.exists(CRASH_REPORT_PATH)) return;  // nothing waiting
+  if (!uploadCrashReport(username, password)) return;
+  // Delivered: drop the local copy so the next connection does not resend it.
+  // Deliberately only on success -- a failed upload leaves the file for the next
+  // attempt, which is the whole point of queueing it rather than requiring the
+  // user to be looking at the crash screen at the moment they have WiFi.
+  Storage.remove(CRASH_REPORT_PATH);
+  diagLog("crash report flushed and cleared");
 }
 
 void reportDeviceStats(const std::string& username, const std::string& password) {

--- a/src/FouladDeviceTracking.h
+++ b/src/FouladDeviceTracking.h
@@ -83,6 +83,12 @@ void uploadDebugLog(const std::string& username, const std::string& password);
 // crash report file doesn't exist, or the upload ultimately fails.
 bool uploadCrashReport(const std::string& username, const std::string& password);
 
+// Uploads a queued crash report on reconnect, then deletes it so it is sent once.
+// No-op when none is waiting. Unlike uploadCrashReport() this is not user-initiated:
+// a device that panics and reboots cleanly never shows the crash screen, so the
+// Send button there delivers nothing for exactly the failures worth seeing.
+void flushPendingCrashReport(const std::string& username, const std::string& password);
+
 // Reports device telemetry (battery/RSSI/free heap/uptime) and a reading-
 // stats snapshot (streaks, totals, per-book history, reading-day heatmap)
 // for the "My Devices" web page's Device Stats / Reading Stats tabs -- see

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1030,6 +1030,18 @@ void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   // is the one reliable moment to sync any progress accumulated since the
   // last time the device was online.
   FouladDeviceTracking::flushPendingReadingStats(server.username, server.password);
+  // Crash reports go the same way, and for a stronger reason: until now the only
+  // path was the user tapping Send on the crash screen. A device that panics and
+  // reboots cleanly never shows that screen, so nobody taps it -- which is why
+  // zero crash reports have ever reached the server while nine debug logs have.
+  // The very failures worth seeing were the ones that reported nothing.
+  //
+  // Queued instead: the report sits on the SD card until the next time the device
+  // is online with an account, then uploads unattended and is deleted so it is
+  // sent once. Unconditional -- unlike the debug log below it, this is not gated
+  // on Settings -> Apps -> Debug, because a crash is not routine logging and the
+  // people whose devices crash are the least likely to have opted into anything.
+  FouladDeviceTracking::flushPendingCrashReport(server.username, server.password);
   // Same reasoning: uploading the debug log here (rather than at the moment
   // a book is opened, when WiFi is already gone) is what actually delivers
   // it. No-op unless Settings -> Apps -> Debug is on.


### PR DESCRIPTION
Acting on the device-log findings: **nine debug logs have reached the server, zero crash reports ever.**

## Why none arrived

Not a bug in the upload — structural. `uploadCrashReport()` only ran when a user tapped **Send** on the crash screen, and a device that panics and reboots cleanly never shows that screen. The failures most worth seeing were precisely the ones that reported nothing.

## Now queued

The report stays on the SD card until the device is next online with an account, uploads unattended from the same reconnect hook that already flushes reading stats and the debug log, and is deleted **on success only** — a failed upload leaves the file for the next attempt, which is the point of queueing rather than needing the user to be looking at the crash screen at the moment they happen to have WiFi.

**Unconditional**, unlike the debug log beside it, which is gated on Settings → Apps → Debug. A crash isn't routine logging, and people whose devices crash are the least likely to have opted into anything beforehand.

## Also: `firmware_version` on both uploads (§5.2)

Rather than letting the server fall back to whatever the device last registered with. "Did yesterday's RC break this" is the question the fleet grouping exists to answer, and it can't answer it from a version that may be a release behind what actually produced the fault.

## Not included

**§5.1, the double registration.** `reportDeviceTrackingOnConnect()` calls `registerDevice()` outright and `reportReadingStats()` re-registers on a 404, so two in one connection is explicable — but I'd be guessing which is spurious without the log lines, and SSH is blocked for me by the permission classifier. Paste the two `[FDT] register` lines with their surroundings and I'll fix it properly.

**The HTTP credentials issue** is not fixable from firmware. `midad.one` currently serves a cert whose subject is `CN=foulad.one` — it doesn't cover the new domain — and the chain is still `ISRG Root YE`, the hierarchy `FouladEbooksConfig.h` documents as unrecognised by ESP-IDF's bundle. Pinning a root in firmware was tried, drove free heap to ~5 KB and froze devices. Needs a cert covering `midad.one` on a validatable chain.

## Testing

- `pio run -e gh_release_rc` clean; clang-format verified.

Needs hardware:
- [ ] Provoke a crash, reboot, open Library — report should upload with no user action and `/crash_report.txt` disappear
- [ ] With WiFi unavailable, confirm the file **survives** for a later attempt
- [ ] Confirm the uploaded row carries the running firmware version
- [ ] Signed-out device: no upload, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)