### PR TITLE
fix: apply a cross-device jump from loop(), not onEnter()

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -247,46 +247,28 @@ void EpubReaderActivity::onEnter() {
     pageShownAtMs = millis();
   }
 
-  // Consume a jump accepted on the sync screen. Applied here rather than there
-  // because turning a percentage into a spine/page needs the Epub loaded, and the
-  // sync activity had to release it to afford the TLS handshake. Cleared before
-  // jumping, and persisted immediately, so a crash mid-jump cannot leave the reader
-  // re-jumping on every open.
+  // Consume a jump accepted on the sync screen -- but only READ it here. Applying it
+  // is deferred to the first loop() iteration.
+  //
+  // Doing the jump inside onEnter() meant resetting `section` and taking a RenderLock
+  // while the activity was still constructing itself, on the one boot that follows a
+  // sync. That is exactly where a repeating panic lands: "assert failed:
+  // xQueueSemaphoreTake queue.c:1709 (pxQueue)" ~791ms into the post-sync boot, on
+  // two consecutive releases. A null handle with 129KB free is not an allocation
+  // failure -- it is a handle taken before whatever owns it is ready.
+  //
+  // Every other reader action runs from loop(), after onEnter() has returned and the
+  // render task is serving this activity. The jump has no reason to be the exception,
+  // and one render frame later is imperceptible on e-ink.
+  //
+  // Still cleared and persisted here, not at apply time, so a crash between the two
+  // cannot leave a device re-jumping on every open.
   if (APP_STATE.pendingSyncJumpPercent > 0) {
-    const int target = APP_STATE.pendingSyncJumpPercent;
-    const int targetSpine = APP_STATE.pendingSyncJumpSpine;
+    pendingJumpPercent = APP_STATE.pendingSyncJumpPercent;
+    pendingJumpSpine = APP_STATE.pendingSyncJumpSpine;
     APP_STATE.pendingSyncJumpPercent = 0;
     APP_STATE.pendingSyncJumpSpine = -1;
     APP_STATE.saveToFile();
-    // Spine only when documents are fine-grained enough to beat the percentage.
-    // Each covers roughly 100/spineCount percent: on a 103-document book that is ~1%
-    // and the spine wins easily, but on a three-document book "open document 3"
-    // lands near 67% for a position 22% in -- worse than the percentage it replaced.
-    // Three of the four books on production are the coarse case, so preferring spine
-    // unconditionally would regress most of the library.
-    const int spineCount = epub ? epub->getSpineItemsCount() : 0;
-    if (targetSpine >= 0 && spineCount >= 30) {
-      LOG_INF("SYNC", "Applying accepted cross-device jump to spine=%d of %d (%d%%)", targetSpine, spineCount, target);
-      jumpToSpine(targetSpine);
-    } else if (targetSpine >= 0) {
-      LOG_INF("SYNC", "Spine anchor %d of %d too coarse; using %d%% instead", targetSpine, spineCount, target);
-      jumpToPercent(target);
-    } else {
-      LOG_INF("SYNC", "Applying accepted cross-device jump to %d%% (no spine anchor)", target);
-      jumpToPercent(target);
-    }
-    // Where the percentage actually landed, next to what we were told. Requested by
-    // foulad-ebooks after a jump missed and the report had already been overwritten
-    // server-side: without the outcome logged, reconstructing what happened took
-    // three reads instead of one.
-    //
-    // Spine only, deliberately. Both jump paths reset `section` so the next render
-    // rebuilds it, which means pagination is ALWAYS unresolved at this point -- the
-    // previous line printed "page=-1 of -1" every single time and was reasonably
-    // read as evidence that the jump had raced section building. It had not; that
-    // was this log line running where it does. Page numbers appear in the section
-    // build logs that follow.
-    LOG_INF("SYNC", "Jump applied: spine=%d, pagination resolves on next render", currentSpineIndex);
   }
 
   // Trigger first update
