### PR TITLE
feat: offer firmware updates in Library from the catalog response

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -14,6 +14,7 @@
 #include "KOReaderCredentialStore.h"
 #include "RecentBooksStore.h"
 #include "network/HttpDownloader.h"
+#include "network/OtaUpdater.h"
 #include "reading/ReadingStatsStore.h"
 #include "util/DebugLog.h"
 #include "util/DebugLogging.h"
@@ -428,6 +429,38 @@ std::string getSerialNumber() {
   return std::string("XTE-") + mac.c_str();
 }
 
+// Resolved once per registration: the build to offer, or empty for "nothing to say".
+// A std::string rather than a pointer into the response -- responseDoc dies with the
+// call and the Library reads this minutes later.
+static std::string latestFirmwareOffer;
+
+// Picks this device's channel out of {"stable", "rc"} and keeps the tag only if it
+// beats the running build.
+//
+// A stable device is never offered an -rc: it opted out of pre-releases by running a
+// release, and a popup is not the place to change that. An RC device prefers the rc
+// tag and falls back to stable, which is what carries it off a pre-release once the
+// equal-numbered release lands -- exactly the case OtaUpdater's -rc rule exists for
+// (a device on 1.8.19-rc takes 1.8.19, since the rc tag is by then identical to what
+// it is already running).
+static void captureLatestFirmware(JsonVariantConst latest) {
+  latestFirmwareOffer.clear();
+  if (latest.isNull()) return;  // older server, or GitHub was unreachable for it
+
+  const auto newerOrNull = [](JsonVariantConst v) -> const char* {
+    const char* tag = v.is<const char*>() ? v.as<const char*>() : nullptr;
+    return OtaUpdater::isVersionNewer(tag) ? tag : nullptr;
+  };
+
+  const char* offer = nullptr;
+  if (strstr(CROSSPOINT_VERSION, "-rc") != nullptr) offer = newerOrNull(latest["rc"]);
+  if (offer == nullptr) offer = newerOrNull(latest["stable"]);
+  if (offer == nullptr) return;
+
+  latestFirmwareOffer = offer;
+  LOG_INF(TAG, "Server reports newer firmware: %s (running %s)", offer, CROSSPOINT_VERSION);
+}
+
 void registerDevice(const std::string& username, const std::string& password) {
   if (!wifiConnected() || username.empty() || password.empty()) return;
 
@@ -454,6 +487,7 @@ void registerDevice(const std::string& username, const std::string& password) {
   JsonDocument responseDoc;
   if (!deserializeJson(responseDoc, response)) {
     applySettingsFromServer(responseDoc["settings"].as<JsonObjectConst>());
+    captureLatestFirmware(responseDoc["latest_firmware"]);
   }
 }
 
@@ -639,5 +673,7 @@ void reportDeviceStats(const std::string& username, const std::string& password)
   // treated as "already reported."
   if (ok && includeReading) lastReportedTotalReadingMs = totalMs;
 }
+
+const std::string& pendingFirmwareUpdate() { return latestFirmwareOffer; }
 
 }  // namespace FouladDeviceTracking

--- a/src/FouladDeviceTracking.h
+++ b/src/FouladDeviceTracking.h
@@ -112,4 +112,19 @@ void flushPendingCrashReport(const std::string& username, const std::string& pas
 // the OOM aborts a prior Gym-app bug already demonstrated on this device.
 void reportDeviceStats(const std::string& username, const std::string& password);
 
+// The newest firmware build the catalog server named in its last registerDevice()
+// response, if it is newer than the one running; empty otherwise. Read-only, free,
+// and always safe to call: it is a string parsed out of a reply the device already
+// fetched, so consulting it costs no request, no TLS handshake and no heap.
+//
+// That is the entire point of routing this through registration. The Library once
+// asked GitHub directly and aborted the device doing it -- a TLS handshake needs
+// ~32KB of mbedTLS record buffers, and the heap after Home/library browsing has
+// nothing like that contiguous (see SettingsActivity's Check for updates, which
+// reboots first for exactly this reason).
+//
+// Empty is the normal state: an older server omits the key, and so does a current
+// one that could not reach GitHub. Absent means "no information", never "up to date".
+const std::string& pendingFirmwareUpdate();
+
 }  // namespace FouladDeviceTracking

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -150,6 +150,27 @@ void OpdsBookBrowserActivity::onExit() {
 }
 
 void OpdsBookBrowserActivity::loop() {
+  if (state == BrowserState::UPDATE_PROMPT) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      // Reboots into the OTA flow rather than downloading here: this session has an
+      // OPDS feed and its cover cache resident, and the firmware download needs more
+      // contiguous heap than that leaves. Does not return.
+      silentRestartToOtaCheck();
+      return;
+    }
+    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      state = BrowserState::BROWSING;  // declined; carry on browsing
+      requestUpdate();
+      return;
+    }
+    return;  // nothing else acts while the offer is up
+  }
+
+  maybeOfferFirmwareUpdate();
+  // The offer can go up mid-frame; hand this frame to it rather than letting a
+  // keypress fall through to the catalog underneath.
+  if (state == BrowserState::UPDATE_PROMPT) return;
+
   if (state == BrowserState::WIFI_SELECTION || state == BrowserState::SEARCH_INPUT) {
     return;
   }
