### PR TITLE
fix: watchdog-safe section builds + bound selector ring streak

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -451,6 +451,19 @@ bool Section::buildSomeMore(const int maxPages, const unsigned long budgetMs) {
   // would otherwise turn one "small" chunk into a blocking rebuild of the whole watermark.
   const int startCount = builtPageCount_;
   const unsigned long startMs = budgetMs > 0 ? millis() : 0;
+  // Real-device crash: a chapter whose HTML is almost entirely one pathologically dense
+  // paragraph (an AO3-via-FanFicFare export artifact -- hundreds of <p> tags with no page
+  // break between them) can drive many parseStep() calls without ever completing a single
+  // page, so the maxPages/budgetMs exit checks below never trigger -- neither can fire until
+  // AFTER a page finishes. That runs this loop for the parse's full duration with no
+  // opportunity for FreeRTOS to service the task watchdog, which then resets the device
+  // (CLAUDE.md's "Watchdog Timeout" debugging guidance -- same class as
+  // TxtReaderActivity's index-build loop). Unconditional and independent of
+  // maxPages/budgetMs: this must feed the watchdog even on the createSectionFile()
+  // percent-jump path, which calls with both at 0 (genuinely unbounded by design --
+  // a percent jump needs the whole chapter's page count).
+  int stepsSinceYield = 0;
+  constexpr int YIELD_EVERY_STEPS = 20;
   for (;;) {
     const auto status = build_->parser->parseStep();
     if (status == ChapterHtmlSlimParser::ParseStatus::Error) {
@@ -460,6 +473,10 @@ bool Section::buildSomeMore(const int maxPages, const unsigned long budgetMs) {
     }
     if (status == ChapterHtmlSlimParser::ParseStatus::Done) {
       return finalizeBuild();
+    }
+    if (++stepsSinceYield >= YIELD_EVERY_STEPS) {
+      stepsSinceYield = 0;
+      vTaskDelay(1);
     }
     // ParseStatus::More: yield once we've laid out the requested number of pages,
     // or once the time budget elapses (parseStep granularity: roughly one

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -428,14 +428,16 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
   // of a keypress, and it is what makes the selector feel slow. When the framebuffer
   // already holds this exact grid page and only the selection moved, redraw just the two
   // cells whose frame changed and leave the rest of the frame standing.
-  if (canFastRepaintSelector()) {
+  if (canFastRepaintSelector() && fastRepaintStreak < FAST_REPAINT_CAP) {
     const GridLayout layout = computeGridLayout();
     drawGridSelectionRing(layout, fbSelectorIndex - layout.bookStart - fbGridPageStart, /*black=*/false);
     drawGridSelectionRing(layout, selectorIndex - layout.bookStart - fbGridPageStart, /*black=*/true);
     renderer.displayBuffer();
     fbSelectorIndex = selectorIndex;
+    fastRepaintStreak++;
     return;
   }
+  fastRepaintStreak = 0;
   // Anything that is not a full grid render leaves the framebuffer in a state the fast
   // path must not touch up. Invalidated here and re-armed only at the end of a grid
   // render, so every other path (list, error, loading, popups) is covered by default.

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -171,6 +171,18 @@ class OpdsBookBrowserActivity final : public Activity {
   int fbGridPageStart = FB_GRID_NONE;
   int fbSelectorIndex = -1;
   bool canFastRepaintSelector() const;
+  // Consecutive ring-only touch-ups since the last full grid repaint. Real-device
+  // testing (holding Down/Right so onContinuous fires the move handlers faster than
+  // the ~560ms e-ink refresh cycle can drain them) found a stuck double-ring: two
+  // cells' borders lit simultaneously, persisting across many subsequent moves,
+  // eventually followed by a device reset. A long unbroken chain of partial ring
+  // updates with no intervening full clearScreen()+redraw is exactly the class of
+  // problem HalDisplay's forceCleanBaseOnHalf exists for elsewhere in this codebase
+  // -- cap it the same way: force a full repaint (which re-clears and redraws
+  // everything, self-correcting any accumulated state) every FAST_REPAINT_CAP
+  // touch-ups instead of letting the chain run unbounded.
+  static constexpr int FAST_REPAINT_CAP = 5;
+  int fastRepaintStreak = 0;
 
   // Row height (pitch) in pixels for plain text-list rows (category/navigation entries, both
   // the pure-list page and the nav strips above/below a book grid). Kept tight/Latin-sized


### PR DESCRIPTION
## Summary

Two real-device bugs found this session, both confirmed via live serial capture + video:

- **Watchdog reset on pathological chapter content**: `Section::buildSomeMore()`'s build loop only yields when a page count or time budget trips, both gated on a page actually completing. A chapter whose HTML is almost entirely one pathologically dense run (an AO3-via-FanFicFare export artifact -- hundreds of `<p>` tags with zero page break between them) can drive many `parseStep()` calls without ever finishing a single page, running unyielded for the parse's full duration -- confirmed on-device (`rst:0xc RTC_SW_CPU_RST`, no panic backtrace -- a clean watchdog reset, not a crash) while opening an affected book. Fix: unconditional `vTaskDelay(1)` every 20 `parseStep()` calls, matching `TxtReaderActivity`'s existing identical pattern. Covers every caller including `createSectionFile()`'s genuinely-unbounded percent-jump path.
- **Stuck double-ring on the OPDS grid selector**: holding Down/Right (so `onContinuous` fires faster than the ~560ms e-ink refresh can drain) produced two simultaneously-highlighted grid cells that persisted across many further moves -- caught on video. Cap consecutive ring-only fast-path repaints at 5; the next move falls through to a full grid repaint, which re-clears and self-corrects.

## Test plan
- [x] `pio run -e default` clean build
- [x] `pio check` (cppcheck) clean
- [ ] User to confirm on-device: the specific pathological book opens without a reset; selector ring never gets stuck across an extended held-button session