### PR TITLE
chore: set version to 1.8.13 for release

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.8.1
+version = 1.8.13
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
Prerequisite for tagging `v1.8.13`, same as #35 and #38 were for earlier releases.

`release.yml` has no version-stamping step — `gh_release` reads `CROSSPOINT_VERSION` straight from `platformio.ini`. Left at 1.8.1, a `v1.8.13` tag would publish firmware reporting **1.8.1**, and devices would be re-offered the same update forever.

**1.8.13, not 1.8.2** — to match the RC it's built from. A stable numbered below the pre-releases it supersedes would read as *older* to `isUpdateNewer()`, so a device on `1.8.13-rc` would never be offered the identical stable build, and the next auto RC would collide with numbers already used.

`[skip release]` in the subject so this doesn't cut an RC of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)