@@ -345,6 +366,25 @@ void OpdsBookBrowserActivity::loop() {
 }
 
 void OpdsBookBrowserActivity::render(RenderLock&&) {
+  if (state == BrowserState::BROWSING && browsingFramesRendered < 2) browsingFramesRendered++;
+
+  if (state == BrowserState::UPDATE_PROMPT) {
+    const auto& metrics = UITheme::getInstance().getMetrics();
+    const int lineHeight = renderer.getLineHeight(UI_10_FONT_ID);
+    const int top = (renderer.getScreenHeight() - lineHeight * 3) / 2;
+    renderer.clearScreen();
+    GUI.drawHeader(renderer, Rect{0, metrics.topPadding, renderer.getScreenWidth(), metrics.headerHeight},
+                   tr(STR_UPDATE));
+    renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NEW_UPDATE), true, EpdFontFamily::BOLD);
+    renderer.drawCenteredText(
+        UI_10_FONT_ID, top + lineHeight + metrics.verticalSpacing,
+        (std::string(tr(STR_NEW_VERSION)) + FouladDeviceTracking::pendingFirmwareUpdate()).c_str());
+    const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    renderer.displayBuffer();
+    return;
+  }
+
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -1049,6 +1089,30 @@ void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
   // Device/reading-stats snapshot for the "My Devices" web page's Device
   // Stats / Reading Stats tabs -- same reliable-moment reasoning.
   FouladDeviceTracking::reportDeviceStats(server.username, server.password);
