### PR TITLE
fix: move OPDS entries into the list instead of copying them

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -5,6 +5,7 @@
 #include <XmlParserUtils.h>
 
 #include <cstring>
+#include <utility>
 
 OpdsParser::OpdsParser() {
   parser = XML_ParserCreate(nullptr);
@@ -233,7 +234,24 @@ void XMLCALL OpdsParser::endElement(void* userData, const XML_Char* name) {
   if (strcmp(name, "entry") == 0 || strstr(name, ":entry") != nullptr) {
     if (!self->currentEntry.title.empty() && !self->currentEntry.href.empty()) {
       if (self->entries.size() < MAX_ENTRIES) {
-        self->entries.push_back(self->currentEntry);
+        // MOVED, not copied. Copying an OpdsEntry copy-constructs all seven of its
+        // std::string members, and every one of those that exceeds the small-string
+        // buffer calls the THROWING operator new -- which, with -fno-exceptions, aborts
+        // the device instead of failing. Three real crash reports (1.8.40, 1.8.41, 1.8.44)
+        // symbolicate to exactly this line, every one landing in
+        // construct_at<OpdsEntry, OpdsEntry CONST&> -> operator new -> bad_alloc ->
+        // std::terminate, on a heap the HTTP session had already taken down to ~30KB.
+        //
+        // Moving transfers the buffers the parser has already allocated instead of
+        // duplicating them, so an entry costs zero allocations to store and the peak
+        // never holds two copies of the same strings at once. That removes the failing
+        // call rather than trying to predict whether it would succeed -- which is what
+        // the reserve() heap floor below attempts, and why that alone did not fix this:
+        // it only guards the vector's own block, never the per-string copies.
+        //
+        // Safe because currentEntry is dead after this: the branch sets inEntry = false
+        // immediately below, and the next <entry> start assigns it a fresh OpdsEntry{}.
+        self->entries.push_back(std::move(self->currentEntry));
       } else {
         if (!self->truncated) {
           LOG_ERR("OPDS", "Feed has more than %u entries; truncating (server should paginate)",


### PR DESCRIPTION
Third crash report in a row (1.8.40, 1.8.41, now **1.8.44**) symbolicating to the same line — and the first two fixes did not touch what was actually failing. Being explicit about that, because it's the point of this one.

## What the stack actually says

```
OpdsParser::endElement:245
  -> std::construct_at<OpdsEntry, OpdsEntry const&>      <-- COPY constructor
  -> operator new -> bad_alloc -> std::terminate
```

That `const&` is the whole story. `entries.push_back(currentEntry)` **copy**-constructs all seven `std::string` members of the entry, and every one long enough to escape the small-string buffer calls the *throwing* global `operator new` — which, with `-fno-exceptions`, aborts the device rather than failing.

## Why the previous fix couldn't have worked

It pre-sized the vector's own contiguous block via `reserve()`. But the allocations that abort are the **per-string copies inside each entry**, which happen whether or not the block was pre-sized. Recalibrating that floor to 32KB didn't help either, and the logs show why — the `[HTTP] connected` lines during these fetches read **29–36KB free**, so the reserve was being skipped almost every time anyway.

## The fix

Move instead of copy. This removes the failing call rather than trying to predict whether it will succeed. The parser already allocated those string buffers while parsing the entry; handing them to the vector transfers ownership instead of duplicating them, so storing an entry costs **zero** allocations and the peak never holds two copies of the same strings.

That matters most exactly where it's been worst: an **Authors page of 50 entries** was doing ~350 small string allocations into an already-fragmented heap, which is why it failed far more reliably than a 10-entry Collections feed.

Safe because `currentEntry` is dead at that point — the branch sets `inEntry = false` immediately after, and the next `<entry>` start assigns it a fresh `OpdsEntry{}`. The handoff out of the parser (`getEntries() &&`) already moved; this closes the one copy left on the path.

## Test plan
- [x] `gh_release_rc` builds clean; `cppcheck` no defects; `clang-format` a no-op
- [ ] hardware: Collections and By Author browsing, repeatedly, under the same heap conditions the three crash reports show

## Not addressed here
The **slow selector** on collection grids is a separate problem with a separate cause: `OpdsBookBrowserActivity.cpp:582-596` re-opens and re-decodes *every* cover BMP from the SD card on every render, so moving the selector one cell costs N SD reads + N BMP decodes on top of the e-ink refresh. Fixing that means not redrawing unchanged covers when only the selection moved — deliberately kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)