### PR TITLE
chore: record what the firmware check actually saw

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -445,21 +445,48 @@ static std::string latestFirmwareOffer;
 // equal-numbered release lands -- exactly the case OtaUpdater's -rc rule exists for
 // (a device on 1.8.19-rc takes 1.8.19, since the rc tag is by then identical to what
 // it is already running).
+// Every outcome below is recorded to the SD debug log, not just the one that produces an
+// offer. From outside the device "the server named nothing" and "the server named a build
+// that is not newer than this one" are the same observation -- no popup -- but they are
+// completely different problems, and telling them apart is otherwise impossible after the
+// fact: the LOG_INF here reaches serial only, which nobody has attached while actually
+// using the device. A report that the Library update check "stopped working" is
+// unanswerable without this line.
 static void captureLatestFirmware(JsonVariantConst latest) {
   latestFirmwareOffer.clear();
-  if (latest.isNull()) return;  // older server, or GitHub was unreachable for it
 
-  const auto newerOrNull = [](JsonVariantConst v) -> const char* {
-    const char* tag = v.is<const char*>() ? v.as<const char*>() : nullptr;
+  const auto tagOf = [](JsonVariantConst v) -> const char* {
+    return v.is<const char*>() ? v.as<const char*>() : nullptr;
+  };
+  const auto orNone = [](const char* s) { return s ? s : "(none)"; };
+
+  if (latest.isNull()) {
+    // Older server, or a current one that could not reach GitHub. Absent means "no
+    // information", never "up to date".
+    diagLog(std::string("firmware check: server sent no latest_firmware (running ") + CROSSPOINT_VERSION + ")");
+    return;
+  }
+
+  const char* rcTag = tagOf(latest["rc"]);
+  const char* stableTag = tagOf(latest["stable"]);
+
+  const auto newerOrNull = [&tagOf](JsonVariantConst v) -> const char* {
+    const char* tag = tagOf(v);
     return OtaUpdater::isVersionNewer(tag) ? tag : nullptr;
   };
 
   const char* offer = nullptr;
   if (strstr(CROSSPOINT_VERSION, "-rc") != nullptr) offer = newerOrNull(latest["rc"]);
   if (offer == nullptr) offer = newerOrNull(latest["stable"]);
-  if (offer == nullptr) return;
+  if (offer == nullptr) {
+    diagLog(std::string("firmware check: rc=") + orNone(rcTag) + " stable=" + orNone(stableTag) +
+            " -- none newer than " + CROSSPOINT_VERSION);
+    return;
+  }
 
   latestFirmwareOffer = offer;
+  diagLog(std::string("firmware check: offering ") + offer + " (rc=" + orNone(rcTag) + " stable=" + orNone(stableTag) +
+          ", running " + CROSSPOINT_VERSION + ")");
   LOG_INF(TAG, "Server reports newer firmware: %s (running %s)", offer, CROSSPOINT_VERSION);
 }
 


### PR DESCRIPTION
The Library update offer was reported as no longer appearing. **Every part of the device-side path checks out**, so this adds the one piece of information that was missing rather than changing behaviour.

## What I verified first

- `maybeOfferFirmwareUpdate()` still runs each tick from `loop()`
- `registerDevice()` succeeds — the device's own debug log shows `[FDT] register serial=... -> ok`
- Its response is still parsed into `captureLatestFirmware(responseDoc["latest_firmware"])`
- Git history: nothing has touched this path since `a1a0edf7` introduced it
- **`a1a0edf7` is already in v1.8.28** — the public release runs the *same* implementation as current RCs, so the code did not regress between them

That leaves what the *server* reports for a given device, which nothing recorded.

## The gap

From outside the device these three are indistinguishable, and they are different problems:

- the server sent no `latest_firmware` at all
- it named a build that is not newer than the running one
- it named one and the offer was raised

All three produce the same observation: no popup. The only line distinguishing them was a `LOG_INF`, which reaches **serial** — and nobody has serial attached while actually using the device, which is exactly when this gets reported.

## Change

Each outcome now writes to the SD debug log, alongside the `rc`/`stable` tags the server named and the version running:

```
[FDT] firmware check: server sent no latest_firmware (running 1.8.47-rc+…)
[FDT] firmware check: rc=(none) stable=v1.8.28 -- none newer than 1.8.47-rc+…
[FDT] firmware check: offering v1.8.48-rc+… (rc=v1.8.48-rc+…, stable=v1.8.28, running 1.8.47-rc+…)
```

Diagnostic only — no behaviour change, and the offer logic itself is untouched.

## Test plan
- [x] `gh_release_rc` builds clean; `cppcheck` no defects; `clang-format` a no-op
- [ ] hardware: open Library, then send the debug log — the `firmware check:` line says which of the three cases is happening

🤖 Generated with [Claude Code](https://claude.com/claude-code)