### PR TITLE
feat: a navigation entry with cover art gets a grid cell

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -70,6 +70,17 @@ std::string extractFouladBookId(const std::string& entryId) {
   return tail;
 }
 
+// What earns a cell in the cover grid. Books always do. A navigation entry does when
+// it carries cover art -- a collection is a shelf with a picture on it, and rendering
+// it as a "> Summer reading" text row beside a grid of book covers would make the one
+// thing the user is meant to press look like the page furniture.
+//
+// Navigation entries WITHOUT art stay text rows on purpose: that is the Prev/Next page
+// strip and any plain category link, none of which are things to show a cell for.
+bool isGridItem(const OpdsEntry& entry) {
+  return entry.type == OpdsEntryType::BOOK || (entry.type == OpdsEntryType::NAVIGATION && !entry.coverUrl.empty());
+}
+
 int moveHorizontalInGrid(const int currentIndex, const int totalItems, const bool moveRight) {
   return GridNav::moveHorizontal(currentIndex, totalItems, moveRight);
 }
@@ -575,7 +586,7 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
         }
       }
       renderer.drawRect(cellX, cellY, layout.coverWidth, layout.coverHeight);
-      if (!drawn && server.url == FOULAD_EBOOKS_NEWS_URL) {
+      if (!drawn && (server.url == FOULAD_EBOOKS_NEWS_URL || entry.type == OpdsEntryType::NAVIGATION)) {
         // News entries carry no cover art -- there is no image link in the feed, so
         // nothing failed to download and nothing is going to appear later. The generic
         // book icon reads as a book that did not load; the feed's own name on a
@@ -668,7 +679,7 @@ OpdsBookBrowserActivity::GridLayout OpdsBookBrowserActivity::computeGridLayout()
   int firstBookIndex = -1;
   int lastBookIndex = -1;
   for (size_t i = 0; i < entries.size(); i++) {
-    if (entries[i].type == OpdsEntryType::BOOK) {
+    if (isGridItem(entries[i])) {
       if (firstBookIndex < 0) firstBookIndex = static_cast<int>(i);
       lastBookIndex = static_cast<int>(i);
     }
@@ -937,7 +948,7 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
     int firstBook = -1;
     int lastBook = -1;
     for (size_t i = 0; i < entries.size(); i++) {
-      if (entries[i].type == OpdsEntryType::BOOK) {
+      if (isGridItem(entries[i])) {
         if (firstBook < 0) firstBook = static_cast<int>(i);
         lastBook = static_cast<int>(i);
       }


### PR DESCRIPTION
Collections should appear as a tile of stacked covers that opens into its books. The books half already worked; the tile didn't — the cover grid only ever built itself out of `BOOK` entries.

A collection is a `NAVIGATION` entry, so a shelf with artwork rendered as `> Summer reading`: a text row indistinguishable from the Prev/Next page strip, for the one thing on the page the user is meant to press.

`isGridItem()` now decides — **books always, navigation entries when they carry cover art.**

Coverless navigation entries stay text rows deliberately: that's exactly what the synthetic Prev/Next rows are, and there's nothing else to tell them apart by. (So the server should always send an image link for a collection — noted back to foulad-ebooks.)

A grid cell whose art fails to download falls back to the **named tile** rather than the generic book icon, the same treatment news feeds get. A collection is either its stack or its name, never an anonymous placeholder.

### Verified
Against a synthetic collections feed served locally: two collections with composited 1-bit art render as tiles with titles beneath (Arabic shaped correctly), the coverless third stays a row, and the grid navigates and opens as before.

**Inert until the server ships it.** Collections carry no image links yet, and books are unaffected either way.

### One latent bug found, not fixed here
`OpdsCoverCache` passes `entry.coverUrl` to the downloader **unresolved**, so a *relative* `rel="image"` href never loads — it silently fails and you get the fallback tile. midad.one sends absolute cover URLs so nothing is affected today, and third-party OPDS servers can no longer be added from Settings, which is why I've left it. Worth knowing it's there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)