### PR TITLE
feat: TLS for Midad, pinned to one root

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -42,6 +42,8 @@ void FontDecompressor::freePageBuffer() {
 }
 
 void FontDecompressor::freeHotGroup() {
+  failedGroupFont = nullptr;
+  failedGroupIndex = UINT16_MAX;
   free(hotGroup);
   hotGroup = nullptr;
   hotGroupCapacity = 0;
@@ -261,7 +263,16 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
     // ensureCapacity may free the buffer, so the cached-group identity dies with it either way.
     hotGroupFont = nullptr;
     hotGroupIndex = UINT16_MAX;
+    // Already known to be unaffordable, and nothing has been freed since. Bail
+    // without allocating or logging -- the caller gets the same nullptr either way.
+    if (failedGroupFont == fontData && failedGroupIndex == groupIndex) {
+      stats.bitmapAllocFailures++;
+      stats.getBitmapTimeUs += micros() - tStart;
+      return nullptr;
+    }
     if (!ensureCapacity(hotGroup, hotGroupCapacity, group.uncompressedSize)) {
+      failedGroupFont = fontData;
+      failedGroupIndex = groupIndex;
       LOG_ERR("FDC", "Failed to allocate %u bytes for hot group %u", group.uncompressedSize, groupIndex);
       stats.bitmapAllocFailures++;
       if (stats.firstFailedAllocBytes == 0) stats.firstFailedAllocBytes = group.uncompressedSize;
@@ -278,6 +289,9 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
     hotGroupFont = fontData;
     hotGroupIndex = groupIndex;
     stats.hotGroupBytes = group.uncompressedSize;
+    // Memory is evidently available again; stop suppressing whatever failed before.
+    failedGroupFont = nullptr;
+    failedGroupIndex = UINT16_MAX;
   } else {
     stats.cacheHits++;
   }

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -114,6 +114,17 @@ class FontDecompressor {
   // ensureCapacity() returns false on OOM so the caller can skip the glyph gracefully.
   const EpdFontData* hotGroupFont = nullptr;
   uint16_t hotGroupIndex = UINT16_MAX;
+  // Last (font, group) whose decompression buffer could not be allocated. getBitmap()
+  // runs per glyph, so without this a group that fails once is retried by every
+  // remaining glyph on the line -- observed as eleven attempts at the same 10,667
+  // bytes in 23ms on a device already down to 18.7KB free. Each retry cannot succeed
+  // and fragments a little further on the way out.
+  //
+  // Cleared on any successful allocation and by clearCache(), so it suppresses a
+  // hopeless burst rather than permanently blacklisting a group: once memory is
+  // freed, the next attempt goes through.
+  const EpdFontData* failedGroupFont = nullptr;
+  uint16_t failedGroupIndex = UINT16_MAX;
   uint8_t* hotGroup = nullptr;  // owned; freed in freeHotGroup()/dtor
   uint32_t hotGroupCapacity = 0;
 

--- a/src/FouladEbooksConfig.h
+++ b/src/FouladEbooksConfig.h
@@ -16,7 +16,7 @@ constexpr char FOULAD_EBOOKS_NAME[] = "Midad";
 // updates its bundle. Basic Auth credentials travel in cleartext over this
 // connection as a result -- an accepted, explicit tradeoff for beta, not something
 // to carry into a production release without revisiting.
-constexpr char FOULAD_EBOOKS_URL[] = "http://midad.one/opds";
+constexpr char FOULAD_EBOOKS_URL[] = "https://midad.one/opds";
 
 // Font-conversion relay endpoint (Settings/File Transfer portal -> Fonts ->
 // Convert a Font): the device uploads a raw TTF/OTF plus a language choice,
@@ -25,7 +25,7 @@ constexpr char FOULAD_EBOOKS_URL[] = "http://midad.one/opds";
 // expected to rate-limit this server-side. Plain http:// for the same reason
 // as FOULAD_EBOOKS_URL above (foulad.one's current certificate chain isn't in
 // ESP-IDF's trust bundle); revisit alongside that fix.
-constexpr char FOULAD_EBOOKS_FONT_CONVERT_URL[] = "http://midad.one/api/fonts/convert";
+constexpr char FOULAD_EBOOKS_FONT_CONVERT_URL[] = "https://midad.one/api/fonts/convert";
 
 // QR-code sign-in (see FouladDeviceLogin.h). Unauthenticated JSON POSTs, no
 // cookies/CSRF. Plain http:// is deliberate and expected here for the same
@@ -34,8 +34,8 @@ constexpr char FOULAD_EBOOKS_FONT_CONVERT_URL[] = "http://midad.one/api/fonts/co
 // Nothing secret is sent TO these endpoints; the token they return is what
 // replaces the account password on the wire, so this flow strictly reduces what
 // is exposed rather than adding to it.
-constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_START_URL[] = "http://midad.one/api/device-login/start";
-constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_POLL_URL[] = "http://midad.one/api/device-login/poll";
+constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_START_URL[] = "https://midad.one/api/device-login/start";
+constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_POLL_URL[] = "https://midad.one/api/device-login/poll";
 
 // Device-facing sign-out: "remove me", identified by this device's own serial.
 // On the OPDS surface rather than the app API below, because that one sits behind
@@ -43,7 +43,7 @@ constexpr char FOULAD_EBOOKS_DEVICE_LOGIN_POLL_URL[] = "http://midad.one/api/dev
 // it can delete any device, change settings and manage fonts. Removing only itself is a
 // far narrower capability, so a token may reach this. Contract:
 // docs/ebooks-device-signout-endpoint.md.
-constexpr char FOULAD_EBOOKS_DEVICE_SIGNOUT_URL[] = "http://midad.one/opds/device/signout";
+constexpr char FOULAD_EBOOKS_DEVICE_SIGNOUT_URL[] = "https://midad.one/opds/device/signout";
 
 // Foulad One's app JSON API, used by signing out to remove this device from the
 // account (see FouladDeviceLogout). Behind the SAME opds.auth Basic-Auth middleware
@@ -60,9 +60,9 @@ constexpr char FOULAD_EBOOKS_DEVICE_SIGNOUT_URL[] = "http://midad.one/opds/devic
 // The shared currency is progress_percent, not page: the phone paginates with
 // epub.js at its own font size and cannot act on a page number computed for a
 // 5-inch panel. page/total_pages are sent for display only.
-constexpr char FOULAD_EBOOKS_READING_POSITION_URL[] = "http://midad.one/opds/reading-position";
+constexpr char FOULAD_EBOOKS_READING_POSITION_URL[] = "https://midad.one/opds/reading-position";
 
-constexpr char FOULAD_EBOOKS_APP_DEVICES_URL[] = "http://midad.one/api/app/devices";
+constexpr char FOULAD_EBOOKS_APP_DEVICES_URL[] = "https://midad.one/api/app/devices";
 
 // The one host every URL above points at. Matched on the host rather than on a
 // URL prefix because the requests that must carry the device serial header are

--- a/src/OpdsServerStore.cpp
+++ b/src/OpdsServerStore.cpp
@@ -41,27 +41,29 @@ bool OpdsServerStore::fromJson(JsonVariantConst doc) {
     // right: those credentials are typed account passwords.
     server.isDeviceToken = obj["is_device_token"] | false;
 
-    // Midad rename migration. A device paired before the rename holds
-    // "http://foulad.one/opds" here, and this stored entry -- not the constant --
-    // is what every request uses, so without rewriting it the device would keep
-    // talking to the old host indefinitely. Worse, ActivityManager::goToFouladEbooks()
-    // decides "is this account set up?" by comparing this URL against
-    // FOULAD_EBOOKS_URL: left alone, the comparison fails after the rename and the
-    // device concludes it is signed out, throwing the user at a QR screen despite a
-    // perfectly good credential.
+    // Normalise a stored Midad catalog URL to whatever the current constant is.
     //
-    // Host swap only. The credential, its is_device_token flag and the account
-    // itself are untouched and stay valid -- the server is the same server under a
-    // new name. needsResave persists it, so this runs once, not on every boot.
-    if (!server.url.empty() && server.url.find(FOULAD_EBOOKS_LEGACY_HOST) != std::string::npos &&
-        isFouladEbooksUrl(server.url)) {
-      const size_t hostPos = server.url.find(FOULAD_EBOOKS_LEGACY_HOST);
-      server.url.replace(hostPos, std::strlen(FOULAD_EBOOKS_LEGACY_HOST), FOULAD_EBOOKS_HOST);
-      // The display name was "Foulad eBooks" on those entries; bring it along so the
-      // server list doesn't show the old brand next to a migrated URL.
+    // Originally this only swapped the host for the Midad rename. That was not
+    // enough the moment the scheme changed too: every device in the field has
+    // "http://midad.one/opds" on its SD card, and this entry -- not the constant --
+    // is what requests use. Worse, "is this account set up?" is decided by comparing
+    // it against FOULAD_EBOOKS_URL (goToFouladEbooks, the reader's sync gating, the
+    // Settings login row), so a scheme change alone would make every existing device
+    // conclude it was signed out and demand a fresh QR scan.
+    //
+    // Replacing the whole URL rather than patching pieces means the next change --
+    // host, scheme, path -- needs no new migration. isFouladEbooksUrl() matches both
+    // the current and pre-rename hosts, which is why FOULAD_EBOOKS_LEGACY_HOST still
+    // has to exist even though nothing calls foulad.one any more: without it these
+    // entries stop being recognised as ours and never get rewritten at all.
+    //
+    // Credential, token flag and account are untouched -- same server, same account,
+    // different address.
+    if (!server.url.empty() && server.url != FOULAD_EBOOKS_URL && isFouladEbooksUrl(server.url)) {
+      LOG_INF("OPS", "Migrated stored catalog URL: %s -> %s", server.url.c_str(), FOULAD_EBOOKS_URL);
+      server.url = FOULAD_EBOOKS_URL;
       server.name = FOULAD_EBOOKS_NAME;
       needsResave = true;
-      LOG_INF("OPS", "Migrated stored catalog URL to %s", server.url.c_str());
     }
 
     servers.push_back(std::move(server));

--- a/src/activities/apps/GymAssetSyncActivity.h
+++ b/src/activities/apps/GymAssetSyncActivity.h
@@ -12,10 +12,10 @@
 // at add-exercise or mid-workout time would be a disruptive interruption; the
 // user syncs assets deliberately, same as Font/Dictionary "Manage" screens.
 #ifndef FOULAD_GYM_IMAGE_BASE_URL
-#define FOULAD_GYM_IMAGE_BASE_URL "http://midad.one/api/gym/image/"
+#define FOULAD_GYM_IMAGE_BASE_URL "https://midad.one/api/gym/image/"
 #endif
 #ifndef FOULAD_GYM_EXERCISE_BASE_URL
-#define FOULAD_GYM_EXERCISE_BASE_URL "http://midad.one/api/gym/exercise/"
+#define FOULAD_GYM_EXERCISE_BASE_URL "https://midad.one/api/gym/exercise/"
 #endif
 
 class GymAssetSyncActivity final : public Activity {

--- a/src/activities/apps/GymCatalogSyncActivity.h
+++ b/src/activities/apps/GymCatalogSyncActivity.h
@@ -8,7 +8,7 @@
 // for the server contract). Overridable for local testing, same convention as
 // FOULAD_DICTS_CATALOG_URL/FOULAD_FONTS_CATALOG_URL.
 #ifndef FOULAD_GYM_CATALOG_URL
-#define FOULAD_GYM_CATALOG_URL "http://midad.one/api/gym/catalog"
+#define FOULAD_GYM_CATALOG_URL "https://midad.one/api/gym/catalog"
 #endif
 
 // Downloads the full exercise catalog (metadata only, no images/instructions

--- a/src/activities/settings/DictionaryDownloadActivity.h
+++ b/src/activities/settings/DictionaryDownloadActivity.h
@@ -10,7 +10,7 @@
 // font store: plain http (see src/FouladEbooksConfig.h), version=1 schema,
 // per-file crc32 verification. Overridable for local testing.
 #ifndef FOULAD_DICTS_CATALOG_URL
-#define FOULAD_DICTS_CATALOG_URL "http://midad.one/api/dicts/catalog"
+#define FOULAD_DICTS_CATALOG_URL "https://midad.one/api/dicts/catalog"
 #endif
 
 // Download store for StarDict dictionaries, modeled on FontDownloadActivity:

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -19,7 +19,7 @@
 // filter). Plain http for the same reason as FOULAD_EBOOKS_URL -- see
 // src/FouladEbooksConfig.h. Overridable for local testing.
 #ifndef FOULAD_FONTS_CATALOG_URL
-#define FOULAD_FONTS_CATALOG_URL "http://midad.one/api/fonts/catalog"
+#define FOULAD_FONTS_CATALOG_URL "https://midad.one/api/fonts/catalog"
 #endif
 
 #ifndef FONT_MANIFEST_URL

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -19,6 +19,7 @@
 
 #include "FouladDeviceTracking.h"
 #include "FouladEbooksConfig.h"
+#include "MidadRootCa.h"
 
 namespace {
 // RX holds the response headers. 4096 fits real OPDS servers; GitHub's release
@@ -199,7 +200,20 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   // servers over plain http (esp_http_client picks the transport from the URL
   // scheme, so http:// needs no cert config). The prior setInsecure() worked
   // only because Arduino's ssl_client drives mbedtls directly.
-  config.crt_bundle_attach = esp_crt_bundle_attach;
+  // One pinned root for Midad, the full bundle for everything else. The bundle costs
+  // ~250KB of contiguous allocation during the handshake -- the reason every Midad
+  // endpoint was on plain http, with account credentials in clear on every request.
+  // ISRG Root X1 alone verifies midad.one's cross-signed chain at ~1.9KB, which a
+  // device observed at 18.7KB free can actually afford.
+  //
+  // GitHub is on a Sectigo chain this root cannot verify, so OTA and font downloads
+  // keep the bundle. Selection is by host, matching the same helper that gates the
+  // device-serial header.
+  if (isFouladEbooksUrl(url)) {
+    config.cert_pem = MIDAD_ROOT_CA_PEM;
+  } else {
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
   config.keep_alive_enable = true;
   if (conditional) {
     config.event_handler = captureResponseEtag;
@@ -415,7 +429,20 @@ HttpDownloader::DownloadError runPostFile(const std::string& url,
   config.buffer_size = HTTP_RX_BUF;
   config.buffer_size_tx = HTTP_TX_BUF;
   config.timeout_ms = timeoutMs;
-  config.crt_bundle_attach = esp_crt_bundle_attach;
+  // One pinned root for Midad, the full bundle for everything else. The bundle costs
+  // ~250KB of contiguous allocation during the handshake -- the reason every Midad
+  // endpoint was on plain http, with account credentials in clear on every request.
+  // ISRG Root X1 alone verifies midad.one's cross-signed chain at ~1.9KB, which a
+  // device observed at 18.7KB free can actually afford.
+  //
+  // GitHub is on a Sectigo chain this root cannot verify, so OTA and font downloads
+  // keep the bundle. Selection is by host, matching the same helper that gates the
+  // device-serial header.
+  if (isFouladEbooksUrl(url)) {
+    config.cert_pem = MIDAD_ROOT_CA_PEM;
+  } else {
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
   config.keep_alive_enable = true;
 
   esp_http_client_handle_t client = esp_http_client_init(&config);
@@ -570,7 +597,20 @@ HttpDownloader::DownloadError runDelete(const std::string& url, const std::strin
   config.buffer_size = HTTP_RX_BUF;
   config.buffer_size_tx = HTTP_TX_BUF;
   config.timeout_ms = timeoutMs;
-  config.crt_bundle_attach = esp_crt_bundle_attach;
+  // One pinned root for Midad, the full bundle for everything else. The bundle costs
+  // ~250KB of contiguous allocation during the handshake -- the reason every Midad
+  // endpoint was on plain http, with account credentials in clear on every request.
+  // ISRG Root X1 alone verifies midad.one's cross-signed chain at ~1.9KB, which a
+  // device observed at 18.7KB free can actually afford.
+  //
+  // GitHub is on a Sectigo chain this root cannot verify, so OTA and font downloads
+  // keep the bundle. Selection is by host, matching the same helper that gates the
+  // device-serial header.
+  if (isFouladEbooksUrl(url)) {
+    config.cert_pem = MIDAD_ROOT_CA_PEM;
+  } else {
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
   config.keep_alive_enable = true;
 
   esp_http_client_handle_t client = esp_http_client_init(&config);
@@ -656,7 +696,20 @@ HttpDownloader::DownloadError runPostJson(const std::string& url, const std::str
   config.buffer_size = HTTP_RX_BUF;
   config.buffer_size_tx = HTTP_TX_BUF;
   config.timeout_ms = timeoutMs;
-  config.crt_bundle_attach = esp_crt_bundle_attach;
+  // One pinned root for Midad, the full bundle for everything else. The bundle costs
+  // ~250KB of contiguous allocation during the handshake -- the reason every Midad
+  // endpoint was on plain http, with account credentials in clear on every request.
+  // ISRG Root X1 alone verifies midad.one's cross-signed chain at ~1.9KB, which a
+  // device observed at 18.7KB free can actually afford.
+  //
+  // GitHub is on a Sectigo chain this root cannot verify, so OTA and font downloads
+  // keep the bundle. Selection is by host, matching the same helper that gates the
+  // device-serial header.
+  if (isFouladEbooksUrl(url)) {
+    config.cert_pem = MIDAD_ROOT_CA_PEM;
+  } else {
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
   config.keep_alive_enable = true;
 
   esp_http_client_handle_t client = esp_http_client_init(&config);

--- a/src/network/MidadRootCa.h
+++ b/src/network/MidadRootCa.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// ISRG Root X1 -- the single trust anchor needed for midad.one.
+//
+// Why one pinned root rather than esp_crt_bundle_attach: the bundle is ~250KB of
+// contiguous allocation during the handshake, which on this device drove free heap
+// to ~5KB and froze it (see HttpDownloader.cpp's own note on the removed fallback).
+// This is ~1.9KB. On a device observed at 18.7KB free that difference is the whole
+// argument.
+//
+// Why X1 and not the leaf's immediate issuer: midad.one presents the full
+// cross-signed chain -- leaf <- Let's Encrypt YE1 <- ISRG Root YE <- ISRG Root X2
+// <- ISRG Root X1 -- so X1 alone verifies it. Measured with
+// `openssl s_client -CAfile isrgrootx1.pem`: return code 0.
+//
+// Only used for Midad hosts. GitHub is on a Sectigo chain that this root cannot
+// verify, so those requests keep the full bundle (see runGet's cert selection).
+//
+// Expires 2035-06-04. Replacing it is a firmware release, so it is worth watching
+// rather than discovering.
+constexpr char MIDAD_ROOT_CA_PEM[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n"
+    "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n"
+    "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n"
+    "WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n"
+    "ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n"
+    "MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n"
+    "h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n"
+    "0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n"
+    "A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n"
+    "T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n"
+    "B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n"
+    "B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n"
+    "KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n"
+    "OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n"
+    "jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n"
+    "qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n"
+    "rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n"
+    "HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n"
+    "hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n"
+    "ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n"
+    "3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n"
+    "NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n"
+    "ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n"
+    "TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n"
+    "jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n"
+    "oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n"
+    "4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n"
+    "mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n"
+    "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n"
+    "-----END CERTIFICATE-----\n";


### PR DESCRIPTION
Every OPDS request has been carrying account Basic Auth **in clear text**. This ends that.

## Both of my objections were wrong

**"The certificate doesn't cover midad.one."** I read the CN (`foulad.one`) and never looked at the SAN, which is what hostname verification uses. It lists both. I said this twice.

**"Pinning drove free heap to ~5 KB."** That was `esp_crt_bundle_attach` — ~250 KB of contiguous allocation during the handshake. **ISRG Root X1 alone is ~1.9 KB**, and it verifies midad.one's full cross-signed chain:

```
leaf ← Let's Encrypt YE1 ← ISRG Root YE ← ISRG Root X2 ← ISRG Root X1
openssl s_client -CAfile isrgrootx1.pem  →  Verify return code: 0 (ok)
```

On a device observed at 18.7 KB free that difference is the whole argument. foulad-ebooks had measured it correctly while I was comparing against the wrong thing.

## What changed

- All **twelve** `midad.one` URLs → `https`
- Cert selection **by host**, reusing the helper that already gates the device-serial header
- **GitHub keeps the bundle** — its Sectigo chain can't be verified by this root, so OTA and font downloads are untouched

## The migration bug this exposed

Switching to `https` would have **signed every existing device out**.

The stored `OpdsServerStore` entry — not the constant — is what requests use, and every device in the field has `http://midad.one/opds` on its card. The rename migration only swapped the *host*. And `server.url == FOULAD_EBOOKS_URL` decides "is this account set up?" for the home tile, sync gating and the Settings login row — so a scheme change alone would have demanded a fresh QR scan from every paired device.

That's the exact failure the rename migration was written to prevent, recreated by changing a different part of the same string. It now replaces the whole URL when the entry is recognisably ours but not equal to the current constant, so the next host/scheme/path change needs no new migration.

`FOULAD_EBOOKS_LEGACY_HOST` stays even though nothing calls `foulad.one` — it's what lets `isFouladEbooksUrl()` recognise a pre-rename entry as ours. Without it those devices are never migrated at all.

## Also: font-decompressor retry storm

From the first X4 crash: **eleven attempts at the same 10,667 bytes in 23 ms**, at 18.7 KB free. `getBitmap()` runs per glyph and never remembered a failure, so a group that couldn't be allocated was retried by every remaining glyph on the line — none could succeed, each fragmented further.

The failed `(font, group)` is now skipped without allocating or logging, cleared on any successful allocation and by `clearCache()`.

## Blast radius — stating it plainly

This touches **every request the device makes to Midad**, and the migration touches **every paired device**. If the pin is wrong, the catalog stops for everyone. If the migration is wrong, everyone is signed out.

**Pre-release channel only until verified on hardware.**

## Testing

- `pio run -e gh_release_rc` clean, no warnings; clang-format verified.
- Chain verified against X1 alone with `openssl`.

Needs hardware:
- [ ] **An already-paired device stays signed in after updating** (the migration)
- [ ] Library loads over https
- [ ] Download a book; open a cover
- [ ] QR sign-in from signed-out
- [ ] OTA update check still works (GitHub, still on the bundle)
- [ ] Font download still works (GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)