### PR TITLE
fix: clear a feed's render cache when the feed is replaced

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1023,6 +1023,15 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // the download writes to the same path.
   if (isNewsFeed && Storage.exists(filename.c_str())) {
     Storage.remove(filename.c_str());
+    // And the cache with it. The cache directory is keyed on the FILE PATH
+    // (Epub.h: "epub_" + hash(filepath)) and is only validated against the cache
+    // format version -- never against the file's size or contents. A feed keeps the
+    // same path every time, so without this the reader would find yesterday's
+    // book.bin and rendered sections still valid and read the old articles out of
+    // cache, no matter how fresh the download was. Progress goes too, which is
+    // correct: page 4 of yesterday's articles means nothing in today's.
+    const std::string cacheDir = Epub(filename, "/.crosspoint").getCachePath();
+    if (Storage.exists(cacheDir.c_str())) Storage.removeDir(cacheDir.c_str());
   }
 
   if (!isNewsFeed && Storage.exists(filename.c_str())) {


### PR DESCRIPTION
Found while answering "how does news update, and is it the same book or a new one?" — the honest answer turned out to be *"the same book, and it would have shown you yesterday's articles."*

News re-downloads to the same path every time, deliberately: each download is the whole current feed, so replacing rather than accumulating is the point. But the reader's cache directory is keyed on the **file path** (`Epub.h`: `"epub_" + hash(filepath)`) and is validated only against the **cache format version** — never against the file's size or contents.

So a feed kept its cache across every refresh. The download was current, the `book.bin` and rendered sections were yesterday's, and the version check said they were fine. The reader would have served old articles out of cache from a file it had just replaced.

Same class of bug as the "already downloaded, open it directly" fast path already fixed for news — one layer further down. The file stopped being stale and the cache took over.

Progress goes with it, which is right: page 4 of yesterday's articles is not a position in today's.

**Books are untouched.** Their path only repeats when the same book is downloaded again, and then the cached render genuinely does match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)