### PR TITLE
feat: offer a firmware update once the Library is on screen

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -29,6 +29,7 @@
 #include "components/icons/book.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
+#include "network/OtaUpdater.h"
 #include "util/BookCacheUtils.h"
 #include "util/DebugLog.h"
 #include "util/DebugLogging.h"
@@ -150,6 +151,27 @@ void OpdsBookBrowserActivity::onExit() {
 }
 
 void OpdsBookBrowserActivity::loop() {
+  if (state == BrowserState::UPDATE_PROMPT) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      // Reboots into the OTA flow on a fresh heap, exactly as Settings does -- the
+      // catalog session has just held a feed and a TLS handshake, and the firmware
+      // download needs more contiguous memory than that leaves. Does not return.
+      silentRestartToOtaCheck();
+      return;
+    }
+    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      state = BrowserState::BROWSING;  // declined; carry on browsing
+      requestUpdate();
+      return;
+    }
+    return;  // nothing else acts while the offer is up
+  }
+
+  maybeCheckForFirmwareUpdate();
+  // The check can raise the prompt mid-frame; hand this frame to it rather than
+  // letting a keypress fall through to the catalog underneath.
+  if (state == BrowserState::UPDATE_PROMPT) return;
+
   if (state == BrowserState::WIFI_SELECTION || state == BrowserState::SEARCH_INPUT) {
     return;
   }
@@ -345,6 +367,25 @@ void OpdsBookBrowserActivity::loop() {
 }
 
 void OpdsBookBrowserActivity::render(RenderLock&&) {
+  if (state == BrowserState::BROWSING && browsingFramesRendered < 2) browsingFramesRendered++;
+
+  if (state == BrowserState::UPDATE_PROMPT) {
+    const auto& metrics = UITheme::getInstance().getMetrics();
+    const int pageWidth = renderer.getScreenWidth();
+    const int pageHeight = renderer.getScreenHeight();
+    const int lineHeight = renderer.getLineHeight(UI_10_FONT_ID);
+    const int top = (pageHeight - lineHeight * 3) / 2;
+    renderer.clearScreen();
+    GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_UPDATE));
+    renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NEW_UPDATE), true, EpdFontFamily::BOLD);
+    renderer.drawCenteredText(UI_10_FONT_ID, top + lineHeight + metrics.verticalSpacing,
+                              (std::string(tr(STR_NEW_VERSION)) + pendingUpdateVersion).c_str());
+    const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    renderer.displayBuffer();
+    return;
+  }
+
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -1023,6 +1064,11 @@ void OpdsBookBrowserActivity::performSearch(const std::string& query) {
   fetchFeed(url);
 }
 
+// Once per boot, not once per Library entry: someone browsing in and out repeatedly
+// should not pay for a GitHub round trip each time. File-scope rather than a member
+// because the activity is destroyed and rebuilt on every entry.
+static bool gFirmwareUpdateCheckedThisBoot = false;
+
 void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   if (server.url != FOULAD_EBOOKS_URL) return;
   FouladDeviceTracking::registerDevice(server.username, server.password);
@@ -1049,6 +1095,30 @@ void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   // Device/reading-stats snapshot for the "My Devices" web page's Device
   // Stats / Reading Stats tabs -- same reliable-moment reasoning.
   FouladDeviceTracking::reportDeviceStats(server.username, server.password);
