### PR TITLE
fix: Sync with Midad did nothing when pressed

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -388,42 +388,43 @@ void EpubReaderActivity::openReaderMenu() {
   const std::string& lang = epub->getLanguage();
   const bool isArabicBook = ScriptDetector::containsArabic(epub->getTitle().c_str()) || lang.rfind("ar", 0) == 0 ||
                             lang.rfind("fa", 0) == 0 || lang.rfind("ur", 0) == 0;
-  startActivityForResult(
-      std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, epub.get(), currentSpineIndex, currentPage,
-                                               totalPages, bookProgressPercent, SETTINGS.orientation,
-                                               !currentPageFootnotes.empty(), !cachedBookmarks.empty(), isArabicBook),
-      [this](const ActivityResult& result) {
-        // Always apply orientation / auto-turn / per-book setting edits, even
-        // if the menu was cancelled (Back just closes the drawer).
-        const auto& menu = std::get<MenuResult>(result.data);
-        LOG_INF("ERS", "Drawer closed: action=%d cancelled=%d settingsChanged=%d chapterSpine=%d", menu.action,
-                result.isCancelled ? 1 : 0, menu.bookSettingsChanged ? 1 : 0, menu.chapterSpineIndex);
-        applyOrientation(menu.orientation);
-        toggleAutoPageTurn(menu.pageTurnOption);
-        if (menu.bookSettingsChanged && epub) {
-          BookReaderSettings::saveFromSettings(epub->getCachePath());
-          {
-            // Same mid-book re-layout dance as applyOrientation(): preserve the
-            // position, reload the font systems for the new per-book values, and
-            // reset the section -- the changed fontId/arabicFontId/lineCompression/
-            // alignment in the section cache key forces a rebuild, and
-            // applyDeferredReposition() remaps the page once the count is known.
-            RenderLock lock(*this);
-            if (section) {
-              cachedSpineIndex = currentSpineIndex;
-              cachedChapterTotalPageCount = section->pageCount;
-              nextPageNumber = section->currentPage;
-            }
-            sdFontSystem.ensureLoaded(renderer);
-            arabicFontSystem.ensureLoaded(renderer);
-            section.reset();
-          }
-          requestUpdate();
-        }
-        if (!result.isCancelled) {
-          onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action), menu);
-        }
-      });
+  startActivityForResult(std::make_unique<EpubReaderMenuActivity>(
+                             renderer, mappedInput, epub.get(), currentSpineIndex, currentPage, totalPages,
+                             bookProgressPercent, SETTINGS.orientation, !currentPageFootnotes.empty(),
+                             !cachedBookmarks.empty(), isArabicBook, bookHasFouladId()),
+                         [this](const ActivityResult& result) {
+                           // Always apply orientation / auto-turn / per-book setting edits, even
+                           // if the menu was cancelled (Back just closes the drawer).
+                           const auto& menu = std::get<MenuResult>(result.data);
+                           LOG_INF("ERS", "Drawer closed: action=%d cancelled=%d settingsChanged=%d chapterSpine=%d",
+                                   menu.action, result.isCancelled ? 1 : 0, menu.bookSettingsChanged ? 1 : 0,
+                                   menu.chapterSpineIndex);
+                           applyOrientation(menu.orientation);
+                           toggleAutoPageTurn(menu.pageTurnOption);
+                           if (menu.bookSettingsChanged && epub) {
+                             BookReaderSettings::saveFromSettings(epub->getCachePath());
+                             {
+                               // Same mid-book re-layout dance as applyOrientation(): preserve the
+                               // position, reload the font systems for the new per-book values, and
+                               // reset the section -- the changed fontId/arabicFontId/lineCompression/
+                               // alignment in the section cache key forces a rebuild, and
+                               // applyDeferredReposition() remaps the page once the count is known.
+                               RenderLock lock(*this);
+                               if (section) {
+                                 cachedSpineIndex = currentSpineIndex;
+                                 cachedChapterTotalPageCount = section->pageCount;
+                                 nextPageNumber = section->currentPage;
+                               }
+                               sdFontSystem.ensureLoaded(renderer);
+                               arabicFontSystem.ensureLoaded(renderer);
+                               section.reset();
+                             }
+                             requestUpdate();
+                           }
+                           if (!result.isCancelled) {
+                             onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action), menu);
+                           }
+                         });
 }
 
 namespace {
@@ -1014,15 +1015,39 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
   }
 }
 
