### PR TITLE
fix: two real-device issues from hardware testing round 2

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1081,7 +1081,12 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
     errorMessage = (server.url == FOULAD_EBOOKS_NEWS_URL) ? tr(STR_NEWS_EMPTY) : tr(STR_NO_ENTRIES);
   }
 
-  {
+  // Crash report: a heap-corruption abort (multi_heap assert_valid_block) landed inside
+  // this block's temporary std::string destructors, after an extended low-heap OPDS
+  // session -- the same throwing-`new`-under-`-fno-exceptions` hazard hasHeapForNavigation()
+  // guards against below, just one call site earlier. This block is pure diagnostics
+  // (RollingSdLog), so skipping it under memory pressure costs nothing but a log line.
+  if (hasHeapForNavigation()) {
     int bookCount = 0;
     for (const auto& e : entries) {
       if (e.type == OpdsEntryType::BOOK) bookCount++;
@@ -1089,6 +1094,8 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
     browseLog("FETCH " + url + " entries=" + std::to_string(entries.size()) + " books=" + std::to_string(bookCount) +
               " next=" + (feedNextUrl.empty() ? "-" : feedNextUrl) +
               " prev=" + (feedPrevUrl.empty() ? "-" : feedPrevUrl));
+  } else {
+    LOG_ERR("OPDS", "Skipped FETCH diagnostic log, low heap: free=%u", static_cast<unsigned>(ESP.getFreeHeap()));
   }
   requestUpdate();
 }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -138,7 +138,12 @@ class EpubReaderActivity final : public Activity {
   // Deadline backstop for the predictive gates above: if the blocking build-to-target still
   // hasn't produced the landing page this long after the build started, surface the popup
   // mid-build. Builds that finish under the deadline stay popup-free.
-  static constexpr unsigned long BUILD_POPUP_DEADLINE_MS = 1000;
+  // 2500, not 1000: real-device serial logs (X3, ordinary chapters, no images) showed
+  // "Rendered page" landing at 1000-1200ms routinely -- an initial 1000ms deadline fired
+  // on essentially every book open, showing "Indexing" for ordinary landings the predictive
+  // gates above were specifically designed to keep popup-free. 2500ms gives real hardware
+  // headroom over that baseline while still catching genuinely slow builds.
+  static constexpr unsigned long BUILD_POPUP_DEADLINE_MS = 2500;
   // True only during render()'s blocking build-to-target phase, until the popup has been
   // drawn. Gates showBuildPopup() so the parser's popup callback (which persists into
   // background buildSomeMore ticks) can never draw over a displayed page.


### PR DESCRIPTION
## Summary
- Raise `BUILD_POPUP_DEADLINE_MS` 1000ms -> 2500ms in `EpubReaderActivity.h`. Real X3 serial logs showed ordinary chapter builds landing at 1000-1200ms routinely, so the backstop deadline fired on nearly every book open and showed "Indexing" where upstream CrossPoint stays popup-free for ordinary landings.
- Guard the `FETCH` diagnostic `browseLog()` call in `OpdsBookBrowserActivity::fetchFeed()` behind the existing `hasHeapForNavigation()` check. A real-device crash symbolized to a `multi_heap assert_valid_block` abort inside this block's temporary `std::string` destructors, after an extended low-heap OPDS browsing session. Same class of hazard already guarded one call site later (`navigateToEntry()`); this block is pure diagnostic logging, so skipping it under memory pressure costs nothing.

## Test plan
- [x] `pio run -e default` clean build
- [x] Flashed to connected X3, confirmed via serial log evidence for the deadline root cause
- [ ] User to confirm on-device: book open no longer shows "Indexing" under 2.5s builds
- [ ] User to confirm on-device: no further heap-corruption crash after an extended low-heap OPDS session