### PR TITLE
perf: reserve Page::elements before the deserialize push_back loop

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -169,6 +169,16 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
   uint16_t count;
   serialization::readPod(file, count);
 
+  // Reserve up front so a page load costs one allocation for the element vector
+  // instead of a grow-copy-free cycle every doubling. `count` is untrusted (it
+  // comes straight off the SD cache), so clamp it: a real page holds a few dozen
+  // elements, while a corrupt header could ask for 65535 * sizeof(shared_ptr) and
+  // abort() on the failed allocation (vector's operator new is throwing, and this
+  // firmware builds with -fno-exceptions). Under-reserving is harmless -- the
+  // push_back path below still grows normally.
+  static constexpr uint16_t RESERVE_CAP = 256;
+  page->elements.reserve(std::min(count, RESERVE_CAP));
+
   for (uint16_t i = 0; i < count; i++) {
     uint8_t tag;
     serialization::readPod(file, tag);


### PR DESCRIPTION
## Summary
- `Page::deserialize` did a bare `push_back` loop with no `reserve()`, causing grow-copy-free cycles on every page load (every page turn, not just book-open).
- Ports upstream CrossPoint's `fe37bf80` fix verbatim: reserve clamped to 256 (count is untrusted, comes off the SD cache).

## Test plan
- [x] `pio run -e default` clean build