### PR TITLE
feat: Phase 2.7a .dict.dz (dictzip) StarDict support

### DIFF
--- a/lib/InflateReader/InflateReader.cpp
+++ b/lib/InflateReader/InflateReader.cpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 namespace {
-constexpr size_t INFLATE_DICT_SIZE = 32768;
+constexpr size_t INFLATE_DICT_SIZE = InflateReader::RING_BYTES;
 }
 
 // Guarantee the cast pattern in the header comment is valid.
@@ -19,6 +19,7 @@ bool InflateReader::init(const bool streaming) {
   if (streaming) {
     ringBuffer = static_cast<uint8_t*>(malloc(INFLATE_DICT_SIZE));
     if (!ringBuffer) return false;
+    ownsRing = true;
     memset(ringBuffer, 0, INFLATE_DICT_SIZE);
   }
 
@@ -26,11 +27,20 @@ bool InflateReader::init(const bool streaming) {
   return true;
 }
 
+bool InflateReader::initWithRing(uint8_t* ring) {
+  deinit();  // free any owned ring buffer and reset state
+  if (!ring) return false;
+  ringBuffer = ring;
+  ownsRing = false;  // caller's buffer: never freed here
+  memset(ringBuffer, 0, INFLATE_DICT_SIZE);
+  uzlib_uncompress_init(&decomp, ringBuffer, INFLATE_DICT_SIZE);
+  return true;
+}
+
 void InflateReader::deinit() {
-  if (ringBuffer) {
-    free(ringBuffer);
-    ringBuffer = nullptr;
-  }
+  if (ringBuffer && ownsRing) free(ringBuffer);
+  ringBuffer = nullptr;
+  ownsRing = false;
   memset(&decomp, 0, sizeof(decomp));
 }
 

--- a/lib/InflateReader/InflateReader.h
+++ b/lib/InflateReader/InflateReader.h
@@ -44,12 +44,29 @@ class InflateReader {
   InflateReader(const InflateReader&) = delete;
   InflateReader& operator=(const InflateReader&) = delete;
 
+  // Size of the streaming ring buffer, exposed so callers using initWithRing()
+  // can allocate it themselves.
+  static constexpr size_t RING_BYTES = 32768;
+
   // Initialise decompressor. streaming=true allocates a 32KB ring buffer needed
   // when read() or readAtMost() will be called multiple times.
   // Returns false only in streaming mode if the ring buffer allocation fails.
   bool init(bool streaming = false);
 
-  // Release the ring buffer and reset internal state.
+  // Initialise streaming mode over a caller-owned ring buffer of RING_BYTES.
+  //
+  // Exists for allocation ordering. The ring is by far the largest block a
+  // streaming decode needs, and on a heap where every allocation is carved from
+  // one big free run, taking any smaller buffer first can leave the largest
+  // block just short of 32KB -- measured on device at 32756 bytes against a
+  // 32768 requirement. A caller that allocates the ring FIRST, then its own
+  // state, never hits that. The buffer must outlive the reader; deinit() does
+  // not free it.
+  // Returns false if ring is null (e.g. a forwarded failed allocation), leaving
+  // the reader deinitialised.
+  bool initWithRing(uint8_t* ring);
+
+  // Release the ring buffer (only if this reader owns it) and reset state.
   void deinit();
 
   // Set the entire compressed input as a contiguous memory buffer.
@@ -82,4 +99,5 @@ class InflateReader {
  private:
   uzlib_uncomp decomp = {};
   uint8_t* ringBuffer = nullptr;
+  bool ownsRing = false;
 };

--- a/src/DictionaryStore.cpp
+++ b/src/DictionaryStore.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "fontIds.h"
+#include "util/DictZip.h"
 
 namespace {
 constexpr uint32_t CACHE_MAGIC = 0x44435458;  // DCTX
@@ -1176,8 +1177,8 @@ bool DictionaryStore::loadEntryFromIfoPath(const std::string& ifoPath, Dictionar
 
   // Probe for the compressed variant BEFORE deciding missingFiles: a dictionary
   // shipping only <stem>.dict.dz has no plain .dict, and testing for one first
-  // flagged it as BOTH compressed and missing (harmless while compressed is
-  // itself a rejection, but it made the app show the wrong reason).
+  // would flag it as missing (readDefinition() handles compressed=true fine via
+  // DictZip, so this must not fall through to the missingFiles rejection below).
   entry.compressed = !Storage.exists(entry.dictPath.c_str()) && Storage.exists((entry.dictPath + ".dz").c_str());
   entry.missingFiles =
       !Storage.exists(entry.idxPath.c_str()) || (!Storage.exists(entry.dictPath.c_str()) && !entry.compressed);
@@ -1301,8 +1302,7 @@ void DictionaryStore::scan() {
     }
   }
 
-  if (activeIndex < 0 && entries.size() == 1 && !entries[0].compressed && !entries[0].missingFiles &&
-      !entries[0].unsupportedFormat) {
+  if (activeIndex < 0 && entries.size() == 1 && !entries[0].missingFiles && !entries[0].unsupportedFormat) {
     activeIndex = 0;
     activeIfoPath = entries[0].ifoPath;
     saveConfig();
@@ -1312,7 +1312,7 @@ void DictionaryStore::scan() {
 bool DictionaryStore::setActiveIndex(const int index) {
   if (!scanned) scan();
   if (index < 0 || index >= static_cast<int>(entries.size())) return false;
-  if (entries[index].compressed || entries[index].missingFiles || entries[index].unsupportedFormat) return false;
+  if (entries[index].missingFiles || entries[index].unsupportedFormat) return false;
   activeIndex = index;
   activeIfoPath = entries[index].ifoPath;
   clearActiveOnlyEntry();
@@ -1498,7 +1498,9 @@ bool DictionaryStore::saveCheckpointCache(const DictionaryEntry& entry) const {
 }
 
 bool DictionaryStore::ensurePrepared(DictionaryEntry& entry, const std::function<void(int percent)>& onProgress) {
-  if (entry.compressed || entry.missingFiles || entry.unsupportedFormat) return false;
+  // compressed is NOT a rejection here: index preparation only reads entry.idxPath
+  // (always plain), never entry.dictPath -- readDefinition() is what handles .dz.
+  if (entry.missingFiles || entry.unsupportedFormat) return false;
   if (!entry.checkpoints.empty() && !entry.ordinals.empty()) return true;
   if (loadCheckpointCache(entry)) return true;
 
@@ -1788,31 +1790,68 @@ std::string DictionaryStore::readDefinition(const DictionaryEntry& entry, const 
   truncated = readBytes == 0 || hit.dictSize > readBytes;
   if (readBytes == 0) return "";
 
-  HalFile dict;
-  if (!Storage.openFileForRead("DICT", entry.dictPath, dict)) return "";
+  std::string raw;
+  if (entry.compressed) {
+    // Most downloadable StarDict dictionaries ship .dict.dz, not a plain .dict --
+    // decompress just the needed byte range (dictzip's chunked format) instead of
+    // inflating the whole file. extractEntry() writes to a file, not a buffer, so
+    // round-trip through a scratch temp file next to the dictionary; it's a single
+    // discrete lookup, not a hot loop, so the extra SD I/O is an acceptable trade
+    // against not holding a second copy of the definition data in RAM.
+    const std::string dzPath = entry.dictPath + ".dz";
+    const std::string tempPath = entry.dictPath + ".dz.tmp";
+    Storage.remove(tempPath.c_str());
+    HalFile out;
+    if (!Storage.openFileForWrite("DICT", tempPath, out)) return "";
+    DictZip::ExtractError dzErr = DictZip::ExtractError::None;
+    const bool extracted =
+        DictZip::extractEntry(dzPath.c_str(), hit.dictOffset, static_cast<uint32_t>(readBytes), out, &dzErr);
+    out.close();
+    if (!extracted) {
+      LOG_ERR("DICT", "dictzip extract failed: off=%u size=%zu err=%d", hit.dictOffset, readBytes,
+              static_cast<int>(dzErr));
+      Storage.remove(tempPath.c_str());
+      return "";
+    }
 
-  // The offset/size pair comes from the .idx, i.e. from untrusted SD content: a
-  // truncated .dict, an .idx/.dict pair from different builds, or a corrupt
-  // cache all yield offsets past EOF. Without this, seekSet+read past the end
-  // returns whatever the FS hands back and we render it as a definition.
-  // Subtraction (not offset + size) so a size near UINT32_MAX can't wrap.
-  const uint32_t dictFileSize = static_cast<uint32_t>(dict.fileSize());
-  if (hit.dictOffset > dictFileSize || hit.dictSize > dictFileSize - hit.dictOffset) {
-    LOG_ERR("DICT", "Definition out of range: off=%u size=%u file=%u", hit.dictOffset, hit.dictSize, dictFileSize);
+    HalFile in;
+    if (!Storage.openFileForRead("DICT", tempPath, in)) {
+      Storage.remove(tempPath.c_str());
+      return "";
+    }
+    raw.resize(readBytes);
+    const int bytesRead = in.read(raw.data(), readBytes);
+    in.close();
+    Storage.remove(tempPath.c_str());
+    if (bytesRead <= 0) return "";
+    raw.resize(static_cast<size_t>(bytesRead));
+  } else {
+    HalFile dict;
+    if (!Storage.openFileForRead("DICT", entry.dictPath, dict)) return "";
+
+    // The offset/size pair comes from the .idx, i.e. from untrusted SD content: a
+    // truncated .dict, an .idx/.dict pair from different builds, or a corrupt
+    // cache all yield offsets past EOF. Without this, seekSet+read past the end
+    // returns whatever the FS hands back and we render it as a definition.
+    // Subtraction (not offset + size) so a size near UINT32_MAX can't wrap.
+    const uint32_t dictFileSize = static_cast<uint32_t>(dict.fileSize());
+    if (hit.dictOffset > dictFileSize || hit.dictSize > dictFileSize - hit.dictOffset) {
+      LOG_ERR("DICT", "Definition out of range: off=%u size=%u file=%u", hit.dictOffset, hit.dictSize, dictFileSize);
+      dict.close();
+      return "";
+    }
+
+    if (!dict.seekSet(hit.dictOffset)) {
+      dict.close();
+      return "";
+    }
+
+    raw.resize(readBytes);
+    const int bytesRead = dict.read(raw.data(), readBytes);
     dict.close();
-    return "";
+    if (bytesRead <= 0) return "";
+    raw.resize(static_cast<size_t>(bytesRead));
   }
-
-  if (!dict.seekSet(hit.dictOffset)) {
-    dict.close();
-    return "";
-  }
-
-  std::string raw(readBytes, '\0');
-  const int bytesRead = dict.read(raw.data(), readBytes);
-  dict.close();
-  if (bytesRead <= 0) return "";
-  raw.resize(static_cast<size_t>(bytesRead));
 
   std::string decoded = decodeStarDictData(raw, entry.sameTypeSequence);
   raw.clear();

--- a/src/activities/apps/DictionaryActivity.cpp
+++ b/src/activities/apps/DictionaryActivity.cpp
@@ -115,13 +115,6 @@ void DictionaryActivity::selectCurrent() {
   const int dictionaryIndex = selectedIndex - DICTIONARY_ACTION_COUNT;
   if (dictionaryIndex < 0 || dictionaryIndex >= static_cast<int>(entries.size())) return;
   const auto& entry = entries[dictionaryIndex];
-  if (entry.compressed) {
-    GUI.drawPopup(renderer, tr(STR_DICTIONARY_COMPRESSED_UNSUPPORTED));
-    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
-    delay(1100);
-    requestUpdate();
-    return;
-  }
   if (entry.missingFiles || entry.unsupportedFormat) {
     // unsupportedFormat = .ifo declared idxoffsetbits=64. Shares the "missing
     // files" wording rather than adding a string every translation would have to
@@ -266,9 +259,12 @@ void DictionaryActivity::render(RenderLock&&) {
           if (index == ACTION_DEFINITION_TEXT_SIZE) return std::string(textSizeLabel());
           if (index < DICTIONARY_ACTION_COUNT) return std::string();
           const int entryIndex = index - DICTIONARY_ACTION_COUNT;
-          if (entries[entryIndex].compressed) return std::string("ZIP");
+          // Active takes priority: a compressed dictionary can now be active (readDefinition
+          // handles .dz), so the "ZIP" format badge must not hide that state.
+          if (entryIndex == activeIndex) return std::string(tr(STR_DICTIONARY_ACTIVE));
           if (entries[entryIndex].missingFiles || entries[entryIndex].unsupportedFormat) return std::string("!");
-          return entryIndex == activeIndex ? std::string(tr(STR_DICTIONARY_ACTIVE)) : std::string();
+          if (entries[entryIndex].compressed) return std::string("ZIP");
+          return std::string();
         },
         true);
   }

--- a/src/util/DictZip.cpp
+++ b/src/util/DictZip.cpp
@@ -1,0 +1,289 @@
+#include "DictZip.h"
+
+#include <Arduino.h>  // ESP.getMaxAllocHeap for the pre-reserve heap guard
+#include <InflateReader.h>
+#include <Memory.h>
+
+#include <cstddef>
+
+namespace DictZip {
+namespace {
+
+// Caps the chunk table at 32KB of heap (8192 * 4 bytes); at the typical ~58KB
+// chunk length that still allows ~460MB of uncompressed dictionary data.
+constexpr uint16_t MAX_CHUNK_COUNT = 8192;
+
+// Slack required above the chunk table before reserving it, so a table that
+// would only just fit is refused rather than left to abort inside reserve().
+constexpr size_t CHUNK_TABLE_HEAP_HEADROOM_BYTES = 1024;
+
+bool readLe16(HalFile& file, uint16_t* out) {
+  uint8_t raw[2];
+  if (file.read(raw, 2) != 2) return false;
+  *out = static_cast<uint16_t>(raw[0] | (static_cast<uint16_t>(raw[1]) << 8));
+  return true;
+}
+
+// Compressed input for one chunk, pulled from the file on demand instead of
+// buffered whole. A dictzip chunk is ~58KB uncompressed (measured at 18KB
+// compressed for a real dictionary), so an old whole-chunk buffer would be a
+// large contiguous request made while the 32KB inflate window is about to be
+// taken as well -- two big blocks live at once, on a heap that during a
+// reading session has well under 50KB free. This holds INPUT_BUF_BYTES instead.
+//
+// InflateReader MUST stay the first member: the uzlib callback receives only a
+// uzlib_uncomp* and recovers this struct by casting it (see InflateReader.h).
+constexpr size_t INPUT_BUF_BYTES = 2048;
+
+struct ChunkSource {
+  InflateReader reader;  // must be first
+  HalFile* file = nullptr;
+  uint32_t remaining = 0;  // compressed bytes left in this chunk
+  bool readFailed = false;
+  uint8_t buf[INPUT_BUF_BYTES] = {};
+};
+
+static_assert(offsetof(ChunkSource, reader) == 0, "InflateReader must be first for the uzlib callback cast");
+
+// Refills from the file and returns the next byte, or -1 at the chunk's end.
+// Never reads past compressedSize: the following bytes belong to the next
+// chunk, and stopping there reproduces exactly the hard limit a whole-chunk
+// buffer would impose.
+int chunkReadCb(uzlib_uncomp* u) {
+  auto* src = reinterpret_cast<ChunkSource*>(u);
+  if (src->remaining == 0) return -1;
+
+  const uint32_t want = src->remaining < INPUT_BUF_BYTES ? src->remaining : INPUT_BUF_BYTES;
+  const int n = src->file->read(src->buf, static_cast<int>(want));
+  if (n <= 0) {
+    // Remember the cause: uzlib collapses this into a generic decode failure,
+    // but an IO error is a ReadError, not a corrupt .dz.
+    src->readFailed = true;
+    return -1;
+  }
+  src->remaining -= static_cast<uint32_t>(n);
+  u->source = src->buf + 1;
+  u->source_limit = src->buf + n;
+  return src->buf[0];
+}
+
+bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compressedSize, uint32_t discardSize,
+                       uint32_t extractSize, HalFile& outFile, ExtractError* outError) {
+  const auto fail = [outError](ExtractError e) {
+    if (outError) *outError = e;
+    return false;
+  };
+  if (extractSize == 0) return true;
+
+  // Largest block FIRST. Every allocation here is carved from the same big free
+  // run, so taking the ~3KB ChunkSource before the 32KB ring left the ring's
+  // block short on device even on a barely fragmented heap. Ordering by size
+  // removes that failure mode: the ring gets the big block while it is still
+  // whole, and the small buffers fit in what remains -- or in one of the
+  // smaller free blocks.
+  auto window = makeUniqueNoThrow<uint8_t[]>(InflateReader::RING_BYTES);
+  if (!window) return fail(ExtractError::LowMemory);
+
+  auto src = makeUniqueNoThrow<ChunkSource>();
+  if (!src) return fail(ExtractError::LowMemory);
+  src->file = &file;
+  src->remaining = compressedSize;
+
+  // compressedOffset comes from the untrusted .dz chunk table, so an out-of-range
+  // seek is possible -- guard it rather than reading from the prior position.
+  if (!file.seekSet(compressedOffset)) return fail(ExtractError::ReadError);
+
+  // `window` outlives the reader (declared above it, destroyed after), as
+  // initWithRing() requires.
+  if (!src->reader.initWithRing(window.get())) return fail(ExtractError::LowMemory);
+  // initWithRing() leaves source/source_limit null, so the very first byte
+  // already comes through the callback. Set it after, which resets state.
+  src->reader.setReadCallback(&chunkReadCb);
+
+  auto buf = makeUniqueNoThrow<uint8_t[]>(512);
+  if (!buf) return fail(ExtractError::LowMemory);
+
+  // A decode failure after the callback hit an IO error is a read failure, not
+  // a corrupt stream -- keep the two distinguishable for the caller.
+  const auto decodeFail = [&src, &fail] {
+    return fail(src->readFailed ? ExtractError::ReadError : ExtractError::Decompress);
+  };
+
+  uint32_t batch;
+  while (discardSize > 0) {
+    batch = discardSize < 512 ? discardSize : 512;
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
+    discardSize -= batch;
+  }
+
+  while (extractSize > 0) {
+    batch = extractSize < 512 ? extractSize : 512;
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
+    if (outFile.write(buf.get(), batch) != batch) return fail(ExtractError::ReadError);
+    extractSize -= batch;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+bool parse(HalFile& file, Info* info, ExtractError* outError) {
+  // Classify each failure: a header/table read that comes up short is a
+  // ReadError (IO / truncated file); a value that doesn't make sense as dictzip
+  // is a Decompress (malformed/unsupported .dz).
+  const auto fail = [outError](ExtractError e) {
+    if (outError) *outError = e;
+    return false;
+  };
+  if (outError) *outError = ExtractError::None;  // establish the out-param on every path
+  if (!info) return fail(ExtractError::Decompress);
+  *info = {};
+
+  uint8_t header[10];
+  if (file.read(header, sizeof(header)) != static_cast<int>(sizeof(header))) return fail(ExtractError::ReadError);
+  if (header[0] != 0x1f || header[1] != 0x8b || header[2] != 8) return fail(ExtractError::Decompress);
+
+  const uint8_t flags = header[3];
+  if ((flags & 0x04) == 0) return fail(ExtractError::Decompress);  // dictzip requires FEXTRA
+
+  uint16_t xlen = 0;
+  if (!readLe16(file, &xlen)) return fail(ExtractError::ReadError);
+
+  uint32_t extraRead = 0;
+  bool foundRa = false;
+  while (extraRead + 4 <= xlen) {
+    uint8_t subHeader[4];
+    if (file.read(subHeader, sizeof(subHeader)) != static_cast<int>(sizeof(subHeader)))
+      return fail(ExtractError::ReadError);
+    extraRead += 4;
+    const uint16_t subLen = static_cast<uint16_t>(subHeader[2] | (static_cast<uint16_t>(subHeader[3]) << 8));
+    if (extraRead + subLen > xlen) return fail(ExtractError::Decompress);
+
+    if (subHeader[0] == 'R' && subHeader[1] == 'A') {
+      // Reject a second RA table rather than break: breaking would leave
+      // extraRead < xlen and trip the check below for valid files carrying other
+      // FEXTRA subfields after the RA one. Re-entering would push_back past the
+      // reserve() below, and that growth aborts under -fno-exceptions.
+      if (foundRa) return fail(ExtractError::Decompress);
+      if (subLen < 6) return fail(ExtractError::Decompress);
+
+      uint16_t version = 0;
+      uint16_t chunkLen = 0;
+      uint16_t chunkCount = 0;
+      if (!readLe16(file, &version) || !readLe16(file, &chunkLen) || !readLe16(file, &chunkCount))
+        return fail(ExtractError::ReadError);
+      extraRead += 6;
+      if (version != 1 || chunkLen == 0 || chunkCount == 0 || chunkCount > MAX_CHUNK_COUNT)
+        return fail(ExtractError::Decompress);
+      if (subLen != static_cast<uint16_t>(6 + chunkCount * 2)) return fail(ExtractError::Decompress);
+
+      info->chunkLength = chunkLen;
+      // vector reserve() aborts under -fno-exceptions if it can't allocate;
+      // refuse up front (like DictionaryStore::readDefinition's guard) so a
+      // fragmented heap surfaces LowMemory instead of crashing. chunkCount
+      // <= MAX_CHUNK_COUNT caps this at ~32KB.
+      const size_t chunkTableBytes = (static_cast<size_t>(chunkCount) + 1) * sizeof(uint32_t);
+      if (ESP.getMaxAllocHeap() < chunkTableBytes + CHUNK_TABLE_HEAP_HEADROOM_BYTES)
+        return fail(ExtractError::LowMemory);
+      info->chunkOffsets.reserve(static_cast<size_t>(chunkCount) + 1);
+      info->chunkOffsets.push_back(0);
+      uint32_t cumulative = 0;
+      for (uint16_t i = 0; i < chunkCount; i++) {
+        uint16_t compLen = 0;
+        if (!readLe16(file, &compLen)) return fail(ExtractError::ReadError);
+        extraRead += 2;
+        cumulative += compLen;
+        info->chunkOffsets.push_back(cumulative);
+      }
+      foundRa = true;
+    } else {
+      if (!file.seekSet(file.position() + subLen)) return fail(ExtractError::ReadError);
+      extraRead += subLen;
+    }
+  }
+  if (extraRead != xlen || !foundRa) return fail(ExtractError::Decompress);
+
+  if (flags & 0x08) {  // FNAME
+    int b;
+    do {
+      b = file.read();
+      if (b < 0) return fail(ExtractError::ReadError);
+    } while (b != 0);
+  }
+  if (flags & 0x10) {  // FCOMMENT
+    int b;
+    do {
+      b = file.read();
+      if (b < 0) return fail(ExtractError::ReadError);
+    } while (b != 0);
+  }
+  if (flags & 0x02) {  // FHCRC
+    uint8_t crc[2];
+    if (file.read(crc, 2) != 2) return fail(ExtractError::ReadError);
+  }
+
+  info->dataOffset = static_cast<uint32_t>(file.position());
+  const uint32_t fileSize = static_cast<uint32_t>(file.fileSize());
+  if (fileSize < 4) return fail(ExtractError::Decompress);
+  if (!file.seekSet(fileSize - 4)) return fail(ExtractError::ReadError);
+  uint8_t isizeRaw[4];
+  if (file.read(isizeRaw, 4) != 4) return fail(ExtractError::ReadError);
+  info->totalSize = static_cast<uint32_t>(isizeRaw[0]) | (static_cast<uint32_t>(isizeRaw[1]) << 8) |
+                    (static_cast<uint32_t>(isizeRaw[2]) << 16) | (static_cast<uint32_t>(isizeRaw[3]) << 24);
+  if (info->totalSize == 0) return fail(ExtractError::Decompress);
+  info->valid = true;
+  return true;
+}
+
+bool extractEntry(const char* path, uint32_t offset, uint32_t size, HalFile& outFile, ExtractError* outError) {
+  const auto fail = [outError](ExtractError e) {
+    if (outError) *outError = e;
+    return false;
+  };
+  if (outError) *outError = ExtractError::None;
+  if (size == 0) return true;
+
+  HalFile file;
+  if (!Storage.openFileForRead("DICTZIP", path, file)) return fail(ExtractError::ReadError);
+
+  Info info;
+  // parse() reports its own cause: a header/table read failure is ReadError,
+  // a malformed/unsupported .dz is Decompress.
+  if (!parse(file, &info, outError)) return false;
+
+  // Reject ranges outside the uncompressed data (offset/size come from the
+  // untrusted .idx). Subtraction form avoids uint32 overflow in offset + size
+  // and guarantees localOffset < chunkOutSize in the loop below.
+  if (offset > info.totalSize || size > info.totalSize - offset) return fail(ExtractError::ReadError);
+
+  const uint32_t startChunk = offset / info.chunkLength;
+  const uint32_t endChunk = (offset + size - 1) / info.chunkLength;
+  if (endChunk + 1 >= info.chunkOffsets.size()) return fail(ExtractError::ReadError);
+
+  uint32_t remaining = size;
+  const uint32_t lastChunk = static_cast<uint32_t>(info.chunkOffsets.size() - 2);
+  for (uint32_t chunk = startChunk; chunk <= endChunk; chunk++) {
+    uint32_t chunkOutSize = info.chunkLength;
+    if (chunk == lastChunk) chunkOutSize = info.totalSize - chunk * info.chunkLength;
+    if (chunkOutSize == 0 || chunkOutSize > info.chunkLength) chunkOutSize = info.chunkLength;
+
+    const uint32_t localOffset = (chunk == startChunk) ? (offset % info.chunkLength) : 0;
+    const uint32_t available = chunkOutSize - localOffset;
+    const uint32_t take = remaining < available ? remaining : available;
+
+    const uint32_t compOffset = info.dataOffset + info.chunkOffsets[chunk];
+    const uint32_t compSize = info.chunkOffsets[chunk + 1] - info.chunkOffsets[chunk];
+    if (!extractChunkSlice(file, compOffset, compSize, localOffset, take, outFile, outError)) return false;
+
+    remaining -= take;
+    if (remaining == 0) break;
+  }
+
+  // Should be exhausted given the bounds check + chunk math above; if not, the
+  // chunk table is inconsistent with the requested range -- treat as corrupt.
+  if (remaining != 0) return fail(ExtractError::Decompress);
+  return true;
+}
+
+}  // namespace DictZip

--- a/src/util/DictZip.h
+++ b/src/util/DictZip.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <cstdint>
+#include <vector>
+
+// Random-access reader for dictzip (.dict.dz) files: gzip with an extra "RA"
+// field holding a chunk table, so any byte range can be decompressed without
+// inflating the whole file. Format: https://linux.die.net/man/1/dictzip
+namespace DictZip {
+
+struct Info {
+  uint32_t dataOffset = 0;             // file offset where compressed chunk data starts
+  uint32_t totalSize = 0;              // uncompressed size (gzip ISIZE trailer)
+  uint16_t chunkLength = 0;            // uncompressed bytes per chunk
+  std::vector<uint32_t> chunkOffsets;  // cumulative compressed offsets, chunkCount+1 entries
+  bool valid = false;
+};
+
+// Why an extraction failed, so callers can report the accurate cause.
+enum class ExtractError : uint8_t {
+  None,        // success
+  LowMemory,   // an allocation failed -- the ~32KB inflate window or a chunk
+               // buffer couldn't be obtained from the fragmented heap
+  ReadError,   // file open / read / write / bad-offset failure (IO or a bogus
+               // .idx offset), not a compression problem
+  Decompress,  // the compressed stream itself was bad (inflate failed, or the
+               // .dz header/chunk table didn't parse) -- corrupt/truncated .dz
+};
+
+// Parse the dictzip header/chunk table. On failure, *outError (if provided)
+// reports ReadError for a truncated/IO read or Decompress for a malformed file.
+bool parse(HalFile& file, Info* info, ExtractError* outError = nullptr);
+
+// Decompress the uncompressed byte range [offset, offset+size) into outFile.
+// On failure, *outError (if provided) reports the specific cause so callers can
+// distinguish low memory from IO from a corrupt file.
+bool extractEntry(const char* path, uint32_t offset, uint32_t size, HalFile& outFile, ExtractError* outError = nullptr);
+
+}  // namespace DictZip


### PR DESCRIPTION
## Phase 2.7a of the CrossPoint 1.5.0 upstream-sync plan: .dict.dz (dictzip) StarDict support

Most downloadable StarDict dictionaries ship as `.dict.dz` (dictzip-compressed), not a plain `.dict` — our `DictionaryStore` refused these outright with a "compressed dictionaries are not supported" message, so a user following any standard StarDict setup guide hit a silent wall.

### What's in this PR

- **`src/util/DictZip.{h,cpp}`** (new): random-access dictzip reader — parses the gzip header's `RA` extra-field chunk table, decompresses only the requested byte range via `InflateReader` instead of inflating the whole file.
- **`InflateReader::initWithRing()`/`RING_BYTES`**: lets a caller allocate and own the 32KB ring buffer itself, largest-block-first, avoiding a heap-fragmentation failure mode measured on real hardware (32756 bytes available against a 32768 requirement when smaller buffers were allocated first).

Both ported **verbatim** from upstream's already OOM-hardened version (`47466c77`) — the original introduction (`b1d1d757`, "Slim dictionary") is a feature this fork's independently-built `DictionaryStore` never derived from (see our own prior exclusion note in commit `98a60b09`), which is why dictzip support didn't exist here at all rather than being a smaller gap.

- Wired into `DictionaryStore::readDefinition()`: the compressed-entry path decompresses through a scratch `.dz.tmp` file next to the dictionary (since `extractEntry()` writes to a file, not a buffer) rather than holding a second in-memory copy — a single word lookup is a discrete user action, not a hot loop, so the extra SD round-trip is an acceptable trade.
- Removed the `entry.compressed` exclusion from three gates that never actually needed it (auto-select-single-dictionary, `setActiveIndex()`, `ensurePrepared()` — index prep only ever reads `.idx`, never `.dict`/`.dict.dz`), plus the `DictionaryActivity.cpp` UI block that refused to activate a compressed dictionary.
- **Found and fixed a UI bug this surfaced**: the dictionary list's "ZIP" format badge was checked before the "Active" badge, so a compressed dictionary that became active could never actually display as active in the list.

### Verification done
- `pio run -e gh_release_rc` — clean build
- `pio run -e simulator` — clean build
- `pio check` (cppcheck) — no defects
- clang-format on touched files only (no-op)
- Line-by-line code review of the ported files against upstream's actual shipped source (fetched via `gh api`, not guessed)

### What I could NOT verify here
This is genuinely binary-format code (gzip header parsing, chunk-table math, chunked inflate) and I don't have a real `.dict.dz` file or a way to build one correctly in this environment to exercise it end-to-end. I checked whether adding a host-side unit test was low-effort (this repo has a real gtest suite under `test/`) but it isn't — none of the existing tests touch `HalFile`/`Storage`, and this code needs real HAL mocking infrastructure that doesn't exist yet, which is out of scope for this fix.

**This needs a real hardware/simulator test with an actual `.dict.dz` StarDict dictionary before being trusted** — download a real one (e.g. any StarDict dictionary distributed compressed), drop it on the SD card, and confirm:
- It shows up in the dictionary list without the old rejection message
- It can be set active (and the "Active" badge shows correctly, not stuck on "ZIP")
- Looking up a word returns a correct, complete definition (not truncated/garbled — this is the part most likely to have a subtle bug, since it's chunk-boundary math)
- Looking up a word whose definition happens to span a chunk boundary specifically (harder to construct, but this is exactly the kind of case that low-level chunked-decompression bugs hide in)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
