### PR TITLE
fix: bound OPDS parser fields and percent-encode built URLs

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -7,6 +7,34 @@
 #include <cstring>
 #include <utility>
 
+namespace {
+// Per-field length caps, matching upstream CrossPoint's oom-hardening commit
+// (3e627112). MAX_ENTRIES above bounds the number of entries a feed can add;
+// these bound the size of any ONE field within an entry that is otherwise
+// under that count -- a single feed-controlled <title> or href with no upper
+// bound is its own unbounded-growth vector into the same throwing operator new.
+constexpr size_t MAX_TITLE_CHARS = 160;
+constexpr size_t MAX_AUTHOR_CHARS = 120;
+constexpr size_t MAX_ID_CHARS = 128;
+constexpr size_t MAX_HREF_CHARS = 768;
+constexpr size_t MAX_SEARCH_TEMPLATE_CHARS = 768;
+constexpr size_t MAX_PAGE_URL_CHARS = 768;
+}  // namespace
+
+void OpdsParser::assignBounded(std::string& target, const char* value, const size_t maxLen) {
+  if (!value) {
+    target.clear();
+    return;
+  }
+  target.assign(value, strnlen(value, maxLen));
+}
+
+void OpdsParser::appendBounded(std::string& target, const char* value, const size_t len, const size_t maxLen) {
+  if (target.size() >= maxLen) return;
+  const size_t remaining = maxLen - target.size();
+  target.append(value, len < remaining ? len : remaining);
+}
+
 OpdsParser::OpdsParser() {
   parser = XML_ParserCreate(nullptr);
   if (!parser) {
@@ -137,14 +165,13 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
       const char* type = findAttribute(atts, "type");
 
       if (rel && strcmp(rel, "search") == 0) {
-        std::string sHref(href);
-        if (sHref.find("{searchTerms}") != std::string::npos) {
-          self->searchTemplate = sHref;
+        if (strstr(href, "{searchTerms}") != nullptr) {
+          assignBounded(self->searchTemplate, href, MAX_SEARCH_TEMPLATE_CHARS);
         }
       } else if (rel && strcmp(rel, "next") == 0 && !self->inEntry) {
-        self->nextPageUrl = href;
+        assignBounded(self->nextPageUrl, href, MAX_PAGE_URL_CHARS);
       } else if (rel && strcmp(rel, "previous") == 0 && !self->inEntry) {
-        self->prevPageUrl = href;
+        assignBounded(self->prevPageUrl, href, MAX_PAGE_URL_CHARS);
       }
 
       if (self->inEntry) {
@@ -183,7 +210,7 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
           if (!keepExisting &&
               (self->currentEntry.type != OpdsEntryType::BOOK || (isPlainEpub && !alreadyHasPlainEpub))) {
             self->currentEntry.type = OpdsEntryType::BOOK;
-            self->currentEntry.href = href;
+            assignBounded(self->currentEntry.href, href, MAX_HREF_CHARS);
             // type may be absent now that the rel alone qualifies; nullptr into a
             // std::string is undefined, not empty.
             self->currentEntry.acquisitionType = type ? type : "";
@@ -191,14 +218,14 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
         } else if (type && strstr(type, "application/atom+xml") != nullptr) {
           if (self->currentEntry.type != OpdsEntryType::BOOK) {
             self->currentEntry.type = OpdsEntryType::NAVIGATION;
-            self->currentEntry.href = href;
+            assignBounded(self->currentEntry.href, href, MAX_HREF_CHARS);
           }
         } else if (rel && strstr(rel, "opds-spec.org/image") != nullptr) {
           // Matches both ".../image" and ".../image/thumbnail". Prefer the
           // thumbnail-specific link if one is present; first-seen otherwise.
           const bool isThumbnail = strstr(rel, "thumbnail") != nullptr;
           if (self->currentEntry.coverUrl.empty() || isThumbnail) {
-            self->currentEntry.coverUrl = href;
+            assignBounded(self->currentEntry.coverUrl, href, MAX_HREF_CHARS);
             self->currentEntry.coverType = type ? type : "";
           }
         }
@@ -279,7 +306,11 @@ void XMLCALL OpdsParser::endElement(void* userData, const XML_Char* name) {
 
 void XMLCALL OpdsParser::characterData(void* userData, const XML_Char* s, const int len) {
   auto* self = static_cast<OpdsParser*>(userData);
-  if (self->inTitle || self->inAuthorName || self->inId) {
-    self->currentText.append(s, len);
+  if (self->inTitle) {
+    appendBounded(self->currentText, s, len, MAX_TITLE_CHARS);
+  } else if (self->inAuthorName) {
+    appendBounded(self->currentText, s, len, MAX_AUTHOR_CHARS);
+  } else if (self->inId) {
+    appendBounded(self->currentText, s, len, MAX_ID_CHARS);
   }
 }

--- a/lib/OpdsParser/OpdsParser.h
+++ b/lib/OpdsParser/OpdsParser.h
@@ -117,6 +117,15 @@ class OpdsParser final : public Print {
   std::string prevPageUrl;
   // Helper to find attribute value
   static const char* findAttribute(const XML_Char** atts, const char* name);
+  // Cap a single string field's length so a malformed/malicious feed can't drive
+  // unbounded std::string growth into a throwing operator new -- the same abort
+  // class MAX_ENTRIES above and the move-not-copy push_back below already guard
+  // for the entry vector and per-entry copies; these close the same hole for one
+  // oversized field within an otherwise-normal entry. assignBounded replaces the
+  // target outright (attribute values, e.g. href); appendBounded accumulates
+  // character data across possibly-chunked XML_CharacterDataHandler calls.
+  static void assignBounded(std::string& target, const char* value, size_t maxLen);
+  static void appendBounded(std::string& target, const char* value, size_t len, size_t maxLen);
 
   XML_Parser parser = nullptr;
   std::vector<OpdsEntry> entries;

--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -1,6 +1,29 @@
 #include "UrlUtils.h"
 
+#include <cstdio>
+
 namespace UrlUtils {
+namespace {
+bool isHexDigit(const char c) { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
+
+bool shouldEncode(const unsigned char c) {
+  if (c <= 0x20 || c >= 0x7f) return true;
+  switch (c) {
+    case '"':
+    case '<':
+    case '>':
+    case '\\':
+    case '^':
+    case '`':
+    case '{':
+    case '|':
+    case '}':
+      return true;
+    default:
+      return false;
+  }
+}
+}  // namespace
 
 std::string ensureProtocol(const std::string& url) {
   if (url.find("://") == std::string::npos) {
@@ -22,18 +45,39 @@ std::string extractHost(const std::string& url) {
   return pathStart == std::string::npos ? url : url.substr(0, pathStart);
 }
 
+std::string encodeUnsafeUrlChars(const std::string& url) {
+  std::string out;
+  out.reserve(url.size());
+  for (size_t i = 0; i < url.size(); ++i) {
+    const unsigned char c = static_cast<unsigned char>(url[i]);
+    if (c == '%' && i + 2 < url.size() && isHexDigit(url[i + 1]) && isHexDigit(url[i + 2])) {
+      out += url[i];
+      out += url[i + 1];
+      out += url[i + 2];
+      i += 2;
+    } else if (c == '%' || shouldEncode(c)) {
+      char encoded[4];
+      snprintf(encoded, sizeof(encoded), "%%%02X", c);
+      out += encoded;
+    } else {
+      out += static_cast<char>(c);
+    }
+  }
+  return out;
+}
+
 std::string buildUrl(const std::string& serverUrl, const std::string& path) {
   // If path is already an absolute URL (has protocol), use it directly
   if (path.find("://") != std::string::npos) {
-    return path;
+    return encodeUnsafeUrlChars(path);
   }
   const std::string urlWithProtocol = ensureProtocol(serverUrl);
   if (path.empty()) {
-    return urlWithProtocol;
+    return encodeUnsafeUrlChars(urlWithProtocol);
   }
   if (path[0] == '/') {
     // Absolute path - use just the host
-    return extractHost(urlWithProtocol) + path;
+    return encodeUnsafeUrlChars(extractHost(urlWithProtocol) + path);
   }
   // Relative path - strip query string from base before appending
   std::string base = urlWithProtocol;
@@ -42,9 +86,9 @@ std::string buildUrl(const std::string& serverUrl, const std::string& path) {
     base.resize(queryPos);
   }
   if (base.back() == '/') {
-    return base + path;
+    return encodeUnsafeUrlChars(base + path);
   }
-  return base + "/" + path;
+  return encodeUnsafeUrlChars(base + "/" + path);
 }
 
 }  // namespace UrlUtils

--- a/src/util/UrlUtils.h
+++ b/src/util/UrlUtils.h
@@ -14,6 +14,11 @@ std::string ensureProtocol(const std::string& url);
 std::string extractHost(const std::string& url);
 
 /**
+ * Percent-encode raw characters that esp_http_client rejects in a URL.
+ */
+std::string encodeUnsafeUrlChars(const std::string& url);
+
+/**
  * Build full URL from server URL and path.
  * If path starts with /, it's an absolute path from the host root.
  * Otherwise, it's relative to the server URL.


### PR DESCRIPTION
## Summary
Two standalone, non-wolfSSL pieces of upstream CrossPoint's OOM-hardening commit (`3e627112`):

- **OpdsParser**: `title`/`author`/`id`/`href`/`searchTemplate`/`nextPageUrl`/`prevPageUrl`/`coverUrl` were assigned directly from feed-controlled XML with no length cap -- only the entry *count* was bounded (`MAX_ENTRIES=200`). A single oversized field from a malformed/malicious feed could still drive unbounded `std::string` growth into a throwing `operator new`, which aborts under `-fno-exceptions`. Adds `assignBounded()`/`appendBounded()` with per-field caps matching upstream, while preserving this fork's divergent logic (xtc/xtch acquisition types, coverUrl/coverType, move-not-copy entry push_back).
- **UrlUtils::buildUrl()**: feed-supplied hrefs/redirect paths were concatenated into request URLs unescaped. Adds `encodeUnsafeUrlChars()` and applies it on every return path.

## Test plan
- [x] `pio run -e default` clean build
- [x] `pio check` (cppcheck) clean