### PR TITLE
fix: three from the 31 July feedback

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -258,12 +258,19 @@ void EpubReaderActivity::onEnter() {
     APP_STATE.pendingSyncJumpPercent = 0;
     APP_STATE.pendingSyncJumpSpine = -1;
     APP_STATE.saveToFile();
-    // Spine first when the server had one. A whole-number percent resolves to about
-    // one spine item on a 103-document book, so it cannot be more accurate than that
-    // however correct either side is; the spine anchor has no such ceiling.
-    if (targetSpine >= 0) {
-      LOG_INF("SYNC", "Applying accepted cross-device jump to spine=%d (%d%%)", targetSpine, target);
+    // Spine only when documents are fine-grained enough to beat the percentage.
+    // Each covers roughly 100/spineCount percent: on a 103-document book that is ~1%
+    // and the spine wins easily, but on a three-document book "open document 3"
+    // lands near 67% for a position 22% in -- worse than the percentage it replaced.
+    // Three of the four books on production are the coarse case, so preferring spine
+    // unconditionally would regress most of the library.
+    const int spineCount = epub ? epub->getSpineItemsCount() : 0;
+    if (targetSpine >= 0 && spineCount >= 30) {
+      LOG_INF("SYNC", "Applying accepted cross-device jump to spine=%d of %d (%d%%)", targetSpine, spineCount, target);
       jumpToSpine(targetSpine);
+    } else if (targetSpine >= 0) {
+      LOG_INF("SYNC", "Spine anchor %d of %d too coarse; using %d%% instead", targetSpine, spineCount, target);
+      jumpToPercent(target);
     } else {
       LOG_INF("SYNC", "Applying accepted cross-device jump to %d%% (no spine anchor)", target);
       jumpToPercent(target);
@@ -271,10 +278,15 @@ void EpubReaderActivity::onEnter() {
     // Where the percentage actually landed, next to what we were told. Requested by
     // foulad-ebooks after a jump missed and the report had already been overwritten
     // server-side: without the outcome logged, reconstructing what happened took
-    // three reads instead of one. spine/page here are OUR pagination, which is
-    // exactly the thing that has to be compared against the sender's percentage.
-    LOG_INF("SYNC", "Jump landed: spine=%d page=%d of %d", currentSpineIndex, section ? section->currentPage : -1,
-            section ? section->estimatedTotalPages() : -1);
+    // three reads instead of one.
+    //
+    // Spine only, deliberately. Both jump paths reset `section` so the next render
+    // rebuilds it, which means pagination is ALWAYS unresolved at this point -- the
+    // previous line printed "page=-1 of -1" every single time and was reasonably
+    // read as evidence that the jump had raced section building. It had not; that
+    // was this log line running where it does. Page numbers appear in the section
+    // build logs that follow.
+    LOG_INF("SYNC", "Jump applied: spine=%d, pagination resolves on next render", currentSpineIndex);
   }
 
   // Trigger first update

--- a/src/activities/reader/MidadSyncActivity.cpp
+++ b/src/activities/reader/MidadSyncActivity.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 
 #include "CrossPointState.h"
+#include "FouladDeviceTracking.h"
 #include "FouladEbooksConfig.h"
 #include "MappedInputManager.h"
 #include "OpdsServerStore.h"
@@ -143,6 +144,13 @@ void MidadSyncActivity::performSync() {
     requestUpdate();
     return;
   }
+
+  // Refresh the registration first, exactly as reportDeviceTrackingOnConnect() does
+  // when entering the catalog. Without this a device that only ever syncs -- never
+  // browsing Library after an update -- keeps whatever firmware version it last
+  // registered with. Observed stale across three releases, which quietly misattributes
+  // every debug log, since those carry no version line of their own to fall back to.
+  FouladDeviceTracking::registerDevice(it->username, it->password);
 
   FouladReadingPosition::Position fetched;
   const bool ok = FouladReadingPosition::sync(it->username, it->password, fouladBookId, progressPercent, page,


### PR DESCRIPTION
From `EINK_FEEDBACK_2026-07-31.md` (foulad-ebooks v0.77.0), all from production data.

## §3 — spine anchors only when fine-grained

Their limit is real and shipping without it would have been a regression. Each document covers roughly `100 / spine_count` percent:

| book | spine | per document |
|---|---|---|
| 12 | 102/103 | ~1% — spine wins easily |
| 310 | 3/3 | ~33% — "open document 3" lands near 67% for a position **22%** in |

**Three of the four books on production are the coarse case.** Spine is now used only at ≥30 documents; the percentage is used below that.

## §4 — stale registered firmware

Not the payload — `registerDevice()` always sent the running `CROSSPOINT_VERSION`. It only ran when **entering the catalog**, so a device that syncs but hasn't browsed Library since updating keeps reporting an old version. Observed stale across three releases.

Crash reports survive this because the panic body carries its own version; debug logs have no such fallback. The sync path now refreshes the registration.

## §2 — one correction to the diagnosis

`page=-1 of -1` is **not** evidence that the jump raced section building. Both jump paths reset `section` so the next render rebuilds it, so pagination is *always* unresolved where that log line sits — it printed `-1` on every jump, including ones that worked.

The line now reports the spine and states that pagination resolves on the next render. Page numbers appear in the section build logs that follow.

**The crash itself remains unexplained.** 129 KB free with a 114 KB largest block rules out allocation failure, and their reasoning that a null handle means never-created rather than failed-creation is sound — I can't yet name which handle.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.

Needs hardware:
- [ ] Jump on a many-document book (book 12) → uses spine, lands correctly
- [ ] Jump on a three-document book (book 310) → uses percentage, logs "too coarse"
- [ ] Sync once, then check the server's registered firmware matches the running build
- [ ] No `page=-1 of -1` in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)