### PR TITLE
feat: right-to-left text entry, and drop the OPDS row from System

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -83,7 +83,12 @@ void SettingsActivity::rebuildSettingsLists() {
   appsSettings.push_back(SettingInfo::Toggle(StrId::STR_DEBUG_LOGGING, &CrossPointSettings::debugLoggingEnabled,
                                              "debugLoggingEnabled", StrId::STR_CAT_APPS));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_WIFI_NETWORKS, SettingAction::Network));
-  systemSettings.push_back(SettingInfo::Action(StrId::STR_OPDS_SERVERS, SettingAction::OPDSBrowser));
+  // OPDS Servers is deliberately not listed. Adding a catalog by hand means typing a
+  // URL and credentials on an on-screen keyboard, and every catalog these devices
+  // actually reach is reached by signing in -- so the row only ever offered a way to
+  // get it wrong. The activity itself stays (ActivityManager still routes to it), and
+  // SettingAction::OPDSBrowser with it, so nothing else has to change to bring the row
+  // back.
   systemSettings.push_back(SettingInfo::Action(StrId::STR_CLEAR_READING_CACHE, SettingAction::ClearCache));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_CHECK_UPDATES, SettingAction::CheckForUpdates));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_SD_FIRMWARE_UPDATE, SettingAction::SdFirmwareUpdate));

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <HalGPIO.h>
 #include <I18n.h>
+#include <ScriptDetector.h>
 
 #include <algorithm>
 
@@ -487,6 +488,17 @@ void KeyboardEntryActivity::render(RenderLock&&) {
     if (w > cursorCharWidth) cursorCharWidth = w;
   }
 
+  // A right-to-left field: text hugs the right margin and the caret sits at the
+  // LEFT end, because that is where the next letter goes. drawText already shapes
+  // and reorders the glyphs -- what it cannot know is where the field's origin
+  // should be, which is a layout decision and belongs here.
+  //
+  // Keyed on the content, not just the panel, so a line typed in Arabic keeps its
+  // direction after switching back to abc to add a digit. The empty-field case
+  // falls back to the panel, so opening Arabic puts the caret where the writing
+  // will actually start.
+  const bool rtlField = ScriptDetector::containsArabic(displayText.c_str()) || (arabicMode && displayText.empty());
+
   int lineStartIdx = 0;
   int lineEndIdx = displayText.length();
   int textWidth = 0;
@@ -520,6 +532,10 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         }
         if (centerText) {
           cursorPixelX = effectiveMargin + (maxLineWidth - textWidth) / 2 + beforeWidth + kernOffset;
+        } else if (rtlField) {
+          // Mirrored: the prefix occupies the RIGHT side of the run, so the caret sits
+          // that far in from the right edge rather than from the left.
+          cursorPixelX = effectiveMargin + maxLineWidth - beforeWidth - kernOffset;
         } else {
           cursorPixelX = effectiveMargin + beforeWidth + kernOffset;
         }
@@ -528,7 +544,9 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         isCursorLine = true;
       }
 
-      const int lineStartX = centerText ? effectiveMargin + (maxLineWidth - textWidth) / 2 : effectiveMargin;
+      const int lineStartX = centerText ? effectiveMargin + (maxLineWidth - textWidth) / 2
+                             : rtlField ? effectiveMargin + maxLineWidth - textWidth
+                                        : effectiveMargin;
       if (isCursorLine && cursorMode && isPassword && !passwordVisible && !togglePos) {
         // Draw text in 3 parts to avoid block cursor overflowing onto next char.
         // displayText uses '*' for all chars; actual char may be wider than '*'.


### PR DESCRIPTION
### RTL text entry
Typing Arabic ran the field left to right. The letters shaped and joined correctly — `drawText` already handles that — but they started at the **left** margin with the caret to their right, the opposite end from where the next letter goes.

`drawText` can't fix this on its own: it shapes and reorders glyphs, but where the field's origin sits is a layout decision and that lives in the keyboard. The line now hugs the right margin, and the caret is mirrored — sitting that far in from the right rather than from the left.

**Keyed on the content, not the panel**, so a line typed in Arabic keeps its direction after you switch to `abc` to add a digit. An empty field falls back to the panel, so opening Arabic puts the caret where the writing is about to start.

### OPDS Servers removed from Settings → System
Adding a catalog by hand means typing a URL *and* credentials on an on-screen keyboard, and every catalog these devices actually reach is reached by signing in — so the row only ever offered a way to get it wrong.

Only the row is gone. `OpdsServerListActivity` and `SettingAction::OPDSBrowser` both stay, and `ActivityManager` still routes to it, so restoring the entry is one line.

### Verified
Rendered in the simulator: `القران` sits against the right margin with the caret at its left end. Both `gh_release_rc` and `simulator` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)