+std::string EpubReaderActivity::currentBookFouladId() const {
+  if (!epub) return "";
+  // Stats store first, recents second. The id lives in ReadingBookStats precisely
+  // because RECENT_BOOKS caps at 10 and evicts (see INSTRUCTIONS-14) -- looking it
+  // up only in recents would make Sync vanish for a catalog book read a while ago,
+  // which is the same bug that hid reading from library_reading rows.
+  READING_STATS.ensureLoaded();
+  if (const auto* stats = READING_STATS.findBook(epub->getPath()); stats && !stats->fouladBookId.empty()) {
+    return stats->fouladBookId;
+  }
+  const auto& recents = RECENT_BOOKS.getBooks();
+  const auto it =
+      std::find_if(recents.begin(), recents.end(), [this](const RecentBook& b) { return b.path == epub->getPath(); });
+  return it != recents.end() ? it->fouladBookId : "";
+}
+
+bool EpubReaderActivity::bookHasFouladId() const {
+  // The Sync row is offered only for a book the catalog can be told about.
+  // launchMidadSync() requires the same id and returns silently without one, so
+  // gating the row on anything weaker (an account existing, say) produces a menu
+  // entry that does nothing at all when pressed -- which is exactly what shipped
+  // in v1.8.5-rc and was reported as "nothing happens".
+  //
+  // Empty for a side-loaded file, and also for a catalog book downloaded before
+  // the id was recorded or since evicted from the 10-entry recents list.
+  return !currentBookFouladId().empty();
+}
+
 void EpubReaderActivity::launchMidadSync() {
   if (!epub) return;
 
-  const auto& recents = RECENT_BOOKS.getBooks();
-  const auto recentIt =
-      std::find_if(recents.begin(), recents.end(), [this](const RecentBook& b) { return b.path == epub->getPath(); });
-  if (recentIt == recents.end() || recentIt->fouladBookId.empty()) {
-    return;  // side-loaded: nothing the catalog can be told about
-  }
+  const std::string bookId = currentBookFouladId();
+  if (bookId.empty()) return;  // side-loaded: nothing the catalog can be told about
 
   const int currentPage = section ? section->currentPage : nextPageNumber;
   const int totalPages = section ? section->estimatedTotalPages() : cachedChapterTotalPageCount;
@@ -1031,7 +1056,6 @@ void EpubReaderActivity::launchMidadSync() {
   // close-sync block in onExit() for why a restored reader's timestamp is not an age.
   const uint32_t ageSeconds = pageTurnedThisSession ? static_cast<uint32_t>((millis() - pageShownAtMs) / 1000UL) : 0;
   const std::string savedEpubPath = epub->getPath();
-  const std::string bookId = recentIt->fouladBookId;
 
   // Persist first: the reader is replaced below and resumes from this file, so a
   // failed write would silently lose the reader's place. Same guard as KOReader's.

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -130,6 +130,11 @@ class EpubReaderActivity final : public Activity {
   bool launchKOReaderSync();
   // Midad equivalent: same save-release-replace shape, see the implementation.
   void launchMidadSync();
+  // True when this book carries a Foulad eBooks catalog id, i.e. Sync can do
+  // something. Gates the drawer row so it is never shown-and-inert.
+  bool bookHasFouladId() const;
+  // Catalog id for the open book: stats store first, recents as fallback.
+  std::string currentBookFouladId() const;
   void applyOrientation(uint8_t orientation);
   void toggleAutoPageTurn(uint8_t selectedPageTurnOption);
   void pageTurn(bool isForwardTurn);

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -95,11 +95,12 @@ EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInpu
                                                const int currentSpineIndex, const int currentPage, const int totalPages,
                                                const int bookProgressPercent, const uint8_t currentOrientation,
                                                const bool hasFootnotes, const bool hasBookmarks,
-                                               const bool isArabicBook)
+                                               const bool isArabicBook, const bool canSyncMidad)
     : Activity("EpubReaderMenu", renderer, mappedInput),
       epub(epub),
       currentSpineIndex(currentSpineIndex),
       isArabicBook(isArabicBook),
+      canSyncMidad_(canSyncMidad),
       sdFamilies(sdFamilyNames(isArabicBook ? arabicFontSystem.registry() : sdFontSystem.registry())),
       title(epub ? flattenedTitle(epub->getTitle()) : std::string()),
       pendingOrientation(currentOrientation),
@@ -166,7 +167,7 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildSetti
   // places, and silently changing what a row someone already relies on does reads
   // as data loss. STR_SYNC_PROGRESS was fine when there was only one.
   items.push_back({MenuAction::SYNC, StrId::STR_SYNC_KOREADER});
-  if (hasMidadAccount) {
+  if (hasMidadAccount && canSyncMidad_) {
     items.push_back({MenuAction::MIDAD_SYNC, StrId::STR_SYNC_MIDAD});
   }
   items.push_back({MenuAction::DELETE_CACHE, StrId::STR_DELETE_CACHE});

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -53,7 +53,7 @@ class EpubReaderMenuActivity final : public Activity {
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, Epub* epub,
                                   const int currentSpineIndex, const int currentPage, const int totalPages,
                                   const int bookProgressPercent, const uint8_t currentOrientation,
-                                  const bool hasFootnotes, bool hasBookmarks, bool isArabicBook);
+                                  const bool hasFootnotes, bool hasBookmarks, bool isArabicBook, bool canSyncMidad);
 
   void onEnter() override;
   void onExit() override;
@@ -73,6 +73,10 @@ class EpubReaderMenuActivity final : public Activity {
 
   std::vector<MenuItem> buildReadingItems(bool hasBookmarks) const;
   std::vector<MenuItem> buildSettingsItems(bool hasFootnotes) const;
+  // False when THIS book has no catalog id -- side-loaded, or downloaded before
+  // the id was recorded. The row is hidden rather than shown-and-inert: pressing
+  // Sync and having nothing at all happen is worse than not offering it.
+  bool canSyncMidad_ = false;
 
   std::string valueLabel(MenuAction action) const;
   std::string globalLabel(const char* effectiveValueLabel) const;


### PR DESCRIPTION
Reported from `v1.8.5-rc`: the row appears, you press it, nothing happens and no WiFi comes up.

Two bugs, both mine.

## 1. The row was gated on the wrong condition

It appeared whenever a Midad **account** existed, but `launchMidadSync()` requires the **open book** to carry a catalog id and returns silently without one. So the row showed for every book and did nothing for most.

The PR for #42 even listed *"side-loaded book → no Midad row"* as a test item — the implementation never did that. Now gated on exactly what the launcher requires, so the row is **absent rather than present-and-inert**. Pressing Sync and having nothing at all happen is worse than not being offered it.

## 2. The id lookup used recents only

`RECENT_BOOKS` caps at 10 and evicts — which is **precisely** the bug fixed for `library_reading` rows in INSTRUCTIONS-14, reintroduced three commits later in the same file.

The lookup now prefers `ReadingBookStats`, which holds the id for exactly this reason, falling back to recents. Sync stays available for a catalog book read a while ago instead of vanishing once ten newer books push it off the list.

This is likely why it failed even on a catalog book.

## After this

If the row is there, it works. If it's missing on a book downloaded from Midad, the device genuinely has no id for it — it predates id capture, or the id was lost to eviction before this landed. Re-downloading restores it.

## Open question

A book that can't sync now silently lacks the row — honest, but unexplained. The alternative is keeping it visible and saying *"This book isn't in your Midad library"* when pressed, trading a silent absence for an explained one. Went with hiding it because that's what the spec's shape implied; easy to change.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.

Needs hardware:
- [ ] Recently downloaded catalog book → row present, Sync brings up WiFi
- [ ] Side-loaded book → no row
- [ ] A catalog book read long ago, pushed off recents → row still present (this is bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)