### PR TITLE
fix: an acquisition link is a download whatever its MIME type says

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -138,19 +138,39 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
         // FsHelpers::hasXtcExtension's "either spelling" treatment on the read side.
         const bool isXtcAcquisition =
             type && (strcmp(type, "application/x-xtc") == 0 || strcmp(type, "application/x-xtch") == 0);
-        if (rel && strstr(rel, "opds-spec.org/acquisition") != nullptr && (isEpubAcquisition || isXtcAcquisition)) {
+        // The acquisition rel is the authoritative signal in OPDS: it means "this is
+        // the file to download". Trust it even when the type is one we do not know.
+        //
+        // Requiring a known MIME type here is what made News unusable: its entries
+        // arrived with an acquisition link the type check rejected, so they fell to
+        // the atom branch below, became NAVIGATION, and the reader fetched the EPUB
+        // and tried to parse it as a feed -- "Failed to parse feed" on every article
+        // list. Downloading a file we cannot open is a better failure than pretending
+        // it is a catalogue, and the extension logic already defaults sensibly.
+        if (rel && strstr(rel, "opds-spec.org/acquisition") != nullptr) {
           // Prefer plain EPUB links over derived/other formats when multiple
           // acquisition links are present for one entry.
+          // Known types still win when an entry offers several links: an unfamiliar
+          // one is a fallback, not a preference.
+          const bool isKnownType = isEpubAcquisition || isXtcAcquisition;
+          const bool alreadyKnownType = self->currentEntry.type == OpdsEntryType::BOOK &&
+                                        (self->currentEntry.acquisitionType == "application/epub+zip" ||
+                                         self->currentEntry.acquisitionType == "application/x-xtc" ||
+                                         self->currentEntry.acquisitionType == "application/x-xtch");
+          const bool keepExisting = self->currentEntry.type == OpdsEntryType::BOOK && alreadyKnownType && !isKnownType;
           const bool isPlainEpub =
               isEpubAcquisition && (strstr(href, ".epub") != nullptr || strstr(href, "/epub/") != nullptr);
           const bool alreadyHasPlainEpub = self->currentEntry.type == OpdsEntryType::BOOK &&
                                            self->currentEntry.acquisitionType == "application/epub+zip" &&
                                            (self->currentEntry.href.find(".epub") != std::string::npos ||
                                             self->currentEntry.href.find("/epub/") != std::string::npos);
-          if (self->currentEntry.type != OpdsEntryType::BOOK || (isPlainEpub && !alreadyHasPlainEpub)) {
+          if (!keepExisting &&
+              (self->currentEntry.type != OpdsEntryType::BOOK || (isPlainEpub && !alreadyHasPlainEpub))) {
             self->currentEntry.type = OpdsEntryType::BOOK;
             self->currentEntry.href = href;
-            self->currentEntry.acquisitionType = type;
+            // type may be absent now that the rel alone qualifies; nullptr into a
+            // std::string is undefined, not empty.
+            self->currentEntry.acquisitionType = type ? type : "";
           }
         } else if (type && strstr(type, "application/atom+xml") != nullptr) {
           if (self->currentEntry.type != OpdsEntryType::BOOK) {


### PR DESCRIPTION
Reported from a device with real subscriptions: the News list rendered, but opening any feed gave **"Error: Failed to parse feed"**.

### The list itself said why
Every row was drawn with the `> ` prefix and the Confirm hint read **Open** — both only happen for `NAVIGATION` entries. So the reader had classified the feeds as links to other catalogues, followed one, fetched the EPUB behind it, and tried to parse a zip as Atom.

### The rule was too strict
`OpdsParser.cpp:141` accepted an entry as a book only when the acquisition link's `type` was exactly `application/epub+zip` (or the two xtc spellings). Anything else carrying an `atom+xml` type fell through to the navigation branch at line 155 — which then took the EPUB's own URL as a feed URL.

**The `rel` is the authoritative signal in OPDS.** `opds-spec.org/acquisition` means *this is the file to download*; the type is a hint about what the file is. It's now treated that way.

- Known types still win when an entry offers several links, so nothing changes for the catalogue — an unfamiliar type is a fallback, not a preference.
- `type` may now be absent entirely (the rel alone qualifies), so it's null-guarded — assigning a null `const char*` to `std::string` is undefined, not empty.

Downloading a file we might not be able to open is a better failure than insisting it's a catalogue: the extension logic already defaults to `.epub`, and a book that won't open says so plainly instead of producing a parse error on a list of feeds.

### Still worth confirming server-side
I couldn't see the failing XML — the test account has no subscriptions, so `/opds/news` returns an empty feed. This fix makes the reader robust to whatever the type is, but it'd be worth foulad-ebooks checking that news acquisition links really do carry `type="application/epub+zip"` as `EINK_NEWS_TASKS.md` §3 specifies. If they don't, that's still worth correcting at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)