### PR TITLE
feat: give news feeds a cover instead of an empty box

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -25,6 +25,7 @@
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/KeyboardEntryActivity.h"
+#include "components/TileCover.h"
 #include "components/UITheme.h"
 #include "components/icons/book.h"
 #include "fontIds.h"
@@ -574,7 +575,14 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
         }
       }
       renderer.drawRect(cellX, cellY, layout.coverWidth, layout.coverHeight);
-      if (!drawn) {
+      if (!drawn && server.url == FOULAD_EBOOKS_NEWS_URL) {
+        // News entries carry no cover art -- there is no image link in the feed, so
+        // nothing failed to download and nothing is going to appear later. The generic
+        // book icon reads as a book that did not load; the feed's own name on a
+        // designed tile reads as the thing it is, which is what the app tiles already
+        // do for the same reason.
+        drawTileCover(renderer, cellX, cellY, layout.coverWidth, layout.coverHeight, entry.title.c_str());
+      } else if (!drawn) {
         renderer.drawIcon(BookIcon, cellX + (layout.coverWidth - 32) / 2, cellY + (layout.coverHeight - 32) / 2, 32);
       }
       if (bookIdx == selectorIndex) {

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -22,6 +22,7 @@
 #include "activities/apps/TasbihActivity.h"
 #include "activities/games/GamesMenuActivity.h"
 #include "activities/util/ConfirmationActivity.h"
+#include "components/TileCover.h"
 #include "components/UITheme.h"
 #include "components/icons/book.h"
 #include "fontIds.h"
@@ -78,54 +79,6 @@ std::string filenameStem(const std::string& path) {
   return path.substr(start, end - start);
 }
 
-// "Cover" for synthetic feature tiles (Games, Tasbih) -- there's no real cover
-// image (their paths are never real SD files), and the generic BookIcon
-// placeholder used for every other missing-cover case made it look like a
-// broken/unopened book rather than a deliberate feature tile (an earlier
-// hand-drawn puzzle pictogram had the same problem: too easy to mistake for
-// clutter at a glance). A solid black tile with the label centered reads
-// instantly as its own distinct "book" in the grid, the way a plain black
-// spine stands out on a shelf. Drawn with plain fillRect/drawText primitives,
-// no bitmap asset needed.
-void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label) {
-  renderer.fillRect(cellX, cellY, cellWidth, cellHeight, true);
-
-  // Thin white inset frame -- a plain black rectangle reads as "missing
-  // cover"; a bordered one reads as a designed cover. Inset (not flush)
-  // so it doesn't fight the grid's own cell outline drawn over this by the
-  // caller.
-  const int inset = std::max(4, cellWidth / 20);
-  const int frameThickness = std::max(1, cellWidth / 60);
-  renderer.drawRect(cellX + inset, cellY + inset, cellWidth - 2 * inset, cellHeight - 2 * inset, frameThickness, false);
-
-  // Largest available UI font, bold, white-on-black, centered in the cell.
-  // Falls back a size down if the label would overflow the inset frame (long
-  // translations, e.g. German/French labels).
-  int fontId = UI_12_FONT_ID;
-  int textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
-  const int maxTextWidth = cellWidth - 4 * inset;
-  if (textWidth > maxTextWidth) {
-    fontId = UI_10_FONT_ID;
-    textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
-  }
-  if (textWidth > maxTextWidth) {
-    fontId = SMALL_FONT_ID;
-    textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
-  }
-  const int textX = cellX + (cellWidth - textWidth) / 2;
-  const int textY = cellY + (cellHeight - renderer.getLineHeight(fontId)) / 2;
-  renderer.drawText(fontId, textX, textY, label, false, EpdFontFamily::BOLD);
-
-  // A short rule above and below the label -- breaks up a plain word on a
-  // plain field into something that looks like a designed logotype/badge
-  // rather than a stray caption.
-  const int ruleWidth = std::min(cellWidth - 6 * inset, textWidth + 4 * inset);
-  const int ruleX = cellX + (cellWidth - ruleWidth) / 2;
-  const int ruleGap = std::max(6, cellHeight / 18);
-  renderer.fillRect(ruleX, textY - ruleGap, ruleWidth, frameThickness, false);
-  renderer.fillRect(ruleX, textY + renderer.getLineHeight(fontId) + ruleGap - frameThickness, ruleWidth, frameThickness,
-                    false);
-}
 }  // namespace
 
 void RecentBooksActivity::loadRecentBooks() {

--- a/src/components/TileCover.cpp
+++ b/src/components/TileCover.cpp
@@ -1,0 +1,59 @@
+#include "TileCover.h"
+
+#include <algorithm>
+#include <string>
+
+#include "fontIds.h"
+
+// "Cover" for synthetic feature tiles (Games, Tasbih) -- there's no real cover
+// image (their paths are never real SD files), and the generic BookIcon
+// placeholder used for every other missing-cover case made it look like a
+// broken/unopened book rather than a deliberate feature tile (an earlier
+// hand-drawn puzzle pictogram had the same problem: too easy to mistake for
+// clutter at a glance). A solid black tile with the label centered reads
+// instantly as its own distinct "book" in the grid, the way a plain black
+// spine stands out on a shelf. Drawn with plain fillRect/drawText primitives,
+// no bitmap asset needed.
+void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label) {
+  renderer.fillRect(cellX, cellY, cellWidth, cellHeight, true);
+
+  // Thin white inset frame -- a plain black rectangle reads as "missing
+  // cover"; a bordered one reads as a designed cover. Inset (not flush)
+  // so it doesn't fight the grid's own cell outline drawn over this by the
+  // caller.
+  const int inset = std::max(4, cellWidth / 20);
+  const int frameThickness = std::max(1, cellWidth / 60);
+  renderer.drawRect(cellX + inset, cellY + inset, cellWidth - 2 * inset, cellHeight - 2 * inset, frameThickness, false);
+
+  // Largest available UI font, bold, white-on-black, centered in the cell.
+  // Falls back a size down if the label would overflow the inset frame (long
+  // translations, e.g. German/French labels).
+  int fontId = UI_12_FONT_ID;
+  int textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
+  const int maxTextWidth = cellWidth - 4 * inset;
+  if (textWidth > maxTextWidth) {
+    fontId = UI_10_FONT_ID;
+    textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
+  }
+  if (textWidth > maxTextWidth) {
+    fontId = SMALL_FONT_ID;
+    textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
+  }
+  // Shrinking twice is not enough for a long feed name -- clip what is left so the
+  // label stays inside the frame instead of running past it.
+  const std::string shown = renderer.truncatedText(fontId, label, maxTextWidth);
+  textWidth = renderer.getTextWidth(fontId, shown.c_str(), EpdFontFamily::BOLD);
+  const int textX = cellX + (cellWidth - textWidth) / 2;
+  const int textY = cellY + (cellHeight - renderer.getLineHeight(fontId)) / 2;
+  renderer.drawText(fontId, textX, textY, shown.c_str(), false, EpdFontFamily::BOLD);
+
+  // A short rule above and below the label -- breaks up a plain word on a
+  // plain field into something that looks like a designed logotype/badge
+  // rather than a stray caption.
+  const int ruleWidth = std::min(cellWidth - 6 * inset, textWidth + 4 * inset);
+  const int ruleX = cellX + (cellWidth - ruleWidth) / 2;
+  const int ruleGap = std::max(6, cellHeight / 18);
+  renderer.fillRect(ruleX, textY - ruleGap, ruleWidth, frameThickness, false);
+  renderer.fillRect(ruleX, textY + renderer.getLineHeight(fontId) + ruleGap - frameThickness, ruleWidth, frameThickness,
+                    false);
+}

