### PR TITLE
fix: Phase 2.6 EPUB rendering-correctness roundup

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -6,10 +6,18 @@ All POD fields are written in the ESP32 little-endian representation used by
 
 ## `book.bin`
 
-### Version 7
+### Version 9
 
 `book.bin` stores EPUB metadata plus lookup tables for spine and TOC entries.
 The current firmware writes this version from `BookMetadataCache`.
+
+Version 9 ignores ambiguous EPUB 2 `<guide>` `type="text"` references when
+locating the book's first-reading position: many EPUB 2 files mark every
+content file as `"text"`, so that type alone doesn't reliably identify a
+start location. Only an explicit `type="start"` reference is now used;
+otherwise the reader opens at spine index 0.
+
+Version 8 (undocumented at the time) stores TOC/book titles NFC-composed.
 
 ImHex pattern:
 
@@ -18,7 +26,7 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define EXPECTED_VERSION 7
+#define EXPECTED_VERSION 9
 #define MAX_STRING_LENGTH 65535
 
 struct String {

--- a/lib/EpdFont/scripts/fontconvert_sdcard.py
+++ b/lib/EpdFont/scripts/fontconvert_sdcard.py
@@ -715,6 +715,56 @@ def synthesize_presentation_forms(font_path, intervals):
     return overrides
 
 
+def extract_ligature_glyph_indices_fonttools(font_path):
+    """Map standard ligature codepoints without a cmap entry to their glyph IDs.
+
+    Most fonts implement standard Latin ligatures (fi, fl, ffi...) purely via a
+    GSUB 'liga'/'rlig' substitution triggered by the decomposed letter sequence,
+    with no cmap entry for the precomposed ligature codepoint itself (U+FB00-FB06).
+    That's fine for extract_ligatures_fonttools's runtime substitution table (built
+    from the decomposed sequence), but if the EPUB text already contains the
+    precomposed codepoint directly (common when copy-pasted from a source that
+    applied typographic ligatures), face.get_char_index() finds nothing and the
+    codepoint would be silently dropped from the rasterized set, rendering as
+    tofu. This finds the GSUB target glyph directly so it rasterizes anyway.
+    """
+    from fontTools.ttLib import TTFont
+
+    font = TTFont(font_path)
+    cmap = font.getBestCmap() or {}
+    glyph_to_cp = {gname: cp for cp, gname in cmap.items()}
+    glyph_indices = {gname: index for index, gname in enumerate(font.getGlyphOrder())}
+    overrides = {}
+
+    if 'GSUB' in font:
+        gsub = font['GSUB'].table
+        liga_lookup_indices = set()
+        if gsub.FeatureList:
+            for fr in gsub.FeatureList.FeatureRecord:
+                if fr.FeatureTag in ('liga', 'rlig'):
+                    liga_lookup_indices.update(fr.Feature.LookupListIndex)
+
+        for li in liga_lookup_indices:
+            lookup = gsub.LookupList.Lookup[li]
+            for st in lookup.SubTable:
+                actual = st.ExtSubTable if lookup.LookupType == 7 and hasattr(st, 'ExtSubTable') else st
+                if not hasattr(actual, 'ligatures'):
+                    continue
+                for first_glyph, ligature_list in actual.ligatures.items():
+                    if first_glyph not in glyph_to_cp:
+                        continue
+                    for lig in ligature_list:
+                        if any(component not in glyph_to_cp for component in lig.Component):
+                            continue
+                        seq = tuple([glyph_to_cp[first_glyph]] + [glyph_to_cp[c] for c in lig.Component])
+                        lig_cp = STANDARD_LIGATURE_MAP.get(seq)
+                        if lig_cp is not None and lig_cp not in cmap:
+                            overrides[lig_cp] = glyph_indices[lig.LigGlyph]
+
+    font.close()
+    return overrides
+
+
 def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=False,
                          fallback_fontfile=None, reposition_marks=False):
     """Rasterize all glyphs for one font style. Returns StyleRasterData."""
@@ -738,23 +788,36 @@ def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=F
     if force_autohint:
         load_flags |= freetype.FT_LOAD_FORCE_AUTOHINT
 