+}
+
+void OpdsBookBrowserActivity::maybeCheckForFirmwareUpdate() {
+  if (gFirmwareUpdateCheckedThisBoot) return;
+  if (state != BrowserState::BROWSING || browsingFramesRendered == 0) return;  // wait for a painted feed
+  if (!FouladDeviceTracking::wifiConnected()) return;
+  gFirmwareUpdateCheckedThisBoot = true;
+
+  // After the catalog is up, never before it. Checking first would add a GitHub
+  // round trip to every Library open, which is the one cost this was asked not to
+  // have. Afterwards the wait is invisible: the feed is already readable.
+  //
+  // Cheap in the ordinary case -- the release check sends If-None-Match and an
+  // unchanged list comes back 304, which GitHub does not count against the rate
+  // limit at all (see OtaUpdater).
+  OtaUpdater updater;
+  if (updater.checkForUpdate() != OtaUpdater::OK || !updater.isUpdateNewer()) return;
+
+  pendingUpdateVersion = updater.getLatestVersion();
+  if (!pendingUpdateVersion.empty() && (pendingUpdateVersion[0] == 'v' || pendingUpdateVersion[0] == 'V')) {
+    pendingUpdateVersion.erase(0, 1);
+  }
+  state = BrowserState::UPDATE_PROMPT;
+  requestUpdate();
 }
 
 void OpdsBookBrowserActivity::checkAndConnectWifi() {

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -15,7 +15,18 @@
  */
 class OpdsBookBrowserActivity final : public Activity {
  public:
-  enum class BrowserState { CHECK_WIFI, WIFI_SELECTION, LOADING, BROWSING, DOWNLOADING, ERROR, SEARCH_INPUT };
+  enum class BrowserState {
+    CHECK_WIFI,
+    WIFI_SELECTION,
+    LOADING,
+    BROWSING,
+    DOWNLOADING,
+    ERROR,
+    SEARCH_INPUT,
+    // A firmware update was found while the catalog was already on screen. Not a
+    // step in browsing -- an offer laid over it, which Cancel returns from.
+    UPDATE_PROMPT
+  };
 
   explicit OpdsBookBrowserActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, OpdsServer server)
       : Activity("OpdsBookBrowser", renderer, mappedInput), buttonNavigator(), server(std::move(server)) {}
@@ -166,6 +177,13 @@ class OpdsBookBrowserActivity final : public Activity {
   // not on every page/pagination fetch. No-op for any non-Foulad-eBooks
   // server -- see the server.url check inside.
   void reportDeviceTrackingOnConnect();
+  // Looks for a firmware update once per boot, AFTER the catalog is on screen.
+  // Deliberately not before: the whole point is that opening Library is no slower.
+  void maybeCheckForFirmwareUpdate();
+  // Counts completed BROWSING frames, so the check waits for a rendered feed rather
+  // than merely a parsed one.
+  uint8_t browsingFramesRendered = 0;
+  std::string pendingUpdateVersion;
   void fetchFeed(const std::string& path);
   void navigateToEntry(const OpdsEntry& entry);
   void navigateBack();
@@ -178,6 +196,10 @@ class OpdsBookBrowserActivity final : public Activity {
   // kept the device (and its WiFi radio) awake for as long as Foulad
   // eBooks/OPDS stayed the foreground activity, even fully idle -- a real
   // battery-drain path (user report).
-  bool preventAutoSleep() override { return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING; }
+  bool preventAutoSleep() override {
+    // UPDATE_PROMPT holds the device awake for the same reason OtaUpdateActivity
+    // does: sleeping on an unanswered question loses the answer.
+    return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING || state == BrowserState::UPDATE_PROMPT;
+  }
   const char* activityDebugName() const override { return "OpdsBookBrowserActivity"; }
 };


### PR DESCRIPTION
Opening Library now looks for a new release and offers it in a prompt, without the open itself getting any slower.

**The timing is the design.** Checking before the feed would put a GitHub round trip in front of every Library open — the one cost this was asked not to have. The check runs *after* the catalog is painted (`BROWSING` + at least one completed frame), where the wait is invisible because there is already something to read.

- Once per boot, not once per entry — browsing in and out doesn't pay for it repeatedly. The flag is file-scope because the activity is rebuilt on every entry.
- Confirm → `silentRestartToOtaCheck()`, the same route Settings takes. This session has just held an OPDS feed and a TLS handshake; the firmware download needs more contiguous heap than that leaves.
- Back declines and returns to the catalog. The prompt holds the device awake and swallows its own frame, so a keypress meant for the offer can't reach the list underneath.
- Cheap in the ordinary case: the release check sends `If-None-Match`, and GitHub doesn't count 304s against the rate limit.

Verify on device: open Library with WiFi up while a newer RC exists → feed renders at the usual speed, prompt follows a second or two later. Back returns to the list; re-entering Library does not ask again until reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)