--- a/src/components/TileCover.cpp
+++ b/src/components/TileCover.cpp
@@ -14,7 +14,8 @@
 // instantly as its own distinct "book" in the grid, the way a plain black
 // spine stands out on a shelf. Drawn with plain fillRect/drawText primitives,
 // no bitmap asset needed.
-void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label) {
+void drawTileCover(const GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight,
+                   const char* label) {
   renderer.fillRect(cellX, cellY, cellWidth, cellHeight, true);
 
   // Thin white inset frame -- a plain black rectangle reads as "missing
@@ -36,8 +37,7 @@ void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, i
     textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
   }
   if (textWidth > maxTextWidth) {
-    fontId = SMALL_FONT_ID;
-    textWidth = renderer.getTextWidth(fontId, label, EpdFontFamily::BOLD);
+    fontId = SMALL_FONT_ID;  // no width needed here: the clip below recomputes it
   }
   // Shrinking twice is not enough for a long feed name -- clip what is left so the
   // label stays inside the frame instead of running past it.

--- a/src/components/TileCover.h
+++ b/src/components/TileCover.h
@@ -11,4 +11,4 @@
 // the OPDS browser uses it for news feeds, which carry no cover art in their entries.
 // Both looked broken with the generic BookIcon placeholder -- an anonymous icon in a
 // box reads as an unopened book that failed, not as a thing you are meant to press.
-void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label);
+void drawTileCover(const GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label);

--- a/src/components/TileCover.h
+++ b/src/components/TileCover.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <GfxRenderer.h>
+
+// The "cover" for a grid tile that has no cover image: a solid black cell with the
+// label set in the middle, framed and ruled so it reads as a designed cover rather
+// than a failure to load one.
+//
+// Shared because two grids need it for the same reason. My Books uses it for the
+// synthetic app tiles (Games, Tasbih, News...), whose paths are never real files;
+// the OPDS browser uses it for news feeds, which carry no cover art in their entries.
+// Both looked broken with the generic BookIcon placeholder -- an anonymous icon in a
+// box reads as an unopened book that failed, not as a thing you are meant to press.
+void drawTileCover(GfxRenderer& renderer, int cellX, int cellY, int cellWidth, int cellHeight, const char* label);


### PR DESCRIPTION
Reported: the News grid draws an empty cell with a small book icon for every feed.

**Nothing failed.** News entries carry no cover art — there's no image link in the feed at all — so there was never anything to download and nothing would have appeared later. What was wrong is that *"no cover"* and *"cover failed to load"* looked identical, and the generic `BookIcon` reads as the second: an unopened book that didn't work, rather than a thing you're meant to press.

My Books already solved this for the synthetic app tiles, whose paths are never real files — `drawTileCover` paints the label on a framed black cell so it reads as a designed cover. That helper was private to `RecentBooksActivity`; it's now `src/components/TileCover.{h,cpp}` and the OPDS grid uses it for news feeds.

It gained a truncation step on the way: shrinking the font twice is enough for "Games" and not for "Ars Technica - All content", which ran past the frame.

**Only the news root is affected.** A catalogue book with no cover keeps the book icon — there the art usually does exist and may simply not have downloaded yet, which is a different thing to say.

### Verified
Rendered in the simulator against a local feed: three tiles with their feed names, Arabic shaped correctly, and the long name clipped to "Ars Technica ...".

🤖 Generated with [Claude Code](https://claude.com/claude-code)