-    # GSUB-synthesized presentation-form overrides (see synthesize_presentation_
-    # forms's docstring) -- only ever consulted below after face.get_char_index()
-    # has already returned 0 for a codepoint, so a font with direct cmap
-    # coverage for its presentation forms (Amiri, Cairo) is unaffected and
-    # converts byte-identical to before this existed.
+    # GSUB-synthesized overrides -- only ever consulted below after
+    # face.get_char_index() has already returned 0 for a codepoint, so a font
+    # with direct cmap coverage (for presentation forms or ligatures alike) is
+    # unaffected and converts byte-identical to before either of these existed.
+    # presentation_form_overrides: Arabic init/medi/fina/isol + lam-alef forms
+    # (see synthesize_presentation_forms's docstring). ligature_glyph_overrides:
+    # standard Latin ligature codepoints (U+FB00-FB06) reachable only via a
+    # 'liga'/'rlig' GSUB substitution, not a cmap entry (see
+    # extract_ligature_glyph_indices_fonttools's docstring) -- complements
+    # extract_ligatures_fonttools's runtime decomposed-sequence substitution
+    # table, which doesn't help when the EPUB text already has the precomposed
+    # ligature codepoint.
     presentation_form_overrides = synthesize_presentation_forms(fontfile, intervals)
     if presentation_form_overrides:
         print(f"  [{style_label}] GSUB-synthesized {len(presentation_form_overrides)} presentation forms "
               f"(font has no cmap coverage for them)", file=sys.stderr)
+    glyph_overrides = dict(presentation_form_overrides)
+    ligature_glyph_overrides = extract_ligature_glyph_indices_fonttools(fontfile)
+    if ligature_glyph_overrides:
+        print(f"  [{style_label}] GSUB-synthesized {len(ligature_glyph_overrides)} standard ligatures "
+              f"(font has no cmap coverage for them)", file=sys.stderr)
+    glyph_overrides.update(ligature_glyph_overrides)
 
     def load_glyph(code_point):
         glyph_index = face.get_char_index(code_point)
         if glyph_index > 0:
             face.load_glyph(glyph_index, load_flags)
             return face
-        if code_point in presentation_form_overrides:
-            face.load_glyph(presentation_form_overrides[code_point], load_flags)
+        if code_point in glyph_overrides:
+            face.load_glyph(glyph_overrides[code_point], load_flags)
             return face
         if fallback_face:
             fallback_glyph_index = fallback_face.get_char_index(code_point)
@@ -774,7 +837,7 @@ def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=F
         for code_point in range(i_start, i_end + 1):
             has_primary = face.get_char_index(code_point) != 0
             has_fallback = fallback_face and fallback_face.get_char_index(code_point) != 0
