### PR TITLE
fix: news is not a book, so keep it off the home screen

### DIFF
--- a/src/FouladEbooksConfig.h
+++ b/src/FouladEbooksConfig.h
@@ -34,6 +34,15 @@ constexpr char FOULAD_EBOOKS_URL[] = "http://midad.one/opds";
 // ("urn:midad:feed:<id>"), which is why extractFouladBookId checks the prefix.
 constexpr char FOULAD_EBOOKS_NEWS_URL[] = "http://midad.one/opds/news";
 
+// Downloaded news lives in its own folder rather than beside the books at the SD
+// root. It is not a book: it has no author, it is replaced wholesale every time you
+// open the feed, and finishing it is not finishing anything. Keeping it in one place
+// is what lets the home screen, My Books and the reading stats leave it alone
+// without having to guess from a filename.
+constexpr char FOULAD_NEWS_DIR[] = "/News";
+
+inline bool isNewsBookPath(const std::string_view path) { return path.rfind("/News/", 0) == 0; }
+
 // Font-conversion relay endpoint (Settings/File Transfer portal -> Fonts ->
 // Convert a Font): the device uploads a raw TTF/OTF plus a language choice,
 // foulad-ebooks converts it into the device's .cpfont SD-font format (4 sizes)

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1009,15 +1009,18 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   } else if (book.acquisitionType == "application/x-xtc") {
     extension = ".xtc";
   }
+  // News goes in its own folder; books stay at the root where they have always been.
+  const bool isNewsFeed = server.url == FOULAD_EBOOKS_NEWS_URL;
+  if (isNewsFeed) Storage.mkdir(FOULAD_NEWS_DIR);
   const std::string filename =
-      "/" + StringUtils::sanitizeFilename((book.author.empty() ? "" : book.author + " - ") + book.title) + extension;
+      (isNewsFeed ? std::string(FOULAD_NEWS_DIR) + "/" : std::string("/")) +
+      StringUtils::sanitizeFilename((book.author.empty() ? "" : book.author + " - ") + book.title) + extension;
 
   // News is never "already downloaded". Each download is the whole current feed
   // rather than a delta, and the filename is stable per feed, so the fast path below
   // would open yesterday's articles forever and the page would never refresh
   // (EINK_NEWS_TASKS.md §4: replace rather than accumulate). Remove first, because
   // the download writes to the same path.
-  const bool isNewsFeed = server.url == FOULAD_EBOOKS_NEWS_URL;
   if (isNewsFeed && Storage.exists(filename.c_str())) {
     Storage.remove(filename.c_str());
   }

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 
 #include "CrossPointSettings.h"
+#include "FouladEbooksConfig.h"
 #include "MappedInputManager.h"
 #include "QuranBook.h"
 #include "RecentBooksStore.h"
@@ -121,8 +122,11 @@ void RecentBooksActivity::loadRecentBooks() {
       if (entry.isDirectory()) {
         // XTCache is the STOCK Xteink firmware's cache tree -- 60+ nested dirs
         // of extracted chapter HTML on a card that dual-boots, with no books.
+        // /News holds downloaded feeds, which are reached from the News tile and are
+        // replaced wholesale on every open -- listing them here would put a headline
+        // among the books and leave yesterday's copy looking like one.
         if (strcmp(nameBuf, "System Volume Information") != 0 && strcmp(nameBuf, "fonts") != 0 &&
-            strcmp(nameBuf, "XTCache") != 0) {
+            strcmp(nameBuf, "XTCache") != 0 && entryPath != FOULAD_NEWS_DIR) {
           dirs.push_back(entryPath);
         }
         continue;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -219,14 +219,24 @@ void EpubReaderActivity::onEnter() {
   // Save current epub as last opened epub and add to recent books
   APP_STATE.openEpubPath = epub->getPath();
   APP_STATE.saveToFile();
-  RECENT_BOOKS.addBook(epub->getPath(), epub->getTitle(), epub->getAuthor(), epub->getThumbBmpPath());
+  // News is deliberately not a recent book. The home screen's hero card is the most
+  // recent entry, so a downloaded feed took over the "currently reading" slot with a
+  // progress bar and an estimated time left -- for something that is replaced whole
+  // the next time you open News. It is reached from its own tile, not from here.
+  const bool isNews = isNewsBookPath(epub->getPath());
+  if (!isNews) {
+    RECENT_BOOKS.addBook(epub->getPath(), epub->getTitle(), epub->getAuthor(), epub->getThumbBmpPath());
+  }
 
   loadCachedBookmarks();
 
   // Reading-time tracking: open a session in the day-level stats store and start
   // the first page's dwell timer. Time is credited per page turn; the session is
   // committed and saved in onExit().
-  if (SETTINGS.trackReadingStats) {
+  // Nor does it count as reading. EINK_NEWS_TASKS.md is explicit that finishing a
+  // feed is not finishing a book, and counting it would distort streaks and
+  // books-finished -- the same reason the server refuses a feed id for stats.
+  if (SETTINGS.trackReadingStats && !isNews) {
     READING_STATS.beginSession(epub->getPath(), epub->getTitle(), epub->getAuthor());
     // Capture the catalog id into the stats entry while RecentBooksStore still
     // holds it. That list caps at 10 and evicts, and the id used to live only


### PR DESCRIPTION
Reported with a photo of the home screen showing **"Midad News"** as the book being read — cover, progress bar, 9%, 1m read, ~4m left.

Downloaded feeds were landing at the SD root and going through the same path as any book: added to recents — which is where **both** the hero card and My Books come from — and opened as a reading session in the stats. So a feed took over "currently reading" and started accruing reading time, for a file that gets replaced wholesale the next time you open News.

### One marker, three places
News now downloads to **`/News`**, and the folder is the marker. `isNewsBookPath()` lives next to the endpoint it belongs to, so the three places that must leave news alone — recents, the stats session, and the My Books SD scan — all ask the same question instead of each guessing from a filename.

### Not counting it as reading is the server's own rule
`EINK_NEWS_TASKS.md` refuses a feed id for `/opds/reading-stats` because finishing "Example News" isn't finishing a book and would distort streaks and books-finished. The local stats had no such guard — they do now.

### Known limitation
Feeds downloaded **before** this stay at the SD root and keep behaving like books. There's no reliable way to identify them after the fact — a news EPUB has no author, and nothing else marks it. Removing it from My Books with a long press is enough; `pruneMissing()` drops the entry once the file is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)