@@ -470,6 +452,35 @@ unsigned cpuMhzNow() {
 }  // namespace
 
 void EpubReaderActivity::loop() {
+  // Deferred cross-device jump (see onEnter). Runs once, on the first iteration
+  // after the activity is fully up and the render task is serving it.
+  if (pendingJumpPercent > 0) {
+    const int target = pendingJumpPercent;
+    const int targetSpine = pendingJumpSpine;
+    pendingJumpPercent = 0;
+    pendingJumpSpine = -1;
+    // Spine only when documents are fine-grained enough to beat the percentage.
+    // Each covers roughly 100/spineCount percent: on a 103-document book that is ~1%
+    // and the spine wins, but on a three-document book "open document 3" lands near
+    // 67% for a position 22% in -- worse than the percentage it replaced.
+    const int spineCount = epub ? epub->getSpineItemsCount() : 0;
+    if (targetSpine >= 0 && spineCount >= 30) {
+      LOG_INF("SYNC", "Applying cross-device jump to spine=%d of %d (%d%%)", targetSpine, spineCount, target);
+      jumpToSpine(targetSpine);
+    } else if (targetSpine >= 0) {
+      LOG_INF("SYNC", "Spine anchor %d of %d too coarse; using %d%% instead", targetSpine, spineCount, target);
+      jumpToPercent(target);
+    } else {
+      LOG_INF("SYNC", "Applying cross-device jump to %d%% (no spine anchor)", target);
+      jumpToPercent(target);
+    }
+    // Spine only; both jump paths reset `section` for the next render to rebuild, so
+    // pagination is always unresolved at this point. The previous version of this log
+    // printed "page=-1 of -1" every time and was reasonably read as evidence of a race.
+    LOG_INF("SYNC", "Jump applied: spine=%d, pagination resolves on next render", currentSpineIndex);
+    return;  // let the jump's own reload land before handling input this frame
+  }
+
   if (!epub) {
     // Should never happen
     finish();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -154,6 +154,11 @@ class EpubReaderActivity final : public Activity {
   // True once a page has actually been turned in this activity instance -- see the
   // close-sync block in onExit() for why an age is only honest after that.
   bool pageTurnedThisSession = false;
+  // A cross-device jump read out of APP_STATE in onEnter() and applied on the first
+  // loop() iteration -- see the comment there for why it is not applied immediately.
+  // 0 / -1 mean nothing pending.
+  uint8_t pendingJumpPercent = 0;
+  int16_t pendingJumpSpine = -1;
   // First page dwell after opening/jumping includes orientation time, not reading --
   // skip it as a pace sample (it still counts toward session time).
   bool paceWarmupPending = true;


### PR DESCRIPTION
A repeating panic, now on two consecutive releases:

```
assert failed: xQueueSemaphoreTake queue.c:1709 (( pxQueue ))
```

## The timeline is what identifies it

```
19:59:05  POST /opds/device            200
19:59:06  POST /opds/reading-position  200   ← sync succeeded
19:59:41  POST /opds/device-log        200   ← crash report
```

And the crash log dies at **[791] ms after boot**, right after per-book settings are applied.

The sync **succeeded**. The boot that follows a sync is the one `silentRestartToReader()` causes — so "it crashes when I exit the book after syncing" is the reader **starting up on the way back**, not the sync.

## Cause

The jump was applied inside `onEnter()`: resetting `section` and taking a `RenderLock` while the activity was still constructing itself, before the render task was serving it.

A null semaphore handle with **129 KB free and a 114 KB largest block** is not allocation failure — it's a handle taken before whatever owns it is ready.

## Fix

`onEnter()` now only reads the pending jump out of `APP_STATE` and clears it. The jump runs on the first `loop()` iteration — where every other reader action already runs, and one render frame later is imperceptible on e-ink.

Clearing still happens at read time, not apply time, so a crash between the two can't leave a device re-jumping on every open.

## Confidence

The mechanism is **inferred from where and when it dies**, not from a stack dump I've read. The timing fits precisely and the ordering hazard is real regardless of whether it's *the* one. **If the panic recurs on this build, the hazard is elsewhere** and the full crash body is the next thing needed.

Two things ruled out along the way:
- **Not book-specific.** `epub_3295168710` appears in both because a sync only happens on a book you're actively reading.
- **The ASCII stack fragments** (`"2021"`, `"2039"`) are consistent with dying mid-log-format, which fits an early-boot crash.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.

Needs hardware — this is the whole point:
- [ ] Sync, accept a **Jump**, and let the device return to the book — no panic
- [ ] Sync, **Sync & close** — no panic
- [ ] Jump still lands correctly on a many-document book
- [ ] Reopen the book afterwards — it must not re-jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)