### PR TITLE
feat: Phase 2.5 first-open speedups — image dims probe, CSS dedup, lazy image extraction

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,11 +90,21 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 37
+### Version 39
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Version 39 adds the book-internal source href to each serialized ImageBlock,
+written right after the cache path (lazy image extraction: section builds only
+header-probe images for dimensions, and the file is extracted from the EPUB on
+the page's first render).
+
+Version 38 is a pure cache-bust (no structural change from v37) for two
+upstream layout fixes (#2652, #2679): CJK `MAX_WORD_SIZE` continuation words no
+longer gain a false leading space, and bare text after a closing block tag no
+longer inherits the closed block's style.
 
 Version 37 adds an optional `kashidaExtraPx[wordCount]` array to TextBlock's
 arena (kashida/tatweel justification for Arabic body text): the extra width,

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -9,6 +9,9 @@
 #include <Utf8.h>
 #include <ZipFile.h>
 
+#include <algorithm>
+#include <unordered_map>
+
 #include "Epub/parsers/ContainerParser.h"
 #include "Epub/parsers/ContentOpfParser.h"
 #include "Epub/parsers/TocNavParser.h"
@@ -257,8 +260,44 @@ void Epub::parseCssFiles() const {
     return;
   }
 
+  // Some converters emit one byte-identical stylesheet per chapter (100+ .css
+  // entries), and each parse costs a zip locate plus an SD extract round-trip.
+  // Map every CSS path to its central-directory (CRC32, compressed size) in a
+  // single scan and parse only the first of each identical pair. Rules merge
+  // into one global set, so dropping exact duplicates cannot lose styles. A
+  // path that never matches a directory entry keeps key 0 and always parses.
+  std::vector<uint64_t> dedupKeys(cssFiles.size(), 0);
+  if (cssFiles.size() > 1) {
+    std::unordered_map<std::string, size_t> pathToIndex;
+    pathToIndex.reserve(cssFiles.size());
+    for (size_t i = 0; i < cssFiles.size(); i++) {
+      pathToIndex.emplace(FsHelpers::normalisePath(cssFiles[i]), i);
+    }
+    ZipFile(filepath).enumerateFileEntries([&](std::string_view entryPath, uint32_t crc32, uint32_t compressedSize) {
+      if (!FsHelpers::hasCssExtension(entryPath)) {
+        return;
+      }
+      const auto it = pathToIndex.find(std::string{entryPath});
+      if (it != pathToIndex.end()) {
+        dedupKeys[it->second] = (static_cast<uint64_t>(crc32) << 32) | compressedSize;
+      }
+    });
+  }
+  std::vector<uint64_t> seenKeys;
+  seenKeys.reserve(cssFiles.size());
+  size_t skippedDuplicates = 0;
+
   // No cache yet - parse CSS files
-  for (const auto& cssPath : cssFiles) {
+  for (size_t cssIndex = 0; cssIndex < cssFiles.size(); cssIndex++) {
+    const auto& cssPath = cssFiles[cssIndex];
+    const uint64_t dedupKey = dedupKeys[cssIndex];
+    if (dedupKey != 0) {
+      if (std::find(seenKeys.begin(), seenKeys.end(), dedupKey) != seenKeys.end()) {
+        skippedDuplicates++;
+        continue;
+      }
+      seenKeys.push_back(dedupKey);
+    }
     LOG_DBG("EBP", "Parsing CSS file: %s", cssPath.c_str());
 
     // Check heap before parsing - CSS parsing allocates heavily
@@ -313,7 +352,8 @@ void Epub::parseCssFiles() const {
     LOG_ERR("EBP", "Failed to save CSS rules to cache");
   }
 
-  LOG_DBG("EBP", "Loaded %zu CSS style rules from %zu files", cssParser->ruleCount(), cssFiles.size());
+  LOG_DBG("EBP", "Loaded %zu CSS style rules from %zu files (%zu identical duplicates skipped)", cssParser->ruleCount(),
+          cssFiles.size(), skippedDuplicates);
   cssParser->clear();
 }
 
@@ -766,14 +806,30 @@ uint8_t* Epub::readItemContentsToBytes(const std::string& itemHref, size_t* size
   return content;
 }
 
-bool Epub::readItemContentsToStream(const std::string& itemHref, Print& out, const size_t chunkSize) const {
+bool Epub::readItemContentsToStream(const std::string& itemHref, Print& out, const size_t chunkSize,
+                                    const bool allowEarlyStop) const {
   if (itemHref.empty()) {
     LOG_DBG("EBP", "Failed to read item, empty href");
     return false;
   }
 
   const std::string path = FsHelpers::normalisePath(itemHref);
-  return ZipFile(filepath).readFileToStream(path.c_str(), out, chunkSize);
+  return ZipFile(filepath).readFileToStream(path.c_str(), out, chunkSize, allowEarlyStop);
+}
+
+bool Epub::extractItemToFile(const std::string& itemHref, const std::string& destPath) const {
+  HalFile out;
+  if (!Storage.openFileForWrite("EBP", destPath, out)) {
+    return false;
+  }
+  const bool ok = readItemContentsToStream(itemHref, out, 4096);
+  out.flush();
+  // Explicit close: Storage.remove below acts on the same path.
+  out.close();
+  if (!ok) {
+    Storage.remove(destPath.c_str());
+  }
+  return ok;
 }
 
 bool Epub::getItemSize(const std::string& itemHref, size_t* size) const {

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -64,7 +64,10 @@ class Epub {
   std::string getExternalCoverPath(bool png) const;
   uint8_t* readItemContentsToBytes(const std::string& itemHref, size_t* size = nullptr,
                                    bool trailingNullByte = false) const;
-  bool readItemContentsToStream(const std::string& itemHref, Print& out, size_t chunkSize) const;
+  bool readItemContentsToStream(const std::string& itemHref, Print& out, size_t chunkSize,
+                                bool allowEarlyStop = false) const;
+  // Extract an item to a file on SD. On failure the partial file is removed.
+  bool extractItemToFile(const std::string& itemHref, const std::string& destPath) const;
   bool getItemSize(const std::string& itemHref, size_t* size) const;
   BookMetadataCache::SpineEntry getSpineItem(int spineIndex) const;
   BookMetadataCache::TocEntry getTocItem(int tocIndex) const;

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -72,7 +72,17 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  if (!ib) {
+    LOG_ERR("PGE", "Deserialization failed: null ImageBlock");
+    return nullptr;
+  }
+
+  auto* image = new (std::nothrow) PageImage(std::move(ib), xPos, yPos);
+  if (!image) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageImage");
+    return nullptr;
+  }
+  return std::unique_ptr<PageImage>(image);
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -37,7 +37,10 @@ namespace {
 // continuation word so it doesn't get a false leading space, and closing a block
 // tag now starts a fresh text block instead of letting bare text after it inherit
 // the closed block's style (alignment/margins). Both change layout output.
-constexpr uint8_t SECTION_FILE_VERSION = 38;
+// v39: ImageBlock serializes the book-internal source href after the cache path
+// (lazy extraction: images are header-probed at build time and extracted on
+// first render).
+constexpr uint8_t SECTION_FILE_VERSION = 39;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -6,6 +6,8 @@
 #include <Memory.h>
 #include <Serialization.h>
 
+#include <new>
+
 #include "Epub/converters/DirectPixelWriter.h"
 #include "Epub/converters/ImageDecoderFactory.h"
 
@@ -14,8 +16,16 @@
 // - uint16_t height
 // - uint8_t pixels[...] - 2 bits per pixel, packed (4 pixels per byte), row-major order
 
-ImageBlock::ImageBlock(const std::string& imagePath, int16_t width, int16_t height)
-    : imagePath(imagePath), width(width), height(height) {}
+ImageBlock::ImageBlock(const std::string& imagePath, const std::string& srcPath, int16_t width, int16_t height)
+    : imagePath(imagePath), srcPath(srcPath), width(width), height(height) {}
+
+void* ImageBlock::extractCtx = nullptr;
+ImageBlock::ExtractFn ImageBlock::extractFn = nullptr;
+
+void ImageBlock::setExtractor(void* ctx, ExtractFn fn) {
+  extractCtx = ctx;
+  extractFn = fn;
+}
 
 bool ImageBlock::imageExists() const { return Storage.exists(imagePath.c_str()); }
 
@@ -205,6 +215,15 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
     return;  // Successfully rendered from cache
   }
 
+  // The build only header-probed the image for dimensions; pull the actual
+  // file out of the book now, on first visit to the page.
+  if (!srcPath.empty() && extractFn && !Storage.exists(imagePath.c_str())) {
+    LOG_DBG("IMG", "Lazy-extracting %s -> %s", srcPath.c_str(), imagePath.c_str());
+    if (!extractFn(extractCtx, srcPath.c_str(), imagePath.c_str())) {
+      LOG_ERR("IMG", "Lazy extraction failed: %s", srcPath.c_str());
+    }
+  }
+
   // No cache - need to decode the image
   // Check if image file exists
   HalFile file;
@@ -256,6 +275,7 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
 
 bool ImageBlock::serialize(HalFile& file) {
   serialization::writeString(file, imagePath);
+  serialization::writeString(file, srcPath);
   serialization::writePod(file, width);
   serialization::writePod(file, height);
   return true;
@@ -263,9 +283,11 @@ bool ImageBlock::serialize(HalFile& file) {
 
 std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile& file) {
   std::string path;
+  std::string src;
   serialization::readString(file, path);
+  serialization::readString(file, src);
   int16_t w, h;
   serialization::readPod(file, w);
   serialization::readPod(file, h);
-  return std::unique_ptr<ImageBlock>(new ImageBlock(path, w, h));
+  return std::unique_ptr<ImageBlock>(new (std::nothrow) ImageBlock(path, src, w, h));
 }

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -8,7 +8,7 @@
 
 class ImageBlock final : public Block {
  public:
-  ImageBlock(const std::string& imagePath, int16_t width, int16_t height);
+  ImageBlock(const std::string& imagePath, const std::string& srcPath, int16_t width, int16_t height);
   ~ImageBlock() override = default;
 
   const std::string& getImagePath() const { return imagePath; }
@@ -16,6 +16,14 @@ class ImageBlock final : public Block {
   int16_t getHeight() const { return height; }
 
   bool imageExists() const;
+
+  // Lazy extraction hook: the section build only header-probes images for their
+  // dimensions; the file at imagePath is extracted out of the book on first
+  // render, via this callback (function pointer + context, not std::function —
+  // this is render-loop code). Registered by the reader activity that owns the
+  // Epub, cleared on its exit and on any early epub release.
+  using ExtractFn = bool (*)(void* ctx, const char* srcPath, const char* destPath);
+  static void setExtractor(void* ctx, ExtractFn fn);
 
   BlockType getType() override { return IMAGE_BLOCK; }
   bool isEmpty() override { return false; }
@@ -26,8 +34,12 @@ class ImageBlock final : public Block {
 
  private:
   std::string imagePath;
+  std::string srcPath;  // book-internal source href; empty for pre-lazy-extraction cache files
   int16_t width;
   int16_t height;
+
+  static void* extractCtx;
+  static ExtractFn extractFn;
 
   // Transient RAM copy of the 2bpp .pxc cache for this page view. A displayed
   // image page is re-rendered ~13x (BW pass + ~6 strip bands x 2 grayscale

--- a/lib/Epub/Epub/converters/ImageDimsProbe.cpp
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.cpp
@@ -1,0 +1,144 @@
+#include "ImageDimsProbe.h"
+
+#include <cstdint>
+
+namespace {
+// SOFn markers carry the frame dimensions. C4 (DHT), C8 (JPG extension) and
+// CC (DAC) share the 0xCn range but are not frame headers.
+bool isJpegSof(const uint8_t marker) {
+  return marker >= 0xC0 && marker <= 0xCF && marker != 0xC4 && marker != 0xC8 && marker != 0xCC;
+}
+constexpr uint8_t PNG_SIG[8] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+}  // namespace
+
+bool ImageDimsProbe::feed(const uint8_t b) {
+  switch (state) {
+    case State::Sniff:
+      if (b == 0xFF) {
+        state = State::JpegSoi;
+      } else if (b == PNG_SIG[0]) {
+        state = State::PngHeader;
+      } else {
+        state = State::Failed;
+        return false;
+      }
+      pos = 1;
+      return true;
+
+    case State::PngHeader:
+      // Bytes 1..7: signature; 8..11: IHDR length; 12..15: "IHDR"; 16..23: dims.
+      if (pos < 8) {
+        if (b != PNG_SIG[pos]) {
+          state = State::Failed;
+          return false;
+        }
+      } else if (pos >= 12 && pos < 16) {
+        if (b != "IHDR"[pos - 12]) {
+          state = State::Failed;
+          return false;
+        }
+      } else if (pos >= 16 && pos < 20) {
+        width = (width << 8) | b;
+      } else if (pos >= 20 && pos < 24) {
+        height = (height << 8) | b;
+        if (pos == 23) {
+          state = State::Done;
+          pos++;
+          return false;
+        }
+      }
+      pos++;
+      return true;
+
+    case State::JpegSoi:
+      if (b != 0xD8) {
+        state = State::Failed;
+        return false;
+      }
+      state = State::JpegFf;
+      return true;
+
+    case State::JpegFf:
+      if (b != 0xFF) {
+        state = State::Failed;
+        return false;
+      }
+      state = State::JpegMarker;
+      return true;
+
+    case State::JpegMarker:
+      if (b == 0xFF) return true;  // fill bytes before a marker are legal
+      if (b == 0x01 || (b >= 0xD0 && b <= 0xD8)) {
+        // TEM / RSTn / SOI: standalone, no length field.
+        state = State::JpegFf;
+        return true;
+      }
+      if (b == 0xD9 || b == 0xDA) {
+        // EOI or SOS before any SOF: no dimensions to be found.
+        state = State::Failed;
+        return false;
+      }
+      sofPending = isJpegSof(b);
+      state = State::JpegLenHi;
+      return true;
+
+    case State::JpegLenHi:
+      segLen = static_cast<uint16_t>(b << 8);
+      state = State::JpegLenLo;
+      return true;
+
+    case State::JpegLenLo:
+      segLen = static_cast<uint16_t>(segLen | b);
+      if (segLen < 2 || (sofPending && segLen < 7)) {
+        state = State::Failed;
+        return false;
+      }
+      if (sofPending) {
+        sofFill = 0;
+        state = State::JpegSof;
+      } else if (segLen == 2) {
+        state = State::JpegFf;
+      } else {
+        skipLeft = static_cast<uint32_t>(segLen) - 2;
+        state = State::JpegSkip;
+      }
+      return true;
+
+    case State::JpegSkip:
+      if (--skipLeft == 0) state = State::JpegFf;
+      return true;
+
+    case State::JpegSof:
+      sofBuf[sofFill++] = b;
+      if (sofFill == 5) {
+        height = static_cast<uint32_t>((sofBuf[1] << 8) | sofBuf[2]);
+        width = static_cast<uint32_t>((sofBuf[3] << 8) | sofBuf[4]);
+        state = State::Done;
+        return false;
+      }
+      return true;
+
+    case State::Done:
+    case State::Failed:
+      return false;
+  }
+  return false;
+}
+
+size_t ImageDimsProbe::write(const uint8_t b) { return feed(b) ? 1 : 0; }
+
+size_t ImageDimsProbe::write(const uint8_t* data, const size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    if (!feed(data[i])) return i;  // short write: polite early stop
+  }
+  return len;
+}
+
+bool ImageDimsProbe::getDimensions(ImageDimensions& out) const {
+  if (state != State::Done || width == 0 || height == 0 || width > INT16_MAX || height > INT16_MAX) {
+    return false;
+  }
+  out.width = static_cast<int16_t>(width);
+  out.height = static_cast<int16_t>(height);
+  return true;
+}

--- a/lib/Epub/Epub/converters/ImageDimsProbe.h
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <Print.h>
+
+#include "ImageToFramebufferDecoder.h"
+
+// Streaming JPEG/PNG header parser: finds image dimensions from the first few
+// KB of a compressed stream without inflating the whole image. Feed bytes via
+// the Print interface (e.g. Epub::readItemContentsToStream with
+// allowEarlyStop=true); write() returns short once the dimensions are known or
+// the stream is known to be unusable, which the zip layer treats as a polite
+// early stop rather than an error.
+//
+// JPEG: walks marker segments (skipping EXIF/APPn of any size statefully, so
+// nothing is buffered) until a SOFn frame header yields the dimensions.
+// PNG: reads the IHDR fields at their fixed offsets (bytes 16..23).
+class ImageDimsProbe : public Print {
+ public:
+  size_t write(uint8_t b) override;
+  size_t write(const uint8_t* data, size_t len) override;
+
+  // True only when a valid header was found; fills `out`.
+  bool getDimensions(ImageDimensions& out) const;
+
+ private:
+  bool feed(uint8_t b);  // returns false once parsing is finished (found or failed)
+
+  enum class State : uint8_t {
+    Sniff,       // first byte decides the format
+    PngHeader,   // PNG signature + IHDR at fixed offsets
+    JpegSoi,     // second SOI byte (0xD8)
+    JpegFf,      // expect a 0xFF marker prefix
+    JpegMarker,  // marker type byte (0xFF padding allowed)
+    JpegLenHi,   // segment length, high byte
+    JpegLenLo,   // segment length, low byte
+    JpegSkip,    // skipping a non-SOF segment body
+    JpegSof,     // collecting the 5 SOF bytes: precision, height(2), width(2)
+    Done,
+    Failed,
+  };
+  State state = State::Sniff;
+  uint32_t pos = 0;       // absolute stream offset (PNG fixed-offset parsing)
+  uint32_t skipLeft = 0;  // remaining segment bytes to skip
+  uint16_t segLen = 0;
+  bool sofPending = false;  // current segment is a SOF frame header
+  uint8_t sofBuf[5] = {0};
+  uint8_t sofFill = 0;
+  // 32-bit: PNG IHDR width/height are 4-byte fields. Accumulating them in a
+  // uint16_t silently truncates an oversized image to a plausible small value
+  // that passes the INT16_MAX sanity check in getDimensions().
+  uint32_t width = 0;
+  uint32_t height = 0;
+};

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -16,6 +16,7 @@
 #include "Epub.h"
 #include "Epub/Page.h"
 #include "Epub/converters/ImageDecoderFactory.h"
+#include "Epub/converters/ImageDimsProbe.h"
 #include "Epub/converters/ImageToFramebufferDecoder.h"
 #include "Epub/htmlEntities.h"
 
@@ -555,28 +556,47 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
             }
             std::string cachedImagePath = self->imageBasePath + std::to_string(self->imageCounter++) + ext;
 
-            // Extract image to cache file
-            HalFile cachedImageFile;
-            bool extractSuccess = false;
-            if (Storage.openFileForWrite("EHP", cachedImagePath, cachedImageFile)) {
-              extractSuccess = self->epub->readItemContentsToStream(resolvedPath, cachedImageFile, 4096);
-              cachedImageFile.flush();
-              cachedImageFile.close();
-            }
-
-            if (extractSuccess) {
-              // Get image dimensions, retrying to absorb SD-card sync latency on slow
-              // cards. Replaces a blanket delay(50) that cost ~50ms on every image, and
-              // closes the silent-drop bug where a single getDimensions failure was fatal.
+            {
+              // Probe the dimensions from the entry's first bytes (early-aborted
+              // inflate, a few KB) instead of extracting the whole image now —
+              // extraction is deferred to the first render of the page (see
+              // ImageBlock's lazy extractor). This is what keeps first-open of an
+              // image-heavy chapter from stalling for seconds per image.
               ImageDimensions dims = {0, 0};
-              ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(cachedImagePath);
-              bool gotDimensions = false;
-              for (int attempt = 0; attempt < 3 && !gotDimensions; attempt++) {
-                if (attempt > 0) {
-                  delay(50);  // Give a slow SD card time to finish syncing before retrying
+              ImageDimsProbe headerProbe;
+              self->epub->readItemContentsToStream(resolvedPath, headerProbe, 1024, /*allowEarlyStop=*/true);
+              bool gotDimensions = headerProbe.getDimensions(dims);
+
+              if (!gotDimensions) {
+                // No header within the stream (rare) — fall back to extracting the
+                // whole image and probing the file. That can take seconds, so
+                // surface the indexing popup first (single-shot per parser).
+                if (self->popupFn && !self->imagePopupFired) {
+                  self->imagePopupFired = true;
+                  self->popupFn();
                 }
-                gotDimensions = decoder && decoder->getDimensions(cachedImagePath, dims);
+                HalFile cachedImageFile;
+                bool extractSuccess = false;
+                if (Storage.openFileForWrite("EHP", cachedImagePath, cachedImageFile)) {
+                  extractSuccess = self->epub->readItemContentsToStream(resolvedPath, cachedImageFile, 4096);
+                  cachedImageFile.flush();
+                  cachedImageFile.close();
+                }
+                if (extractSuccess) {
+                  // Retry to absorb SD-card sync latency on slow cards, and to close
+                  // the silent-drop bug where a single getDimensions failure was fatal.
+                  ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(cachedImagePath);
+                  for (int attempt = 0; attempt < 3 && !gotDimensions; attempt++) {
+                    if (attempt > 0) {
+                      delay(50);  // Give a slow SD card time to finish syncing before retrying
+                    }
+                    gotDimensions = decoder && decoder->getDimensions(cachedImagePath, dims);
+                  }
+                } else {
+                  LOG_ERR("EHP", "Failed to extract image");
+                }
               }
+
               if (gotDimensions) {
                 LOG_DBG("EHP", "Image dimensions: %dx%d", dims.width, dims.height);
 
@@ -723,13 +743,18 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 self->currentPageNextY += imageMarginTop;
 
                 // Create ImageBlock and add to page
-                auto imageBlock = std::make_shared<ImageBlock>(cachedImagePath, displayWidth, displayHeight);
+                // nothrow: make_shared uses bare new, which aborts on OOM under
+                // -fno-exceptions; images arrive mid-parse when the heap is at its
+                // most loaded, so this must fail soft into the null-check below.
+                auto imageBlock = std::shared_ptr<ImageBlock>(
+                    new (std::nothrow) ImageBlock(cachedImagePath, resolvedPath, displayWidth, displayHeight));
                 if (!imageBlock) {
                   LOG_ERR("EHP", "Failed to create ImageBlock");
                   return;
                 }
                 int xPos = (self->viewportWidth - displayWidth) / 2;
-                auto pageImage = std::make_shared<PageImage>(imageBlock, xPos, self->currentPageNextY);
+                auto pageImage =
+                    std::shared_ptr<PageImage>(new (std::nothrow) PageImage(imageBlock, xPos, self->currentPageNextY));
                 if (!pageImage) {
                   LOG_ERR("EHP", "Failed to create PageImage");
                   return;
@@ -752,10 +777,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 return;
               } else {
                 LOG_ERR("EHP", "Failed to get image dimensions");
+                // Only the fallback path extracts a file; harmless when the probe failed dry.
                 Storage.remove(cachedImagePath.c_str());
               }
-            } else {
-              LOG_ERR("EHP", "Failed to extract image");
             }
           }  // isFormatSupported
         }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -28,6 +28,7 @@ class ChapterHtmlSlimParser {
   GfxRenderer& renderer;
   std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn;
   std::function<void()> popupFn;  // Popup callback
+  bool imagePopupFired = false;   // popupFn fired for the first image probe fallback (single-shot)
   int depth = 0;
   int skipUntilDepth = INT_MAX;
   int boldUntilDepth = INT_MAX;

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -438,7 +438,7 @@ uint8_t* ZipFile::readFileToMemory(const char* filename, size_t* size, const boo
   return data;
 }
 
-bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t chunkSize) {
+bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t chunkSize, const bool allowEarlyStop) {
   const ScopedOpenClose zip{*this};
   if (!zip) return false;
 
@@ -470,8 +470,9 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
       }
 
       if (out.write(buffer, dataRead) != dataRead) {
-        LOG_ERR("ZIP", "Failed to write all output bytes to stream");
         free(buffer);
+        if (allowEarlyStop) return true;  // sink has what it needs
+        LOG_ERR("ZIP", "Failed to write all output bytes to stream");
         return false;
       }
       remaining -= dataRead;
@@ -525,7 +526,11 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
 
       if (produced > 0) {
         if (out.write(outputBuffer, produced) != produced) {
-          LOG_ERR("ZIP", "Failed to write all output bytes to stream");
+          if (allowEarlyStop) {
+            success = true;  // sink has what it needs
+          } else {
+            LOG_ERR("ZIP", "Failed to write all output bytes to stream");
+          }
           break;
         }
       }

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -69,7 +69,10 @@ class ZipFile {
   // Due to the memory required to run each of these, it is recommended to not preopen the zip file for multiple
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
-  bool readFileToStream(const char* filename, Print& out, size_t chunkSize);
+  // allowEarlyStop: a short write from `out` is treated as the sink asking to
+  // stop (returns true) instead of a write failure — used by header probes
+  // that only need the first bytes of an entry.
+  bool readFileToStream(const char* filename, Print& out, size_t chunkSize, bool allowEarlyStop = false);
 
   template <typename F>
   bool enumerateFilePaths(F&& callback) {
@@ -80,6 +83,14 @@ class ZipFile {
       return true;
     }
 
+    return enumerateFileEntries([&callback](std::string_view path, uint32_t, uint32_t) { callback(path); });
+  }
+
+  // Callback receives (path, crc32, compressedSize) for each central-directory
+  // entry. Always scans the central directory: the slim-stat cache does not
+  // hold CRCs.
+  template <typename F>
+  bool enumerateFileEntries(F&& callback) {
     const bool wasOpen = isOpen();
     if (!wasOpen && !open()) {
       return false;
@@ -103,7 +114,11 @@ class ZipFile {
         break;
       }
 
-      file.seekCur(24);
+      file.seekCur(12);
+      uint32_t crc32, compressedSize;
+      file.read(&crc32, 4);
+      file.read(&compressedSize, 4);
+      file.seekCur(4);
       uint16_t nameLen, m, k;
       file.read(&nameLen, 2);
       file.read(&m, 2);
@@ -113,7 +128,7 @@ class ZipFile {
       if (nameLen < sizeof(itemName)) {
         file.read(itemName, nameLen);
         itemName[nameLen] = '\0';
-        callback(std::string_view{itemName, nameLen});
+        callback(std::string_view{itemName, nameLen}, crc32, compressedSize);
       } else {
         file.seekCur(nameLen);
       }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1,6 +1,7 @@
 #include "EpubReaderActivity.h"
 
 #include <Epub/Page.h>
+#include <Epub/blocks/ImageBlock.h>
 #include <Epub/blocks/TextBlock.h>
 #include <FontCacheManager.h>
 #include <FontDecompressor.h>
@@ -177,6 +178,12 @@ void EpubReaderActivity::onEnter() {
 
   epub->setupCacheDir();
 
+  // Lazy image extraction: section builds only header-probe images, so the first
+  // render of an image page pulls the file out of the EPUB through this hook.
+  ImageBlock::setExtractor(epub.get(), [](void* ctx, const char* src, const char* dest) {
+    return static_cast<Epub*>(ctx)->extractItemToFile(src, dest);
+  });
+
   // Per-book reading overrides: load this book's sidecar into SETTINGS.book*
   // (cleared again in onExit). ReaderActivity already ensured the GLOBAL fonts,
   // so the font systems only need a second pass when this book overrides them.
@@ -291,6 +298,10 @@ void EpubReaderActivity::onExit() {
   // the per-book settings write -- leaving no way to tell which side of it died.
   LOG_INF("ERS", "Reader exit: begin");
   Activity::onExit();
+
+  // The extractor holds a raw pointer to this activity's epub; drop it before
+  // the activity (and the shared_ptr) goes away.
+  ImageBlock::setExtractor(nullptr, nullptr);
 
   // Reset orientation back to portrait for the rest of the UI
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
@@ -466,6 +477,18 @@ unsigned cpuMhzNow() {
 }
 }  // namespace
 
+void EpubReaderActivity::showBuildPopup() {
+  // Mid-build indexing popup: only during render()'s blocking build-to-target
+  // phase (buildPopupPending), at most once. The parser's popup callback lives
+  // as long as the build and keeps firing from background buildSomeMore ticks;
+  // without this gate it would draw the popup over an already-displayed page.
+  if (!buildPopupPending) return;
+  GUI.drawPopup(renderer, tr(STR_INDEXING));
+  // HALF-clear the popup when the page replaces it, else "INDEXING" ghosts.
+  pagesUntilFullRefresh = 1;
+  buildPopupPending = false;
+}
+
 void EpubReaderActivity::loop() {
   // Deferred cross-device jump (see onEnter). Runs once, on the first iteration
   // after the activity is fully up and the render task is serving it.
@@ -566,6 +589,44 @@ void EpubReaderActivity::loop() {
           // The chapter re-paginated since the saved progress (settings changed): we now know the
           // real page count, so re-render at the remapped page. No-op for an unchanged resume.
           requestUpdate();
+        }
+      }
+    }
+
+    // Idle glyph prewarm for the likely next page (currentPage + 1). The scan
+    // pass draws nothing (FCM scan mode suppresses text pixels and ImageBlock
+    // skips itself while scanning), so the displayed framebuffer is untouched;
+    // endScanAndPrewarm loads only glyphs not already cached. Debounced past
+    // rapid page-flipping, one attempt per position, and deferred while a
+    // render/build owns the CPU or the heap is near the render floors.
+    // Cross-chapter prewarm is deliberately out of scope (the next spine's
+    // section isn't loaded). Mutually exclusive with the build tick above:
+    // this only runs once the section has finished building.
+    constexpr unsigned long IDLE_PREWARM_DEBOUNCE_MS = 400;
+    if (section && !section->isBuilding() && !RenderLock::peek() && lastRenderCompleteMs != 0 &&
+        millis() - lastRenderCompleteMs > IDLE_PREWARM_DEBOUNCE_MS && ESP.getFreeHeap() > RENDER_MIN_FREE_HEAP &&
+        ESP.getMaxAllocHeap() > RENDER_MIN_LARGEST_BLOCK &&
+        (idlePrewarmSpine != currentSpineIndex || idlePrewarmPage != section->currentPage)) {
+      RenderLock lock;  // the page table must not change under the scan
+      // Re-check under the lock: peek() and acquisition are not atomic, so the render
+      // task may have reset/replaced the section or moved the page in between. cppcheck
+      // can't see the cross-task mutation, so it flags this as always true.
+      // cppcheck-suppress knownConditionTrueFalse
+      if (section && !section->isBuilding() &&
+          (idlePrewarmSpine != currentSpineIndex || idlePrewarmPage != section->currentPage)) {
+        idlePrewarmSpine = currentSpineIndex;
+        idlePrewarmPage = section->currentPage;
+        const int nextPage = section->currentPage + 1;
+        if (nextPage < static_cast<int>(section->pageCount)) {
+          if (const auto p = section->loadPage(nextPage)) {
+            if (auto* fcm = renderer.getFontCacheManager()) {
+              const auto t0 = millis();
+              auto scope = fcm->createPrewarmScope();
+              p->render(renderer, SETTINGS.getReaderFontId(), 0, 0);  // scan only, no pixels
+              scope.endScanAndPrewarm();
+              LOG_DBG("ERS", "Idle prewarm: page %d in %lums", nextPage, millis() - t0);
+            }
+          }
         }
       }
     }
@@ -1203,6 +1264,10 @@ void EpubReaderActivity::launchMidadSync() {
     if (section) {
       nextPageNumber = section->currentPage;
     }
+    // The image extractor holds a raw pointer into this epub (see onEnter);
+    // clear it before the early release, mirroring onExit(), or a later image
+    // render would call through a dangling context.
+    ImageBlock::setExtractor(nullptr, nullptr);
     section.reset();
     epub.reset();
   }
@@ -1250,6 +1315,9 @@ bool EpubReaderActivity::launchKOReaderSync() {
     if (section) {
       nextPageNumber = section->currentPage;
     }
+    // Same dangling-context hazard as the Midad release: the extractor points
+    // into the epub being freed here.
+    ImageBlock::setExtractor(nullptr, nullptr);
     section.reset();
     epub.reset();
   }
@@ -1657,12 +1725,20 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           // HALF-clear the popup when the page replaces it, else "INDEXING" ghosts under the page.
           pagesUntilFullRefresh = 1;
         }
+        // Mid-build popup surfacing for slow builds the predictive gates can't
+        // see (a whole-image extraction fallback inside a single page, or any
+        // chunk overrunning the deadline). The parser fires the callback before
+        // a slow image fallback; buildPopupPending gates it to this blocking
+        // phase so a background build in loop() can never draw over a page.
+        buildPopupPending = !showPopup;
+        const unsigned long buildStartMs = millis();
         if (!section->startBuild(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                  SETTINGS.extraParagraphSpacing, SETTINGS.effParagraphAlignment(), viewportWidth,
                                  viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                 SETTINGS.imageRendering, SETTINGS.focusReadingEnabled)) {
+                                 SETTINGS.imageRendering, SETTINGS.focusReadingEnabled, [this] { showBuildPopup(); })) {
           LOG_ERR("ERS", "Failed to start section build");
           section.reset();
+          buildPopupPending = false;
           showBuildError();
           return;
         }
@@ -1671,13 +1747,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           // Anchor jump: build until the anchor's page is laid out (usually page 0), checking a
           // partial's on-disk anchor map too so an already-indexed anchor resolves immediately.
           // Otherwise: build until the target page exists. loop() builds the rest behind it.
+          if (buildPopupPending && millis() - buildStartMs >= BUILD_POPUP_DEADLINE_MS) {
+            // The predictive gates guessed fast but the build blew the silent budget.
+            showBuildPopup();
+          }
           if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
             LOG_ERR("ERS", "Failed during incremental section build");
             section.reset();
+            buildPopupPending = false;
             showBuildError();
             return;
           }
         }
+        buildPopupPending = false;
       }
     } else {
       LOG_DBG("ERS", "Cache found, skipping build...");
@@ -1887,6 +1969,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     const auto start = millis();
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
+    lastRenderCompleteMs = millis();
   }
   // Only persist when the position actually changed. render() also runs on menu,
   // bookmark and screenshot re-renders, and writeAtomic is several FAT ops for 6 bytes.

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -52,6 +52,13 @@ class EpubReaderActivity final : public Activity {
   bool showBookmarkMessage = false;
   bool ignoreNextConfirmRelease = false;
   bool currentPageBookmarked = false;
+  // Idle-time glyph prewarm: after a page settles, scan the LIKELY next page
+  // (scan mode draws nothing) and load its missing glyphs from SD during idle,
+  // so the next turn's in-render prewarm is a cache hit instead of ~100 ms of
+  // SD reads on the page-turn critical path. One attempt per position.
+  int idlePrewarmSpine = -1;
+  int idlePrewarmPage = -1;
+  unsigned long lastRenderCompleteMs = 0;
   bool bookmarkRemoved = false;  // true when last toggle removed (controls popup text)
   std::vector<BookmarkEntry> cachedBookmarks;
   // Tracks whether this book is currently removed from Recent Books by the
@@ -128,6 +135,23 @@ class EpubReaderActivity final : public Activity {
   // whole HTML must be inflated before page 1 can lay out (the giant single-spine case), which is
   // a multi-second wait. Normal chapters are well under this and stay popup-free.
   static constexpr size_t BUILD_POPUP_BYTE_THRESHOLD = 96 * 1024;
+  // Deadline backstop for the predictive gates above: if the blocking build-to-target still
+  // hasn't produced the landing page this long after the build started, surface the popup
+  // mid-build. Builds that finish under the deadline stay popup-free.
+  static constexpr unsigned long BUILD_POPUP_DEADLINE_MS = 1000;
+  // True only during render()'s blocking build-to-target phase, until the popup has been
+  // drawn. Gates showBuildPopup() so the parser's popup callback (which persists into
+  // background buildSomeMore ticks) can never draw over a displayed page.
+  bool buildPopupPending = false;
+  // Draw the indexing popup mid-build (parser image-probe callback and deadline backstop).
+  void showBuildPopup();
+  // Heap floors for optional render-adjacent work (idle prewarm). Page
+  // deserialization (TextBlock word arenas/strings) and glyph caching allocate
+  // through throwing paths that abort() on OOM under -fno-exceptions; skip
+  // deferrable work below them. The largest-block floor exists because free
+  // heap alone ignores fragmentation (same lesson as the OPDS cover gate).
+  static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
+  static constexpr size_t RENDER_MIN_LARGEST_BLOCK = 16 * 1024;
   // Remap the cached relative reading position once the section's real page count is known
   // (used after a settings change re-paginates a chapter). Returns true if currentPage moved.
   // No-op while the section is still building or when the pagination is unchanged (plain resume).


### PR DESCRIPTION
## Phase 2.5 of the CrossPoint 1.5.0 upstream-sync plan: first-open speedups

Ports the first-open/perceived-latency subset of upstream commit `f0a50557`. That commit's title ("deferred refresh, memory work port, and first-open speedups") bundles 3 unrelated efforts across 22 files/1087 lines — this PR is only the "first-open speedups" third. The other two are separately tracked (task #16: wolfSSL SP-ECC + sdkconfig heap capacity + SdCardFont buffer retention; task #17: async grayscale refresh overlap, held pending a compatibility check against our `EINK_DISPLAY_SINGLE_BUFFER_MODE=1` build).

### What's in this PR

| Piece | What it does |
|---|---|
| `ImageDimsProbe` (new) | Streaming JPEG/PNG header parser — finds dimensions from the first ~1-4KB without inflating the whole image |
| Lazy image extraction | Section build only header-probes images; the actual file is pulled out of the EPUB zip on first render, via a static fn-ptr hook on `ImageBlock` |
| CSS dedup by CRC32 | `ZipFile::enumerateFileEntries` exposes per-entry CRC32; `Epub::parseCssFiles` skips parsing byte-identical stylesheets (common with some converters emitting one CSS file per chapter) |
| Idle glyph prewarm | After a page settles (400ms debounce), scan (not draw) the likely next page and prewarm its glyphs, so the next real page-turn is a cache hit |
| Build-popup deadline | If a blocking build-to-target hasn't produced the landing page within 1000ms, surface "Indexing" even if the predictive thresholds didn't anticipate it |

`SECTION_FILE_VERSION` 38 → 39 (ImageBlock now serializes the book-internal source href).

### Fork divergence handled

- Skipped upstream's static image pixel-cache slot (`releaseRenderCache`/`PxcSlotGuard`) — our `ImageBlock` already solves the same multi-pass-rerender-cost problem with a per-instance `ramCache_`.
- Skipped upstream's `FrameBufferLoan` rescoping — our `render()` has no loan machinery to rescope.
- **Found and fixed a latent gap surfaced by this port**: `ImageBlock::deserialize`'s allocation was bare `new` (aborts on OOM under `-fno-exceptions`, per this repo's CLAUDE.md rule). Converting it to `new(std::nothrow)` (correct per that rule) meant the caller, `PageImage::deserialize`, needed an explicit null-check to match its sibling `PageLine::deserialize` — previously dead code, since the bare-`new` path could never actually return null. Fixed in `Page.cpp`.

### Process note

This was drafted in an isolated worktree that branched before Phase 2 (PR #99) merged, so its `EpubReaderActivity.h/.cpp` changes were built against a pre-Phase-2 base. Caught during review; re-derived the isolated diff for those two files and reapplied it cleanly on top of current `develop` (which has Phase 2's deque conversion and heap gate) — verified both phases' changes coexist correctly (grep-verified `std::deque<std::string> words`, `BUILD_TICK_MIN_FREE_HEAP_BYTES`, and this PR's `RENDER_MIN_FREE_HEAP`/idle-prewarm fields are all present).

### Verification done
- `pio run -e gh_release_rc` — clean build
- `pio run -e simulator` — clean build
- `pio check` (cppcheck) — no defects
- clang-format on touched files only (no-op — already formatted)
- Full manual diff review of every changed file against the actual fork code (not just upstream's diff context)

### Hardware / manual testing requested
- Open an image-heavy EPUB cold (delete `.crosspoint/` first) and confirm first-open is noticeably faster than before, with the "Indexing" popup behaving sanely
- Confirm images still render correctly (lazy extraction on first visit to an image page)
- Confirm dictionary/reading flow is unaffected (idle prewarm runs silently in the background — nothing to see if it's working, but watch for any stutter/heap issues on a long reading session)
- Simulator windows aren't exposed to macOS Accessibility on this machine, so interactive simulator navigation (page-turn testing) couldn't be done here — worth a hardware pass specifically for image pages and the mid-build popup timing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