+}
+
+// Once per boot, not once per Library entry: declining should stick for the session
+// rather than being asked again on every visit. File-scope because the activity is
+// destroyed and rebuilt each time.
+static bool gFirmwareOfferShownThisBoot = false;
+
+void OpdsBookBrowserActivity::maybeOfferFirmwareUpdate() {
+  if (gFirmwareOfferShownThisBoot) return;
+  if (state != BrowserState::BROWSING || browsingFramesRendered == 0) return;
+  // The catalog goes up first and the offer follows. Not a memory precaution -- this
+  // costs nothing -- simply that a popup arriving before the list has painted hides
+  // the thing the user opened Library to see.
+  if (FouladDeviceTracking::pendingFirmwareUpdate().empty()) return;
+
+  // Note what this does NOT do: contact GitHub. The version was parsed out of the
+  // registerDevice() response earlier in this same connect, so raising the offer is
+  // a string comparison. The previous attempt ran OtaUpdater::checkForUpdate() here
+  // and the TLS handshake aborted the device at ~52KB free (v1.8.17-rc); the ~32KB
+  // of mbedTLS record buffers do not fit beside a loaded feed. Nothing in this
+  // function may become a network call without moving it off this path entirely.
+  gFirmwareOfferShownThisBoot = true;
+  state = BrowserState::UPDATE_PROMPT;
+  requestUpdate();
 }
 
 void OpdsBookBrowserActivity::checkAndConnectWifi() {

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -15,7 +15,18 @@
  */
 class OpdsBookBrowserActivity final : public Activity {
  public:
-  enum class BrowserState { CHECK_WIFI, WIFI_SELECTION, LOADING, BROWSING, DOWNLOADING, ERROR, SEARCH_INPUT };
+  enum class BrowserState {
+    CHECK_WIFI,
+    WIFI_SELECTION,
+    LOADING,
+    BROWSING,
+    DOWNLOADING,
+    ERROR,
+    SEARCH_INPUT,
+    // A newer firmware build was named by the catalog server. Not a step in
+    // browsing -- an offer laid over it, which Cancel returns from.
+    UPDATE_PROMPT
+  };
 
   explicit OpdsBookBrowserActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, OpdsServer server)
       : Activity("OpdsBookBrowser", renderer, mappedInput), buttonNavigator(), server(std::move(server)) {}
@@ -166,6 +177,13 @@ class OpdsBookBrowserActivity final : public Activity {
   // not on every page/pagination fetch. No-op for any non-Foulad-eBooks
   // server -- see the server.url check inside.
   void reportDeviceTrackingOnConnect();
+  // Raises the update offer if registration came back naming a newer build. Reads a
+  // cached string; makes no request. An earlier version of this asked GitHub from
+  // here and aborted the device -- see the implementation.
+  void maybeOfferFirmwareUpdate();
+  // Counts painted BROWSING frames, so the offer waits until the catalog it covers
+  // is actually on screen.
+  uint8_t browsingFramesRendered = 0;
   void fetchFeed(const std::string& path);
   void navigateToEntry(const OpdsEntry& entry);
   void navigateBack();
@@ -178,6 +196,10 @@ class OpdsBookBrowserActivity final : public Activity {
   // kept the device (and its WiFi radio) awake for as long as Foulad
   // eBooks/OPDS stayed the foreground activity, even fully idle -- a real
   // battery-drain path (user report).
-  bool preventAutoSleep() override { return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING; }
+  bool preventAutoSleep() override {
+    // UPDATE_PROMPT holds the device awake for the same reason OtaUpdateActivity
+    // does: sleeping on an unanswered question loses the answer.
+    return state == BrowserState::LOADING || state == BrowserState::DOWNLOADING || state == BrowserState::UPDATE_PROMPT;
+  }
   const char* activityDebugName() const override { return "OpdsBookBrowserActivity"; }
 };

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -188,6 +188,12 @@ bool OtaUpdater::isUpdateNewer() const {
   if (!updateAvailable || latestVersion.empty()) {
     return false;
   }
+  return isVersionNewer(latestVersion.c_str());
+}
+
+bool OtaUpdater::isVersionNewer(const char* candidate) {
+  if (candidate == nullptr || *candidate == '\0') return false;
+  const std::string latestVersion(candidate);
 
   // GitHub tag names are conventionally "v1.6.24" while CROSSPOINT_VERSION (from
   // platformio.ini) is the bare "1.6.24" -- strip a leading 'v'/'V' before comparing so the

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -30,6 +30,11 @@ class OtaUpdater {
   size_t getTotalSize() const { return totalSize; }
 
   OtaUpdater() = default;
+  // True when `candidate` (a GitHub tag, leading 'v' optional) names a build newer
+  // than the running one. Public and static because the catalog server now reports
+  // firmware versions too, and that path needs the identical answer -- a second
+  // implementation of "is this newer" is how the two come to disagree about an -rc.
+  static bool isVersionNewer(const char* candidate);
   bool isUpdateNewer() const;
   const std::string& getLatestVersion() const;
   OtaUpdaterError checkForUpdate();


### PR DESCRIPTION
Second attempt at the Library update offer. The first (#57, reverted in #60) asked GitHub directly from the browser and aborted the device — a TLS handshake needs ~32 KB of mbedTLS record buffers, and the crash log showed it failing at **52,404 bytes free**, taking the next feed down with it.

**This one makes no request at all.** `registerDevice()` already runs on every Library connect, already sends this device's version, and its response is already parsed — so the catalog server names the newest build in that same reply, and raising the offer is a string comparison against a value already in memory. Opening Library costs exactly what it did before.

### Channel policy stays on the device
Where the comparison already lives. A **stable device is never offered an `-rc`**: it opted out of pre-releases by running a release, and a popup is not the place to change that. An **RC device prefers the `rc` tag and falls back to `stable`**, which is what carries it off a pre-release once the equal-numbered release lands.

`isUpdateNewer()`'s body becomes the public `OtaUpdater::isVersionNewer()`, so this path gets the identical answer rather than a second implementation of "is this newer" that could come to disagree about an `-rc`.

### Safe to ship ahead of the server
foulad-ebooks has this built on branch `firmware-channels`, not deployed. An older server — or a current one that couldn't reach GitHub — omits `latest_firmware`, and absent means *no information*, not *up to date*. The offer simply never appears until they deploy.

### Verify on device
Library open with a newer build published → catalog paints at its usual speed, offer follows. **Update** reboots into the OTA flow (`silentRestartToOtaCheck`, clean heap); **Cancel** returns to the list and doesn't ask again until reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)