### PR TITLE
perf: OPDS grid selector move touches only the ring, not the cell

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -430,8 +430,8 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
   // cells whose frame changed and leave the rest of the frame standing.
   if (canFastRepaintSelector()) {
     const GridLayout layout = computeGridLayout();
-    drawGridCell(layout, fbGridPageStart, fbSelectorIndex - layout.bookStart - fbGridPageStart, /*eraseFirst=*/true);
-    drawGridCell(layout, fbGridPageStart, selectorIndex - layout.bookStart - fbGridPageStart, /*eraseFirst=*/true);
+    drawGridSelectionRing(layout, fbSelectorIndex - layout.bookStart - fbGridPageStart, /*black=*/false);
+    drawGridSelectionRing(layout, selectorIndex - layout.bookStart - fbGridPageStart, /*black=*/true);
     renderer.displayBuffer();
     fbSelectorIndex = selectorIndex;
     return;
@@ -648,6 +648,15 @@ bool OpdsBookBrowserActivity::canFastRepaintSelector() const {
   if (newLocal < 0 || oldLocal < 0) return false;
   return (newLocal / layout.itemsPerPage) * layout.itemsPerPage == fbGridPageStart &&
          (oldLocal / layout.itemsPerPage) * layout.itemsPerPage == fbGridPageStart;
+}
+
+void OpdsBookBrowserActivity::drawGridSelectionRing(const GridLayout& layout, const int slot, const bool black) const {
+  const int col = slot % layout.columns;
+  const int row = slot / layout.columns;
+  const int titleHeight = getGridTitleHeight();
+  const int cellX = gridStartXFor(layout) + col * (layout.coverWidth + GRID_GUTTER);
+  const int cellY = gridTopFor(layout) + row * (layout.coverHeight + titleHeight + GRID_GUTTER);
+  renderer.drawRect(cellX - 4, cellY - 4, layout.coverWidth + 8, layout.coverHeight + 8, 4, black);
 }
 
 int OpdsBookBrowserActivity::gridStartXFor(const GridLayout& layout) const {

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -153,10 +153,19 @@ class OpdsBookBrowserActivity final : public Activity {
   // the fast path needs because it paints over a live frame instead of a cleared one.
   void drawGridCell(const GridLayout& layout, int pageStart, int slot, bool eraseFirst) const;
 
+  // Selector fast path helper: toggles only the 4px selection-ring border around a cell --
+  // no SD read, no BMP decode, cover art and title untouched. The ring lives entirely in
+  // the GRID_GUTTER=12 gap around a cell (same reasoning as RecentBooksActivity's identical
+  // ringRect idiom), so drawing white then black over it never touches the cover or caption.
+  // Real-device testing showed the previous drawGridCell-based fast path (full erase + SD
+  // read + decode for both the old and new cell) still cost ~1.2-1.4s per selector move --
+  // this replaces that cost with a single rect outline toggle.
+  void drawGridSelectionRing(const GridLayout& layout, int slot, bool black) const;
+
   // Selector fast path (see render()). A full repaint re-reads and re-decodes every cover
   // on the page from the SD card, which is what made moving the selector feel slow, so a
-  // pure selection move within an already-drawn page redraws only the two cells whose
-  // frame changed. These track what the framebuffer currently holds; FB_GRID_NONE means
+  // pure selection move within an already-drawn page redraws only the two cells' ring
+  // borders. These track what the framebuffer currently holds; FB_GRID_NONE means
   // it holds something the fast path must not touch up.
   static constexpr int FB_GRID_NONE = -1;
   int fbGridPageStart = FB_GRID_NONE;


### PR DESCRIPTION
## Summary
- Fixes the collection-grid selector-movement latency reported on real hardware (~1.2-1.4s per move).
- `canFastRepaintSelector()`'s fast path was already correctly limiting the repaint to 2 cells, but each cell was still redrawn via `drawGridCell()` -- a full SD read + BMP decode. This ports the ring-only fast path already proven in `RecentBooksActivity`'s sibling cover-grid screen: on a pure selection move, only the 4px selection border toggles (white -> black), touching neither the cover bitmap nor the title.

## Test plan
- [x] `pio run -e default` clean build
- [ ] User to confirm on-device: moving the selector between collection grid cells is fast