### PR TITLE
fix: stop the dithering path aborting on a failed allocation

### DIFF
--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <new>
 
 // ============================================================================
 // IMAGE PROCESSING OPTIONS
@@ -83,6 +84,8 @@ const char* Bitmap::errorToString(BmpReaderError err) {
 
     case BmpReaderError::OomRowBuffer:
       return "OomRowBuffer";
+    case BmpReaderError::OomDitherer:
+      return "OomDitherer";
     case BmpReaderError::ShortReadRow:
       return "ShortReadRow";
   }
@@ -174,10 +177,23 @@ BmpReaderError Bitmap::parseHeaders() {
   //  - High-color + dithering disabled → simple quantization (no error diffusion)
   const bool highColor = !nativePalette;
   if (highColor && dithering) {
+    // std::nothrow guards the outer allocation; ok() covers the ditherer's own internal
+    // buffer allocations (see BitmapHelpers.h) -- with -fno-exceptions a bare `new` that
+    // fails calls abort() instead of returning nullptr, so both must be checked.
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(width);
+      atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(width);
+      if (!atkinsonDitherer || !atkinsonDitherer->ok()) {
+        delete atkinsonDitherer;
+        atkinsonDitherer = nullptr;
+        return BmpReaderError::OomDitherer;
+      }
     } else {
-      fsDitherer = new FloydSteinbergDitherer(width);
+      fsDitherer = new (std::nothrow) FloydSteinbergDitherer(width);
+      if (!fsDitherer || !fsDitherer->ok()) {
+        delete fsDitherer;
+        fsDitherer = nullptr;
+        return BmpReaderError::OomDitherer;
+      }
     }
   }
 

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -58,6 +58,7 @@ enum class BmpReaderError : uint8_t {
   SeekPixelDataFailed,
   BufferTooSmall,
   OomRowBuffer,
+  OomDitherer,
   ShortReadRow,
 };
 

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <new>
 
 struct BmpHeader;
 
