### PR TITLE
fix: revert the Library update check that crashed on open

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -29,7 +29,6 @@
 #include "components/icons/book.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
-#include "network/OtaUpdater.h"
 #include "util/BookCacheUtils.h"
 #include "util/DebugLog.h"
 #include "util/DebugLogging.h"
@@ -151,27 +150,6 @@ void OpdsBookBrowserActivity::onExit() {
 }
 
 void OpdsBookBrowserActivity::loop() {
-  if (state == BrowserState::UPDATE_PROMPT) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      // Reboots into the OTA flow on a fresh heap, exactly as Settings does -- the
-      // catalog session has just held a feed and a TLS handshake, and the firmware
-      // download needs more contiguous memory than that leaves. Does not return.
-      silentRestartToOtaCheck();
-      return;
-    }
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-      state = BrowserState::BROWSING;  // declined; carry on browsing
-      requestUpdate();
-      return;
-    }
-    return;  // nothing else acts while the offer is up
-  }
-
-  maybeCheckForFirmwareUpdate();
-  // The check can raise the prompt mid-frame; hand this frame to it rather than
-  // letting a keypress fall through to the catalog underneath.
-  if (state == BrowserState::UPDATE_PROMPT) return;
-
   if (state == BrowserState::WIFI_SELECTION || state == BrowserState::SEARCH_INPUT) {
     return;
   }
@@ -367,25 +345,6 @@ void OpdsBookBrowserActivity::loop() {
 }
 
 void OpdsBookBrowserActivity::render(RenderLock&&) {
-  if (state == BrowserState::BROWSING && browsingFramesRendered < 2) browsingFramesRendered++;
-
-  if (state == BrowserState::UPDATE_PROMPT) {
-    const auto& metrics = UITheme::getInstance().getMetrics();
-    const int pageWidth = renderer.getScreenWidth();
-    const int pageHeight = renderer.getScreenHeight();
-    const int lineHeight = renderer.getLineHeight(UI_10_FONT_ID);
-    const int top = (pageHeight - lineHeight * 3) / 2;
-    renderer.clearScreen();
-    GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_UPDATE));
-    renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NEW_UPDATE), true, EpdFontFamily::BOLD);
-    renderer.drawCenteredText(UI_10_FONT_ID, top + lineHeight + metrics.verticalSpacing,
-                              (std::string(tr(STR_NEW_VERSION)) + pendingUpdateVersion).c_str());
-    const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
-    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-    renderer.displayBuffer();
-    return;
-  }
-
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -1064,11 +1023,6 @@ void OpdsBookBrowserActivity::performSearch(const std::string& query) {
   fetchFeed(url);
 }
 
-// Once per boot, not once per Library entry: someone browsing in and out repeatedly
-// should not pay for a GitHub round trip each time. File-scope rather than a member
-// because the activity is destroyed and rebuilt on every entry.
-static bool gFirmwareUpdateCheckedThisBoot = false;
-
 void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   if (server.url != FOULAD_EBOOKS_URL) return;
   FouladDeviceTracking::registerDevice(server.username, server.password);
@@ -1095,30 +1049,6 @@ void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   // Device/reading-stats snapshot for the "My Devices" web page's Device
   // Stats / Reading Stats tabs -- same reliable-moment reasoning.
   FouladDeviceTracking::reportDeviceStats(server.username, server.password);
