### PR TITLE
fix: an empty feed is empty even when a Search row is drawn on it

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -889,9 +889,19 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
   }
 
   searchTemplate = parser->getSearchTemplate();
+  // On the News root the advertised search is the BOOK search (/opds/search), which
+  // would put a row inside News that returns books. Wrong answer to the wrong
+  // question, so News does not offer it.
+  if (server.url == FOULAD_EBOOKS_NEWS_URL) searchTemplate.clear();
   feedNextUrl = parser->getNextPageUrl();
   feedPrevUrl = parser->getPrevPageUrl();
   entries = std::move(*parser).getEntries();
+
+  // Whether the FEED was empty, captured before the synthetic rows go in. The empty
+  // state has to be decided on what the server actually sent: a page carrying only a
+  // Search row is an empty feed wearing a button, and treating it as populated is how
+  // "Add news feeds in the Midad app" stopped appearing at all.
+  const bool feedHadEntries = !entries.empty();
 
   if (!feedPrevUrl.empty()) {
     entries.insert(entries.begin(), OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_PREV_PAGE), "", feedPrevUrl, ""});
@@ -929,8 +939,8 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
     }
   }
 
-  state = entries.empty() ? BrowserState::ERROR : BrowserState::BROWSING;
-  if (entries.empty()) {
+  state = feedHadEntries ? BrowserState::BROWSING : BrowserState::ERROR;
+  if (!feedHadEntries) {
     // An empty feed is the normal, successful answer to "this account has no
     // subscriptions" -- not an error (EINK_NEWS_TASKS.md §2). Say what to do next
     // instead, because the thing to do is on the phone and nothing here can do it.


### PR DESCRIPTION
Two things, both found by pointing the reader at the now-live `/opds/news`.

### The empty state stopped working the moment search became a row
State was decided from `entries.size()` **after** the synthetic Prev/Next/Search rows went in. So a feed the server returned with zero entries arrived carrying one Search row and counted as populated.

For an account with no subscriptions, the News page showed **a lone Search button** instead of *"Add news feeds in the Midad app"* — and an empty book category lost its no-entries message the same way. Emptiness is now taken from what the server actually sent, before anything synthetic is added.

### News no longer offers search at all
`/opds/news` advertises `rel="search"` pointing at `/opds/search` — the **book** search. The row would have sat inside News and returned books: the wrong answer to a question the user didn't ask. Suppressed on that root.

The second problem only becomes visible because the first is fixed: with an empty feed correctly showing its message, a Search row would have been the only thing on the page.

### Verified against production
`GET /opds/news` with the test account returns `HTTP 200`, a valid Atom feed, `<id>urn:midad:news</id>`, zero entries — exactly the "signed in, no subscriptions" state — and yes, it carries the book `rel="search"` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)