@@ -24,9 +25,9 @@ void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder ro
 class Atkinson1BitDitherer {
  public:
   explicit Atkinson1BitDitherer(int width) : width(width) {
-    errorRow0 = new int16_t[width + 4]();  // Current row
-    errorRow1 = new int16_t[width + 4]();  // Next row
-    errorRow2 = new int16_t[width + 4]();  // Row after next
+    errorRow0 = new (std::nothrow) int16_t[width + 4]();  // Current row
+    errorRow1 = new (std::nothrow) int16_t[width + 4]();  // Next row
+    errorRow2 = new (std::nothrow) int16_t[width + 4]();  // Row after next
   }
 
   ~Atkinson1BitDitherer() {
@@ -40,6 +41,10 @@ class Atkinson1BitDitherer {
 
   // EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR
   Atkinson1BitDitherer& operator=(const Atkinson1BitDitherer& other) = delete;
+
+  // False if any error-row buffer failed to allocate. Caller must check before calling
+  // processPixel()/nextRow()/reset() -- they dereference the buffers unconditionally.
+  bool ok() const { return errorRow0 && errorRow1 && errorRow2; }
 
   uint8_t processPixel(int gray, int x) {
     // Apply brightness/contrast/gamma adjustments
@@ -105,9 +110,9 @@ class Atkinson1BitDitherer {
 class AtkinsonDitherer {
  public:
   explicit AtkinsonDitherer(int width) : width(width) {
-    errorRow0 = new int16_t[width + 4]();  // Current row
-    errorRow1 = new int16_t[width + 4]();  // Next row
-    errorRow2 = new int16_t[width + 4]();  // Row after next
+    errorRow0 = new (std::nothrow) int16_t[width + 4]();  // Current row
+    errorRow1 = new (std::nothrow) int16_t[width + 4]();  // Next row
+    errorRow2 = new (std::nothrow) int16_t[width + 4]();  // Row after next
   }
 
   ~AtkinsonDitherer() {
@@ -120,6 +125,10 @@ class AtkinsonDitherer {
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
   AtkinsonDitherer& operator=(const AtkinsonDitherer& other) = delete;
+
+  // False if any error-row buffer failed to allocate. Caller must check before calling
+  // processPixel()/nextRow()/reset() -- they dereference the buffers unconditionally.
+  bool ok() const { return errorRow0 && errorRow1 && errorRow2; }
 
   uint8_t processPixel(int gray, int x) {
     // Add accumulated error
@@ -206,8 +215,8 @@ class AtkinsonDitherer {
 class FloydSteinbergDitherer {
  public:
   explicit FloydSteinbergDitherer(int width) : width(width), rowCount(0) {
-    errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
-    errorNextRow = new int16_t[width + 2]();
+    errorCurRow = new (std::nothrow) int16_t[width + 2]();  // +2 for boundary handling
+    errorNextRow = new (std::nothrow) int16_t[width + 2]();
   }
 
   ~FloydSteinbergDitherer() {
@@ -220,6 +229,10 @@ class FloydSteinbergDitherer {
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
   FloydSteinbergDitherer& operator=(const FloydSteinbergDitherer& other) = delete;
+
+  // False if either error-row buffer failed to allocate. Caller must check before calling
+  // processPixel()/nextRow() -- they dereference the buffers unconditionally.
+  bool ok() const { return errorCurRow && errorNextRow; }
 
   // Process a single pixel and return quantized 2-bit value
   // x is the logical x position (0 to width-1), direction handled internally

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -638,22 +638,26 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
     ctx.nextOutY_srcStart = scaleY_fp;
   }
 
+  // makeUniqueNoThrow only guards the outer allocation -- each ditherer's constructor makes
+  // its own nothrow-checked internal buffer allocations (see BitmapHelpers.h), so ok() must
+  // be checked too or a mid-construction OOM leaves a live object with null buffers that
+  // processPixel()/nextRow() would dereference unconditionally.
   if (oneBit) {
     ctx.atkinson1BitDitherer = makeUniqueNoThrow<Atkinson1BitDitherer>(outWidth);
-    if (!ctx.atkinson1BitDitherer) {
+    if (!ctx.atkinson1BitDitherer || !ctx.atkinson1BitDitherer->ok()) {
       LOG_ERR("JPG", "OOM: Atkinson1BitDitherer");
       return false;
     }
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
       ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth);
-      if (!ctx.atkinsonDitherer) {
+      if (!ctx.atkinsonDitherer || !ctx.atkinsonDitherer->ok()) {
         LOG_ERR("JPG", "OOM: AtkinsonDitherer");
         return false;
       }
     } else if (USE_FLOYD_STEINBERG) {
       ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth);
-      if (!ctx.fsDitherer) {
+      if (!ctx.fsDitherer || !ctx.fsDitherer->ok()) {
         LOG_ERR("JPG", "OOM: FloydSteinbergDitherer");
         return false;
       }

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <new>
 
 #include "BitmapHelpers.h"
 
@@ -691,18 +692,44 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
     return false;
   }
 
-  // Create ditherers (same as JpegToBmpConverter)
+  // Create ditherers (same as JpegToBmpConverter). Both the outer object and its internal
+  // error-row buffers (see BitmapHelpers.h) must be nothrow + null-checked: with
+  // -fno-exceptions a bare `new` that fails calls abort() instead of returning nullptr.
   AtkinsonDitherer* atkinsonDitherer = nullptr;
   FloydSteinbergDitherer* fsDitherer = nullptr;
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
 
   if (oneBit) {
-    atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
+    atkinson1BitDitherer = new (std::nothrow) Atkinson1BitDitherer(outWidth);
+    if (!atkinson1BitDitherer || !atkinson1BitDitherer->ok()) {
+      LOG_ERR("PNG", "OOM: Atkinson1BitDitherer");
+      delete atkinson1BitDitherer;
+      free(rowBuffer);
+      free(ctx.currentRow);
+      free(ctx.previousRow);
+      return false;
+    }
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth);
+      atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(outWidth);
+      if (!atkinsonDitherer || !atkinsonDitherer->ok()) {
+        LOG_ERR("PNG", "OOM: AtkinsonDitherer");
+        delete atkinsonDitherer;
+        free(rowBuffer);
+        free(ctx.currentRow);
+        free(ctx.previousRow);
+        return false;
+      }
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth);
+      fsDitherer = new (std::nothrow) FloydSteinbergDitherer(outWidth);
+      if (!fsDitherer || !fsDitherer->ok()) {
+        LOG_ERR("PNG", "OOM: FloydSteinbergDitherer");
+        delete fsDitherer;
+        free(rowBuffer);
+        free(ctx.currentRow);
+        free(ctx.previousRow);
+        return false;
+      }
     }
   }
 
@@ -713,8 +740,20 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   uint32_t nextOutY_srcStart = 0;
 
   if (needsScaling) {
-    rowAccum = new uint32_t[outWidth]();
-    rowCount = new uint16_t[outWidth]();
+    rowAccum = new (std::nothrow) uint32_t[outWidth]();
+    rowCount = new (std::nothrow) uint16_t[outWidth]();
+    if (!rowAccum || !rowCount) {
+      LOG_ERR("PNG", "OOM: scaling accumulators");
+      delete[] rowAccum;
+      delete[] rowCount;
+      delete atkinsonDitherer;
+      delete fsDitherer;
+      delete atkinson1BitDitherer;
+      free(rowBuffer);
+      free(ctx.currentRow);
+      free(ctx.previousRow);
+      return false;
+    }
     nextOutY_srcStart = scaleY_fp;
   }
 


### PR DESCRIPTION
foulad-ebooks, on the new collection cover tiles: `/opds/collections` fetches fine, several cover requests follow, then a panic with a blank reason and free heap bouncing 24-44KB. Blank is the signature of a raw `abort()` -- every other failure path in this codebase `LOG_ERR`s something into `panicMessage` first.

Root cause: `Atkinson1BitDitherer`, `AtkinsonDitherer`, and `FloydSteinbergDitherer` (`BitmapHelpers.h`) all allocate their error-row buffers with bare `new[]`. With `-fno-exceptions` a failed `new` calls `abort()` instead of returning `nullptr` -- so under exactly the heap pressure these logs show, dithering a cover tips into an unguarded allocation and the device just dies, silently.

`PngToBmpConverter.cpp`'s own outer ditherer allocations and its scaling accumulators (`rowAccum`/`rowCount`) had the same bug. `JpegToBmpConverter.cpp` and `Bitmap.cpp` already wrapped their outer allocation in `makeUniqueNoThrow` / `new(std::nothrow)`, but that only guards the outer object -- the ditherer constructors' internal buffers were still bare `new` underneath, so the existing guard didn't actually cover the crash.

Every allocation in this path now uses `std::nothrow`; each ditherer exposes `ok()` so a mid-construction OOM is caught before any dereference. All three call sites check it and fail cleanly (`LOG_ERR` + `return false` / `BmpReaderError::OomDitherer`) instead of aborting.

## Test plan
- [x] `gh_release_rc` and `simulator` both build clean
- [x] `cppcheck` reports no new findings
- [x] `clang-format` is a no-op
- [x] simulator boots to Home with no regressions
- [ ] hardware: reproduce the collections crash (#82) and confirm it now fails gracefully instead of panicking -- the simulator's flat 1MB heap can't reproduce the fragmentation that triggers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)