-}
-
-void OpdsBookBrowserActivity::maybeCheckForFirmwareUpdate() {
-  if (gFirmwareUpdateCheckedThisBoot) return;
-  if (state != BrowserState::BROWSING || browsingFramesRendered == 0) return;  // wait for a painted feed
-  if (!FouladDeviceTracking::wifiConnected()) return;
-  gFirmwareUpdateCheckedThisBoot = true;
-
-  // After the catalog is up, never before it. Checking first would add a GitHub
-  // round trip to every Library open, which is the one cost this was asked not to
-  // have. Afterwards the wait is invisible: the feed is already readable.
-  //
-  // Cheap in the ordinary case -- the release check sends If-None-Match and an
-  // unchanged list comes back 304, which GitHub does not count against the rate
-  // limit at all (see OtaUpdater).
-  OtaUpdater updater;
-  if (updater.checkForUpdate() != OtaUpdater::OK || !updater.isUpdateNewer()) return;
-
-  pendingUpdateVersion = updater.getLatestVersion();
-  if (!pendingUpdateVersion.empty() && (pendingUpdateVersion[0] == 'v' || pendingUpdateVersion[0] == 'V')) {
-    pendingUpdateVersion.erase(0, 1);
-  }
-  state = BrowserState::UPDATE_PROMPT;
-  requestUpdate();
 }
 
 void OpdsBookBrowserActivity::checkAndConnectWifi() {

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -15,18 +15,7 @@
  */
 class OpdsBookBrowserActivity final : public Activity {
  public:
-  enum class BrowserState {
-    CHECK_WIFI,
-    WIFI_SELECTION,
-    LOADING,
-    BROWSING,
-    DOWNLOADING,
-    ERROR,
-    SEARCH_INPUT,
-    // A firmware update was found while the catalog was already on screen. Not a
-    // step in browsing -- an offer laid over it, which Cancel returns from.
-    UPDATE_PROMPT
-  };
+  enum class BrowserState { CHECK_WIFI, WIFI_SELECTION, LOADING, BROWSING, DOWNLOADING, ERROR, SEARCH_INPUT };
 
   explicit OpdsBookBrowserActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, OpdsServer server)
       : Activity("OpdsBookBrowser", renderer, mappedInput), buttonNavigator(), server(std::move(server)) {}
@@ -177,13 +166,6 @@ class OpdsBookBrowserActivity final : public Activity {
   // not on every page/pagination fetch. No-op for any non-Foulad-eBooks
   // server -- see the server.url check inside.
   void reportDeviceTrackingOnConnect();
-  // Looks for a firmware update once per boot, AFTER the catalog is on screen.
-  // Deliberately not before: the whole point is that opening Library is no slower.
-  void maybeCheckForFirmwareUpdate();
-  // Counts completed BROWSING frames, so the check waits for a rendered feed rather
-  // than merely a parsed one.
-  uint8_t browsingFramesRendered = 0;
-  std::string pendingUpdateVersion;
   void fetchFeed(const std::string& path);
   void navigateToEntry(const OpdsEntry& entry);
   void navigateBack();
@@ -196,10 +178,6 @@ class OpdsBookBrowserActivity final : public Activity {
   // kept the device (and its WiFi radio) awake for as long as Foulad
   // eBooks/OPDS stayed the foreground activity, even fully idle -- a real
   // battery-drain path (user report).
-  bool preventAutoSleep() override {
-    // UPDATE_PROMPT holds the device awake for the same reason OtaUpdateActivity
-    // does: sleeping on an unanswered question loses the answer.
-    return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING || state == BrowserState::UPDATE_PROMPT;
-  }
+  bool preventAutoSleep() override { return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING; }
   const char* activityDebugName() const override { return "OpdsBookBrowserActivity"; }
 };


### PR DESCRIPTION
Reverts #57. Reported crash: Library opened, English books selected, device rebooted and uploaded a log.

The check was wrong in a way this repo had already written down — `SettingsActivity.cpp:390`, on why **Check for updates** reboots rather than opening the OTA flow in place:

> after Home/library browsing the heap is fragmented below what the GitHub TLS handshakes need

That is exactly what #57 created: a GitHub TLS handshake run inline in the browser with an OPDS feed resident. Settings escapes it by rebooting to a clean heap first; the Library check had no such escape. Deferring until after the first render bought nothing, because the problem was never *when* the check ran — it was what sat in memory beside it.

Moving it earlier, before the feed, doesn't rescue it either: the comment blames Home browsing on its own, so the heap is already fragmented by the time Library opens.

The feature is worth having. It needs a design that does no network work in the browser at all — most likely the catalog server reporting the latest firmware version in a response the device already fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)