-            has_override = code_point in presentation_form_overrides
+            has_override = code_point in glyph_overrides
             if not has_primary and not has_fallback and not has_override:
                 if start < code_point:
                     validated_intervals.append((start, code_point - 1))

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -10,7 +10,7 @@
 #include "FsHelpers.h"
 
 namespace {
-constexpr uint8_t BOOK_CACHE_VERSION = 8;  // v8: TOC/book titles stored NFC-composed
+constexpr uint8_t BOOK_CACHE_VERSION = 9;  // v9: ignore ambiguous EPUB2 guide "text" references
 constexpr char bookBinFile[] = "/book.bin";
 constexpr char tmpSpineBinFile[] = "/spine.bin.tmp";
 constexpr char tmpTocBinFile[] = "/toc.bin.tmp";

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -320,9 +320,13 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
       }
     }
     if (!guideHref.empty()) {
-      if (type == "text" || (type == "start" && !self->textReferenceHref.empty())) {
+      // EPUB 2 guides often mark every content file as "text", so that type does
+      // not identify a reliable first-reading location. Only use the explicit
+      // "start" semantic; otherwise the reader opens at spine index 0.
+      if (type == "start" && !self->hasExplicitStartReference) {
         LOG_DBG("COF", "Found %s reference in guide: %s", type.c_str(), guideHref.c_str());
         self->textReferenceHref = guideHref;
+        self->hasExplicitStartReference = true;
       } else if ((type == "cover" || type == "cover-page") && self->guideCoverPageHref.empty()) {
         LOG_DBG("COF", "Found cover reference in guide: %s", guideHref.c_str());
         self->guideCoverPageHref = guideHref;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -31,6 +31,10 @@ class ContentOpfParser final : public Print {
   BookMetadataCache* cache;
   HalFile tempItemStore;
   std::string coverItemId;
+  // True once an explicit type="start" guide reference has been accepted, so a
+  // later one (or a type="text" entry, which EPUB 2 guides use unreliably) can't
+  // override it.
+  bool hasExplicitStartReference = false;
 
   // Index for fast idref→href lookup (binary search over .items.bin)
   struct ItemIndexEntry {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2187,6 +2187,12 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   const bool pageHasImages = page->hasImages();
   const bool manualRefreshPending = forcedRefreshPending;
   forcedRefreshPending = false;
+  // The reader starts with zero here, which means the normal refresh cycle would use
+  // a HALF refresh for its first page. Keep that same clean base for image pages:
+  // their double-FAST path otherwise runs directly over the retained frame after a
+  // silent restart (e.g. returning from KOReader/Midad sync), leaving the old UI
+  // mixed with the image.
+  const bool cleanImageBasePending = manualRefreshPending || pagesUntilFullRefresh <= 1;
   const bool needsTextGrayscale = SETTINGS.textAntiAliasing;
   const bool needsAnyGrayscale = needsTextGrayscale || pageHasImages;
   auto renderGrayscalePass = [&]() {
@@ -2210,8 +2216,8 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     int16_t imgX, imgY, imgW, imgH;
     if (page->getImageBoundingBox(imgX, imgY, imgW, imgH)) {
       // Image pages intentionally bypass the regular refresh cadence. Preserve
-      // the manual clean pass before their double-FAST grayscale pipeline.
-      if (manualRefreshPending) {
+      // a pending clean base before their double-FAST grayscale pipeline.
+      if (cleanImageBasePending) {
         renderer.displayBuffer(HalDisplay::HALF_REFRESH);
       }
       renderer.fillRect(imgX + orientedMarginLeft, imgY + orientedMarginTop, imgW, imgH, false);


### PR DESCRIPTION
## Phase 2.6 of the CrossPoint 1.5.0 upstream-sync plan: EPUB rendering-correctness roundup

Re-audited against actual repo state before porting anything: of the 7 originally-flagged upstream fixes, **4 were already present**:
- 3 landed in an earlier pre-session commit (`98a60b09`, "merge low-risk upstream 1.5 fixes") that the initial audit pass never checked against: `962d5acc` split-text-on-closed-tags, `d7c98adc` antialiasing-after-manual-refresh, `b85580aa` Percent Selection wrap-around.
- `552b2683` (list bullet inline with nested paragraph) was already in the tree by independent means.
- The SVG half of `287457f7` (`<image>`/`xlink:href` handling) was also already present.

Only **3 genuine gaps** remained, all now fixed:

| Fix | Upstream | What it does |
|---|---|---|
| Guide reference type detection | `dde7e037` #2716 | EPUB 2 guides often mark every content file `type="text"`, so that alone can't identify a first-reading location. Only `type="start"` is now trusted. `BOOK_CACHE_VERSION` 8→9. |
| Standard ligature glyph lookup | `9ec77671` #2673 | Fonts implement Latin ligatures (fi, fl, ffi...) via GSUB with no cmap entry for the precomposed codepoint — EPUB text containing that codepoint directly showed as tofu. Verified **not** Arabic-related despite the audit's caution flag (wholly separate from ArabicShaper/BidiUtils). |
| Clean image base after silent restart | `dadc8ec2` #2747 | Image pages' double-FAST refresh could run over a retained stale frame after returning from sync, mixing old UI with the new image. |

### Verification done
- `pio run -e gh_release_rc` — clean build
- `pio run -e simulator` — clean build, boots to Home without error
- `pio check` (cppcheck) — no defects
- clang-format on touched files only (no-op)
- Every "already done" claim verified by grep against actual current code, not assumed from commit messages

### Hardware / manual testing requested
- Open an EPUB with an ambiguous `<guide>` (multiple `type="text"` entries, no `type="start"`) — confirm it opens at spine index 0 instead of a wrong guessed location
- Open an EPUB with a custom SD-card font whose text contains a precomposed ligature character (fi/fl/ffi/ffl) directly — confirm it renders instead of tofu (needs a font regenerated via the updated `fontconvert_sdcard.py` — same caveat as Phase 2's IPA fix, binary regen is a manual follow-up)
- Return to the reader via KOReader/Midad sync on an image page — confirm no visual mixing of old UI and the image

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
