### PR TITLE
feat: make catalog search a row you can see

### DIFF
--- a/lib/OpdsParser/OpdsParser.h
+++ b/lib/OpdsParser/OpdsParser.h
@@ -10,7 +10,12 @@
  */
 enum class OpdsEntryType {
   NAVIGATION,  // Link to another catalog
-  BOOK         // Downloadable book
+  BOOK,        // Downloadable book
+  // Opens the search keyboard rather than fetching anything. Never produced by the
+  // parser -- the browser synthesises one row per feed from the OpenSearch template
+  // in <link rel="search">, so search is a thing you can see and select rather than
+  // a button binding you have to be told about.
+  SEARCH
 };
 
 /**

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -227,12 +227,16 @@ void OpdsBookBrowserActivity::loop() {
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
       if (!entries.empty()) {
         const auto& entry = entries[selectorIndex];
-        entry.type == OpdsEntryType::BOOK ? downloadBook(entry) : navigateToEntry(entry);
+        if (entry.type == OpdsEntryType::SEARCH) {
+          launchSearch();
+        } else if (entry.type == OpdsEntryType::BOOK) {
+          downloadBook(entry);
+        } else {
+          navigateToEntry(entry);
+        }
       }
     } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       navigateBack();
-    } else if (mappedInput.wasReleased(MappedInputManager::Button::Left) && !onBook) {
-      if (!searchTemplate.empty() && selectorIndex == 0) launchSearch();
     }
 
     if (entries.empty()) {
@@ -276,7 +280,9 @@ void OpdsBookBrowserActivity::loop() {
       };
       auto moveUp = [this, layout, goToFeedPage] {
         if (selectorIndex == layout.bookStart && layout.topNavCount > 0) {
-          selectorIndex = 0;
+          // The row directly above the grid, not the top of the strip -- with a search
+          // row now sitting above Prev Page, jumping to 0 would skip past it.
+          selectorIndex = layout.topNavCount - 1;
           requestUpdate();
           return;
         }
@@ -456,7 +462,10 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
   const GridLayout layout = computeGridLayout();
   const bool onBook = !entries.empty() && entries[selectorIndex].type == OpdsEntryType::BOOK;
 
-  const char* confirmLabel = onBook ? tr(STR_DOWNLOAD) : tr(STR_OPEN);
+  // "Open" is wrong on the search row -- nothing opens, a keyboard appears. The hint
+  // names what the button does, the same rule the font browser's tab row follows.
+  const bool onSearchRow = !entries.empty() && entries[selectorIndex].type == OpdsEntryType::SEARCH;
+  const char* confirmLabel = onSearchRow ? tr(STR_SEARCH) : (onBook ? tr(STR_DOWNLOAD) : tr(STR_OPEN));
   const char* leftLabel;
   const char* rightLabel;
   // Grid-page book cells use genuinely horizontal Left/Right (mirror under RTL,
@@ -468,7 +477,7 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
     leftLabel = tr(STR_DIR_LEFT);
     rightLabel = tr(STR_DIR_RIGHT);
   } else {
-    leftLabel = (!searchTemplate.empty() && selectorIndex == 0) ? tr(STR_SEARCH) : tr(STR_DIR_UP);
+    leftLabel = tr(STR_DIR_UP);
     rightLabel = tr(STR_DIR_DOWN);
   }
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, leftLabel, rightLabel, rtlSwapLabels);
@@ -493,7 +502,7 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
 
     for (size_t i = pageStartIndex; i < entries.size() && i < static_cast<size_t>(pageStartIndex + pageItems); i++) {
       const auto& entry = entries[i];
-      std::string displayText = (entry.type == OpdsEntryType::NAVIGATION) ? "> " + entry.title : entry.title;
+      std::string displayText = (entry.type != OpdsEntryType::BOOK) ? "> " + entry.title : entry.title;
       if (entry.type == OpdsEntryType::BOOK && !entry.author.empty()) displayText += " - " + entry.author;
       auto item = renderer.truncatedText(UI_10_FONT_ID, displayText.c_str(), pageWidth - 40);
       renderer.drawTextInWidth(UI_10_FONT_ID, 20, GRID_CONTENT_TOP + (i % pageItems) * rowHeight, pageWidth - 40,
@@ -878,8 +887,20 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
   if (!feedNextUrl.empty()) {
     entries.push_back(OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_NEXT_PAGE), "", feedNextUrl, ""});
   }
+  // Search goes in as a row, above everything, on every feed that advertises it.
+  //
+  // It was already implemented and already worked -- but it lived on the Left button,
+  // and only while the selection happened to be on the top row. Nothing said so. A
+  // catalogue that has grown to 679 books behind a 57-page walk is unusable if the one
+  // feature that finds a book by name is a binding you have to be told about, so it
+  // stops being a binding.
+  if (!searchTemplate.empty()) {
+    entries.insert(entries.begin(), OpdsEntry{OpdsEntryType::SEARCH, tr(STR_SEARCH), "", "", ""});
+  }
 
-  selectorIndex = 0;
+  // Past the search row: it is the first thing you can reach by pressing Up, not the
+  // thing you land on every time a page loads.
+  selectorIndex = (!entries.empty() && entries[0].type == OpdsEntryType::SEARCH && entries.size() > 1) ? 1 : 0;
   if (pendingSelect != PendingGridSelect::None) {
     // Auto-advance landing spot: continue the reading direction seamlessly
     // instead of parking the selection on the "> Prev Page" strip row.

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -191,60 +191,6 @@ bool OtaUpdater::isUpdateNewer() const {
   return isVersionNewer(latestVersion.c_str());
 }
 
-bool OtaUpdater::isVersionNewer(const char* candidate) {
-  if (candidate == nullptr || *candidate == '\0') return false;
-  const std::string latestVersion(candidate);
-
-  // GitHub tag names are conventionally "v1.6.24" while CROSSPOINT_VERSION (from
-  // platformio.ini) is the bare "1.6.24" -- strip a leading 'v'/'V' before comparing so the
-  // two aren't treated as different versions just because of the tag prefix. This also
-  // matters for the sscanf below: handing it a string that starts with a non-digit character
-  // leaves its output variables uninitialized rather than parsed, which previously made this
-  // function's result depend on stack garbage whenever the tag prefix caused a mismatch here.
-  const char* latestVersionStr = latestVersion.c_str();
-  if (*latestVersionStr == 'v' || *latestVersionStr == 'V') latestVersionStr++;
-
-  const auto currentVersion = CROSSPOINT_VERSION;
-  if (strcmp(latestVersionStr, currentVersion) == 0) {
-    return false;
-  }
-
-  int currentMajor, currentMinor, currentPatch;
-  int latestMajor, latestMinor, latestPatch;
-
-  // semantic version check (only match on 3 segments)
-  sscanf(latestVersionStr, "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch);
-  sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch);
-
-  /*
-   * Compare major versions.
-   * If they differ, return true if latest major version greater than current major version
-   * otherwise return false.
-   */
-  if (latestMajor != currentMajor) return latestMajor > currentMajor;
-
-  /*
-   * Compare minor versions.
-   * If they differ, return true if latest minor version greater than current minor version
-   * otherwise return false.
-   */
-  if (latestMinor != currentMinor) return latestMinor > currentMinor;
-
-  /*
-   * Check patch versions.
-   */
-  if (latestPatch != currentPatch) return latestPatch > currentPatch;
-
-  // If we reach here, it means all segments are equal.
-  // One final check, if we're on an RC build (contains "-rc"), we should consider the latest version as newer even if
-  // the segments are equal, since RC builds are pre-release versions.
-  if (strstr(currentVersion, "-rc") != nullptr) {
-    return true;
-  }
-
-  return false;
-}
-
 const std::string& OtaUpdater::getLatestVersion() const { return latestVersion; }
 
 OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgress, void* ctx) {

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdio>
+#include <cstring>
 #include <string>
 
 class OtaUpdater {
@@ -34,9 +36,69 @@ class OtaUpdater {
   // than the running one. Public and static because the catalog server now reports
   // firmware versions too, and that path needs the identical answer -- a second
   // implementation of "is this newer" is how the two come to disagree about an -rc.
+  //
+  // Defined inline, below, deliberately: OtaUpdater.cpp is excluded from the
+  // simulator build (it needs esp_https_ota), so a caller outside the OTA flow --
+  // FouladDeviceTracking, reading the catalog's firmware report -- fails to link
+  // against an out-of-line definition. Comparing two version strings needs nothing
+  // from that translation unit anyway.
   static bool isVersionNewer(const char* candidate);
   bool isUpdateNewer() const;
   const std::string& getLatestVersion() const;
   OtaUpdaterError checkForUpdate();
   OtaUpdaterError installUpdate(ProgressCallback onProgress = nullptr, void* ctx = nullptr);
 };
+
+inline bool OtaUpdater::isVersionNewer(const char* candidate) {
+  if (candidate == nullptr || *candidate == '\0') return false;
+  const std::string latestVersion(candidate);
+
+  // GitHub tag names are conventionally "v1.6.24" while CROSSPOINT_VERSION (from
+  // platformio.ini) is the bare "1.6.24" -- strip a leading 'v'/'V' before comparing so the
+  // two aren't treated as different versions just because of the tag prefix. This also
+  // matters for the sscanf below: handing it a string that starts with a non-digit character
+  // leaves its output variables uninitialized rather than parsed, which previously made this
+  // function's result depend on stack garbage whenever the tag prefix caused a mismatch here.
+  const char* latestVersionStr = latestVersion.c_str();
+  if (*latestVersionStr == 'v' || *latestVersionStr == 'V') latestVersionStr++;
+
+  const auto currentVersion = CROSSPOINT_VERSION;
+  if (strcmp(latestVersionStr, currentVersion) == 0) {
+    return false;
+  }
+
+  int currentMajor, currentMinor, currentPatch;
+  int latestMajor, latestMinor, latestPatch;
+
+  // semantic version check (only match on 3 segments)
+  sscanf(latestVersionStr, "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch);
+  sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch);
+
+  /*
+   * Compare major versions.
+   * If they differ, return true if latest major version greater than current major version
+   * otherwise return false.
+   */
+  if (latestMajor != currentMajor) return latestMajor > currentMajor;
+
+  /*
+   * Compare minor versions.
+   * If they differ, return true if latest minor version greater than current minor version
+   * otherwise return false.
+   */
+  if (latestMinor != currentMinor) return latestMinor > currentMinor;
+
+  /*
+   * Check patch versions.
+   */
+  if (latestPatch != currentPatch) return latestPatch > currentPatch;
+
+  // If we reach here, it means all segments are equal.
+  // One final check, if we're on an RC build (contains "-rc"), we should consider the latest version as newer even if
+  // the segments are equal, since RC builds are pre-release versions.
+  if (strstr(currentVersion, "-rc") != nullptr) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Search was already built and already worked — keyboard entry, percent-encoding, results as a normal feed — and `midad.one` has always advertised the OpenSearch template the parser accepts:

```xml
<link rel="search" href="http://midad.one/opds/search?q={searchTerms}" .../>
```

What it didn't have was any way to **find** it. The trigger was the Left button, and only while the selection happened to sit on the top row. Nothing on screen said so — it's entirely possible search has never been used once on any device.

That matters now the catalogue is 679 books behind a 57-page walk. The one feature that finds a book by name can't be a binding you have to be told about, so it stops being a binding: **every feed that advertises `rel="search"` gets a Search row above everything else**, Confirm opens the keyboard, and the hint reads "Search" rather than "Open". Left goes back to meaning Up everywhere.

A new `OpdsEntryType::SEARCH` carries it. The parser never produces one — the browser synthesises it from the template, exactly as it already synthesises the Prev/Next page rows.

Selection after a fetch skips past the search row, so a page load lands where it used to rather than parking on Search. Up out of the grid lands on the row directly above it (`topNavCount - 1`, which was `0` before).

### Also unbreaks the simulator build
`OtaUpdater.cpp` is excluded from that env (`platformio.ini:128`), so `isVersionNewer()` — added out-of-line in #61 and called from `FouladDeviceTracking` — failed to link there. It's inline in the header now; comparing two version strings never needed anything from that translation unit. Device builds were unaffected, but `pio run -e simulator` has been broken since #61.

### Verified
Simulator, against production: the root feed logged `entries=4` before this change and `entries=5` after — the search row. No abort. Both `gh_release_rc` and `simulator` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)