### PR TITLE
fix: keep news off the sleep screen as well

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -17,6 +17,7 @@
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "CuratedAyahs.h"
+#include "FouladEbooksConfig.h"
 #include "QuranBook.h"
 #include "ReaderTitles.h"
 #include "RecentBooksStore.h"
@@ -351,7 +352,11 @@ void SleepActivity::renderCoverSleepScreen() const {
       break;
   }
 
-  if (APP_STATE.openEpubPath.empty()) {
+  // News is not the book you are reading, so it does not become the sleep screen
+  // either -- the same reason it is kept off the home screen and out of My Books.
+  // openEpubPath itself is left alone: it is what resumes the article you were on
+  // when the device wakes, which is still the right thing mid-session.
+  if (APP_STATE.openEpubPath.empty() || isNewsBookPath(APP_STATE.openEpubPath)) {
     return (this->*renderNoCoverSleepScreen)();
   }
 


### PR DESCRIPTION
Same objection as the home screen, one screen further on: doze off in a feed and the sleep screen shows it as the book you're reading, cover and progress included.

That was the last place a downloaded feed could present itself as a book — the hero card, My Books and the reading stats already leave it alone.

The sleep screen reads `APP_STATE.openEpubPath`, which is **deliberately left set** for news: it's what resumes the article you were on when the device wakes, and mid-session that's still right. Only the display is skipped, falling through to the same no-open-book screen the user already configured.

I checked the other consumers of `openEpubPath` while here — the reader resume, the silent-restart target, and the OPDS browser's hand-off. None of them present it as a book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)