### PR TITLE
fix: make the News tile open News, and give it a cover

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -743,6 +743,8 @@ void RecentBooksActivity::render(RenderLock&&) {
         // Solid fill repaints over the thin outline drawRect() just drew --
         // same black, no visible seam -- with the designed cover on top.
         drawTileCover(renderer, cellX, cellY, geometry.coverWidth, geometry.coverHeight, tr(STR_GAMES));
+      } else if (!drawn && book.path == NEWS_PSEUDO_PATH) {
+        drawTileCover(renderer, cellX, cellY, geometry.coverWidth, geometry.coverHeight, tr(STR_NEWS));
       } else if (!drawn && book.path == TASBIH_PSEUDO_PATH) {
         drawTileCover(renderer, cellX, cellY, geometry.coverWidth, geometry.coverHeight, tr(STR_TASBIH));
       } else if (!drawn && book.path == STOPWATCH_PSEUDO_PATH) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,12 @@ constexpr uint32_t SILENT_REBOOT_TARGET_GYM = 6;
 constexpr uint32_t SILENT_REBOOT_TARGET_SETTINGS = 7;
 constexpr uint32_t SILENT_REBOOT_TARGET_DICTIONARY = 8;
 constexpr uint32_t SILENT_REBOOT_TARGET_NEWS = 9;
+constexpr uint32_t SILENT_REBOOT_TARGET_MAX = SILENT_REBOOT_TARGET_NEWS;
+// Must always name the highest target above. The boot-time range check below uses it
+// to reject uninitialised RTC memory on a cold boot, and a target outside the range
+// is silently treated as 0 -- which is HOME. Adding a target without moving this
+// makes the new one reboot to the home screen instead, with nothing logged: exactly
+// what shipped when NEWS=9 was added while the check still read <= DICTIONARY (8).
 
 // How the device is coming back to life, resolved once at boot. Both resume
 // flows suppress the splash and leave the panel holding its pre-boot frame; a
@@ -530,7 +536,7 @@ void setup() {
   // Bound the target range too — RTC_NOINIT memory is uninitialized on cold boot.
   const bool isSilentReboot = (silentRebootMagic == SILENT_REBOOT_MAGIC);
   const uint32_t snapshotTarget =
-      (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_DICTIONARY) ? silentRebootTarget : 0;
+      (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_MAX) ? silentRebootTarget : 0;
   silentRebootMagic = 0;
   silentRebootTarget = 0;
   gBootWasSilentRestart = isSilentReboot;


### PR DESCRIPTION
Reported: News shows an empty cover, and pressing it lands on the home screen. **Two separate mistakes, both mine, both in the tile I added.**

### It went home because of a bounds check
`main.cpp` rejects out-of-range silent-reboot targets to guard against uninitialised RTC memory on a cold boot — and anything outside the range is treated as `0`, which is **HOME**:

```cpp
(isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_DICTIONARY) ? silentRebootTarget : 0;
```

`DICTIONARY` is 8; I added `NEWS = 9`. So the reboot fired, the target was stored correctly, and it was thrown away one line before it would have been used — silently, with nothing logged.

The check now reads `SILENT_REBOOT_TARGET_MAX`, defined immediately after the targets, so the bound moves with the list instead of being a second place to remember. The comment there says what happens if you forget.

### The empty cover is the other half
Every synthetic tile has a `drawTileCover` branch painting its name — Games, Tasbih, Stop Watch, Pomodoro, Gym all do. News had none, so it fell through to the generic `BookIcon` placeholder, which is precisely what the comment above those tiles describes as looking broken.

### Verified
Builds clean. The bounds bug is the kind that only shows on device — the simulator never takes the reboot path — which is why it reached you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)