### PR TITLE
fix: don't drive WiFi on book exit when there is none

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -21,10 +21,10 @@
 
 namespace FouladDeviceTracking {
 
+bool wifiConnected() { return WiFi.status() == WL_CONNECTED; }
+
 namespace {
 constexpr char TAG[] = "FDT";
-
-bool wifiConnected() { return WiFi.status() == WL_CONNECTED; }
 
 std::string deviceEndpoint() { return std::string(FOULAD_EBOOKS_URL) + "/device"; }
 std::string readingStatsEndpoint() { return std::string(FOULAD_EBOOKS_URL) + "/reading-stats"; }

--- a/src/FouladDeviceTracking.h
+++ b/src/FouladDeviceTracking.h
@@ -21,6 +21,10 @@ namespace FouladDeviceTracking {
 // reboots/firmware updates for the same physical unit.
 std::string getSerialNumber();
 
+// True when a station connection is up. Anything that may reach HttpDownloader must
+// check this first: driving esp_wifi with no station asserts inside IDF.
+bool wifiConnected();
+
 // Registers (or re-registers -- the server upserts by serial_number) this
 // device under the given Foulad eBooks account. Call once per connection,
 // before browsing (e.g. from OpdsBookBrowserActivity right before its first

--- a/src/FouladReadingPosition.cpp
+++ b/src/FouladReadingPosition.cpp
@@ -60,6 +60,19 @@ bool FouladReadingPosition::sync(const std::string& username, const std::string&
                                  const int totalPages, const uint32_t readAtEpochSeconds,
                                  const uint32_t readAtAgeSeconds, Position& out) {
   if (username.empty() || password.empty() || fouladBookId.empty()) return false;
+  // WiFi first, before anything reaches HttpDownloader. Every function in
+  // FouladDeviceTracking opens with this check and mine did not, which is the whole
+  // bug: the reader tears WiFi down before a book is even opened, so this ran on a
+  // stopped stack every time a SERVER book was closed. HttpDownloader's
+  // WifiPowerSaveGuard calls esp_wifi_set_ps() unconditionally in its constructor,
+  // and driving esp_wifi with no station up lands inside IDF on a null queue handle
+  // -- "assert failed: xQueueSemaphoreTake queue.c:1709 (pxQueue)".
+  //
+  // That is why a local book exited cleanly and a downloaded one did not: the close
+  // block is gated on the book carrying a catalog id, so local books never reached
+  // here. It is also why the crash appeared at any uptime and with no OPDS traffic
+  // in the window -- the request never got out.
+  if (!FouladDeviceTracking::wifiConnected()) return false;
 
   JsonDocument doc;
   doc["serial_number"] = FouladDeviceTracking::getSerialNumber();
@@ -120,6 +133,7 @@ bool FouladReadingPosition::sync(const std::string& username, const std::string&
 bool FouladReadingPosition::fetch(const std::string& username, const std::string& password,
                                   const std::string& fouladBookId, Position& out) {
   if (username.empty() || password.empty() || fouladBookId.empty()) return false;
+  if (!FouladDeviceTracking::wifiConnected()) return false;  // see sync()
 
   const std::string url = std::string(FOULAD_EBOOKS_READING_POSITION_URL) + "?book_id=" + fouladBookId;
   std::string response;

--- a/src/activities/home/CrashActivity.cpp
+++ b/src/activities/home/CrashActivity.cpp
@@ -34,8 +34,14 @@ void CrashActivity::loop() {
     finish();
     return;
   }
+  // wasPressed, not wasReleased. Reported as needing two presses to take: the
+  // release edge is cleared by every gpio.update(), including the ones the render
+  // wait performs mid-frame, so a release landing during a repaint is simply lost.
+  // The press edge does not have that problem, and it is what every other
+  // confirm-and-go screen here uses (OtaUpdateActivity, MidadSyncActivity) -- this
+  // was the odd one out.
   if ((sendState == SendState::Idle || sendState == SendState::Failed) &&
-      mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+      mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
     startSendLog();
   }
 }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -276,6 +276,9 @@ void EpubReaderActivity::onEnter() {
 }
 
 void EpubReaderActivity::onExit() {
+  // Bracketing the exit path, requested after three crashes whose last log line was
+  // the per-book settings write -- leaving no way to tell which side of it died.
+  LOG_INF("ERS", "Reader exit: begin");
   Activity::onExit();
 
   // Reset orientation back to portrait for the rest of the UI
@@ -380,6 +383,7 @@ void EpubReaderActivity::onExit() {
     sdFontSystem.ensureLoaded(renderer);
     arabicFontSystem.ensureLoaded(renderer);
   }
+  LOG_INF("ERS", "Reader exit: done");
 }
 
 void EpubReaderActivity::openReaderMenu() {


### PR DESCRIPTION
Three releases, one signature. Sameh's repro was the whole answer:

> *"When I exit the book it crashes. If the book is local it exits normally."*

## Cause — mine, from the first sync commit

Every function in `FouladDeviceTracking` opens with `if (!wifiConnected()) return;`. **The two I added in `FouladReadingPosition` don't.**

The reader tears WiFi down before a book is even opened, so the close-sync ran on a **stopped stack every time a server book was closed**. `HttpDownloader`'s `WifiPowerSaveGuard` calls `esp_wifi_set_ps()` unconditionally from its constructor, and driving esp_wifi with no station up lands inside IDF on a null queue handle:

```
assert failed: xQueueSemaphoreTake queue.c:1709 (( pxQueue ))
```

## It accounts for what killed the earlier theories

| Observation | Explanation |
|---|---|
| Local books exit cleanly | The close block is gated on the book carrying a catalog id — local books never reach it |
| Uptimes 0.8 s / 9.5 s / 51 s | The trigger is the exit, not anything in boot |
| No OPDS traffic in the window | The request never got out |
| 129 KB free, 114 KB largest block | Never an allocation failure |

**Both my earlier fixes were aimed at the wrong thing.** The jump-out-of-`onEnter` change addressed a real ordering hazard and is worth keeping, but it was never this. I inferred from timing twice and was wrong twice; the repro settled it in one line.

## Also

**Exit path bracketed** with begin/done logging — requested after three crashes whose last line was the per-book settings write, leaving no way to tell which side of it died.

**Send Log takes one press now.** It used the release edge, which every `gpio.update()` clears — including the ones the render wait performs mid-frame — so a release landing during a repaint was lost. Now the press edge, like every other confirm-and-go screen here.

## On `epub_3295168710`

Not worth chasing: it's `std::hash<std::string>{}(filepath)` of the book's SD path, computed firmware-side. Same in all three crashes because it's the book he was reading. The local-vs-server distinction was the real signal.

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.

Needs hardware:
- [ ] Open a **downloaded** book, read, exit → no crash *(the repro)*
- [ ] Open a **local** book, exit → still fine
- [ ] Sync, Jump, exit → no crash
- [ ] Crash screen → **Send Log** works on the first press
- [ ] `Reader exit: begin` / `done` both appear in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)