### PR TITLE
feat: overlap grayscale plane render with async panel refresh

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -812,8 +812,9 @@ build_flags =
    **Local simulator patches.** `crosspoint-simulator` is fetched from git HEAD and lags
    this firmware, so `.pio/libdeps/simulator/` needs local edits. All of them live in a
    gitignored directory: `pio clean` or a libdeps re-fetch silently reverts every one.
-   If the simulator misbehaves, check this list before debugging anything else. All three
-   are upstream fix candidates in the crosspoint-simulator repo.
+   If the simulator misbehaves, check this list before debugging anything else. a-c are
+   upstream fix candidates in the crosspoint-simulator repo; e is fork-specific until
+   upstream grows an equivalent async-refresh HAL surface.
 
    a. **Build blocker — `displayBuffer` arity.** The firmware's `HalDisplay::displayBuffer`
       takes three arguments (`mode, turnOffScreen, forceCleanBaseOnHalf`); the simulator's
@@ -845,6 +846,21 @@ build_flags =
       `QrUtils::drawQrCode` faithfully draws nothing. The encoder and draw path are fine on
       device. Do not chase this; verify QR rendering on hardware, or by encoding the payload
       against the real `ricmoo/QRCode` in a standalone host program.
+
+   e. **Build blocker — no async-refresh HAL surface.** The async grayscale refresh
+      overlap feature (`HalDisplay::displayBufferAsync`/`waitRefreshComplete`/
+      `supportsAsyncRefresh`) has no simulator counterpart, so `GfxRenderer.cpp` fails to
+      link with "no member named 'displayBufferAsync' in 'HalDisplay'" until patched.
+      Add all three to `simulator/src/HalDisplay.h` and implement them in
+      `HalDisplay.cpp`: `displayBufferAsync()` just calls the existing blocking
+      `refreshDisplay()` (the sim's SDL push is already synchronous, nothing to overlap),
+      `waitRefreshComplete()` is a no-op, and `supportsAsyncRefresh()` returns `true` so
+      host builds exercise the same 2-plane-buffer overlap path as async-capable device
+      panels (same reasoning as `supportsStripGrayscale()` always returning `true`). Note
+      the firmware's own `GfxRenderer::supportsAsyncRefresh()` still gates on
+      `!fadingFix` — with `fadingFix` at its default of `1`, the sim (and device) fall
+      back to the blocking strip-scratch tier regardless of this stub; set
+      `SETTINGS.fadingFix = 0` before opening a book to actually exercise the overlap tier.
 
    **Seeing the screen without a GUI.** SDL windows are not always exposed to the macOS
    Accessibility API, and when they aren't, `osascript` keystrokes silently go nowhere and

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2488,6 +2488,28 @@ void GfxRenderer::displayBuffer(const HalDisplay::RefreshMode refreshMode, const
   if (darkMode_) invertScreen();
 }
 
+void GfxRenderer::displayBufferAsync(const HalDisplay::RefreshMode refreshMode, const bool forceCleanBaseOnHalf) const {
+  // Fading fix relies on turnOffScreen, which the async SDK primitive has no
+  // hook for at all -- keep those users on the blocking path unconditionally.
+  if (fadingFix) {
+    displayBuffer(refreshMode, forceCleanBaseOnHalf);
+    return;
+  }
+  auto elapsed = millis() - start_ms;
+  LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBufferAsync", elapsed);
+  // Safe to un-invert once this call returns even though the panel is still
+  // refreshing: the SDK's "push" step (SPI transfer into controller RAM) is
+  // synchronous and already complete by the time displayBufferAsync returns;
+  // the panel refreshes afterward from ITS OWN copy, not by re-reading ours.
+  if (darkMode_) invertScreen();
+  display.displayBufferAsync(refreshMode, forceCleanBaseOnHalf);
+  if (darkMode_) invertScreen();
+}
+
+void GfxRenderer::waitRefreshComplete() const { display.waitRefreshComplete(); }
+
+bool GfxRenderer::supportsAsyncRefresh() const { return !fadingFix && display.supportsAsyncRefresh(); }
+
 std::string GfxRenderer::truncatedText(const int fontId, const char* text, const int maxWidth,
                                        const EpdFontFamily::Style style) const {
   if (!text || maxWidth <= 0) return "";

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -286,6 +286,24 @@ class GfxRenderer {
   // is the one caller that passes false.
   void displayBuffer(HalDisplay::RefreshMode refreshMode = HalDisplay::FAST_REFRESH,
                      bool forceCleanBaseOnHalf = true) const;
+  // Non-blocking form: starts the panel waveform and returns so CPU work (the
+  // grayscale plane render) can overlap the panel's refresh time. The
+  // framebuffer must stay untouched until waitRefreshComplete() -- safe to
+  // read/invert again once this call itself returns (the SDK's "push" step is
+  // synchronous; the panel refreshes afterward from its own RAM copy, not by
+  // re-reading ours). Falls back to the blocking displayBuffer() when fading
+  // fix is active: the async SDK primitive has no turnOffScreen hook, which
+  // the fix relies on.
+  void displayBufferAsync(HalDisplay::RefreshMode refreshMode = HalDisplay::FAST_REFRESH,
+                          bool forceCleanBaseOnHalf = true) const;
+  // Block until a pending async refresh completes (no-op when none is).
+  void waitRefreshComplete() const;
+  // True when displayBufferAsync() genuinely overlaps (panel driver defers
+  // the wait); false where it silently falls back to blocking. Callers can
+  // skip overlap scaffolding (e.g. whole-plane grayscale buffers) when there
+  // is nothing to overlap. Also false whenever fading fix is active, since
+  // displayBufferAsync() always takes the blocking fallback in that case.
+  bool supportsAsyncRefresh() const;
   // EXPERIMENTAL: Windowed update - display only a rectangular region
   // void displayWindow(int x, int y, int width, int height) const;
   void invertScreen() const;

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -65,6 +65,18 @@ void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen,
   einkDisplay.displayBuffer(convertRefreshMode(mode), turnOffScreen);
 }
 
+void HalDisplay::displayBufferAsync(HalDisplay::RefreshMode mode, bool forceCleanBaseOnHalf) {
+  if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH && forceCleanBaseOnHalf) {
+    einkDisplay.requestResync(1);
+  }
+
+  einkDisplay.displayBufferAsyncNoShadow(convertRefreshMode(mode));
+}
+
+void HalDisplay::waitRefreshComplete() { einkDisplay.waitRefreshComplete(); }
+
+bool HalDisplay::supportsAsyncRefresh() const { return einkDisplay.supportsAsyncRefresh(); }
+
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {
   if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -52,6 +52,24 @@ class HalDisplay {
   // true so every other existing call site's behavior is unchanged.
   void displayBuffer(RefreshMode mode = RefreshMode::FAST_REFRESH, bool turnOffScreen = false,
                      bool forceCleanBaseOnHalf = true);
+  // Non-blocking refresh: pushes the frame, starts the panel waveform, and
+  // returns (~25ms) while the panel refreshes on its own (~0.3-2s). The
+  // caller must not touch the framebuffer until waitRefreshComplete()
+  // (refreshBusy()==false / any blocking display call also drains it first),
+  // and must rebuild the differential baseline itself before the next
+  // differential update -- the tiled-grayscale cleanup path already does
+  // this via cleanupGrayscaleWithFrameBuffer(). Same X3 forceCleanBaseOnHalf
+  // resync-gating as displayBuffer() above; see that comment for why.
+  // Falls back to the blocking path on panels that don't support deferral
+  // (supportsAsyncRefresh() reports which).
+  void displayBufferAsync(RefreshMode mode = RefreshMode::FAST_REFRESH, bool forceCleanBaseOnHalf = true);
+  // Block until a pending async refresh completes (no-op when none is).
+  void waitRefreshComplete();
+  // True when displayBufferAsync() genuinely overlaps (panel driver defers
+  // the wait); false where it silently falls back to a blocking refresh, in
+  // which case overlap scaffolding upstream (e.g. whole-plane grayscale
+  // buffers) has nothing to overlap and should skip itself.
+  bool supportsAsyncRefresh() const;
   void refreshDisplay(RefreshMode mode = RefreshMode::FAST_REFRESH, bool turnOffScreen = false);
 
   // Power management

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2195,6 +2195,13 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   const bool cleanImageBasePending = manualRefreshPending || pagesUntilFullRefresh <= 1;
   const bool needsTextGrayscale = SETTINGS.textAntiAliasing;
   const bool needsAnyGrayscale = needsTextGrayscale || pageHasImages;
+  const bool tiledGrayscale = needsAnyGrayscale && renderer.supportsStripGrayscale();
+  // Whole-plane buffering only pays when the BW refresh genuinely runs async
+  // underneath it; on a blocking panel it would just spend ~50KB for the
+  // identical serial timing. Image pages take the blocking double-FAST path
+  // below (no async refresh is ever started), so they'd spend the buffers
+  // with nothing in flight to overlap.
+  const bool overlapRefresh = tiledGrayscale && renderer.supportsAsyncRefresh() && !pageHasImages;
   auto renderGrayscalePass = [&]() {
     if (needsTextGrayscale) {
       page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);
@@ -2238,7 +2245,10 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     // regardless of residue.
     pagesUntilFullRefresh = 1;
   } else {
-    ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+    // Async form: start the waveform and return so the grayscale plane
+    // rendering below overlaps the panel's refresh time instead of
+    // following it.
+    ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh, overlapRefresh);
   }
   const auto tDisplay = millis();
 
@@ -2253,35 +2263,63 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     constexpr int STRIP_ROWS = 80;
     const int gh = renderer.getDisplayHeight();
     const int gwBytes = renderer.getDisplayWidthBytes();
+    const size_t planeBytes = static_cast<size_t>(gwBytes) * gh;
 
-    auto scratch = makeUniqueNoThrow<uint8_t[]>(static_cast<size_t>(gwBytes) * STRIP_ROWS);
-    if (!scratch) {
-      LOG_ERR("ERS", "OOM: grayscale strip scratch (%d bytes); skipping AA this page", gwBytes * STRIP_ROWS);
-    } else {
-      // Bands may be streamed in any order: X4 windows each via setRamArea, X3
-      // via PTL.
-      renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    // Render one plane band-by-band into a whole-plane buffer without
+    // touching the controller, so it can run while the refresh is still in
+    // flight.
+    auto renderPlaneToBuffer = [&](const bool lsbPlane, uint8_t* buf) {
+      renderer.setRenderMode(lsbPlane ? GfxRenderer::GRAYSCALE_LSB : GfxRenderer::GRAYSCALE_MSB);
       for (int y = 0; y < gh; y += STRIP_ROWS) {
         const int rows = (gh - y < STRIP_ROWS) ? (gh - y) : STRIP_ROWS;
-        renderer.beginStripTarget(scratch.get(), y, rows);
+        renderer.beginStripTarget(buf + static_cast<size_t>(y) * gwBytes, y, rows);
         renderer.clearScreen(0x00);
         renderGrayscalePass();
         renderer.endStripTarget();
-        renderer.writeGrayscalePlaneStrip(true, scratch.get(), y, rows);
       }
-      const auto tGrayLsb = millis();
+    };
 
-      // MSB plane.
-      renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-      for (int y = 0; y < gh; y += STRIP_ROWS) {
-        const int rows = (gh - y < STRIP_ROWS) ? (gh - y) : STRIP_ROWS;
-        renderer.beginStripTarget(scratch.get(), y, rows);
-        renderer.clearScreen(0x00);
-        renderGrayscalePass();
-        renderer.endStripTarget();
-        renderer.writeGrayscalePlaneStrip(false, scratch.get(), y, rows);
+    // Tiered on heap pressure: two plane buffers hide both plane renders
+    // inside the refresh wait; one hides the LSB render (its buffer is
+    // reused for MSB after streaming); none falls back to the strip-scratch
+    // flow below with no overlap. Each buffer is only attempted when it
+    // leaves ~60KB free so the pass never starves concurrent allocations --
+    // the next page re-render allocates through throwing std::string paths
+    // that abort() on OOM under -fno-exceptions, so a plane buffer that
+    // "fits" but eats the render headroom is worse than the strip fallback.
+    // Blocking panels skip the buffers entirely: overlapRefresh is false, so
+    // there is nothing in flight to hide the render behind.
+    constexpr size_t PLANE_BUF_HEADROOM = 60000;
+    // Free-heap alone ignores fragmentation: taking the largest block for a
+    // plane can leave only slivers behind even when total headroom looks
+    // fine. Require the block to fit the plane with 16KB contiguous to
+    // spare -- both floors sit comfortably above this file's own
+    // RENDER_MIN_FREE_HEAP (24KB), so a plane buffer can never itself starve
+    // the render it is part of.
+    constexpr size_t PLANE_BUF_MAX_ALLOC_RESERVE = 16 * 1024;
+    const auto planeBufFits = [planeBytes] {
+      return ESP.getFreeHeap() >= planeBytes + PLANE_BUF_HEADROOM &&
+             ESP.getMaxAllocHeap() >= planeBytes + PLANE_BUF_MAX_ALLOC_RESERVE;
+    };
+    auto lsbPlaneBuf = (overlapRefresh && planeBufFits()) ? makeUniqueNoThrow<uint8_t[]>(planeBytes) : nullptr;
+    auto msbPlaneBuf = (lsbPlaneBuf && planeBufFits()) ? makeUniqueNoThrow<uint8_t[]>(planeBytes) : nullptr;
+
+    if (lsbPlaneBuf) {
+      renderPlaneToBuffer(true, lsbPlaneBuf.get());
+      if (msbPlaneBuf) renderPlaneToBuffer(false, msbPlaneBuf.get());
+      const auto tGrayRender = millis();
+
+      renderer.waitRefreshComplete();
+      const auto tWait = millis();
+
+      renderer.writeGrayscalePlaneStrip(true, lsbPlaneBuf.get(), 0, gh);
+      if (msbPlaneBuf) {
+        renderer.writeGrayscalePlaneStrip(false, msbPlaneBuf.get(), 0, gh);
+      } else {
+        renderPlaneToBuffer(false, lsbPlaneBuf.get());
+        renderer.writeGrayscalePlaneStrip(false, lsbPlaneBuf.get(), 0, gh);
       }
-      const auto tGrayMsb = millis();
+      const auto tGrayWrite = millis();
 
       renderer.setRenderMode(GfxRenderer::BW);
       renderer.displayGrayBuffer();
@@ -2290,16 +2328,74 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
       // BW framebuffer is intact; re-sync controller RAM for the next
       // differential page turn directly from it.
       renderer.cleanupGrayscaleWithFrameBuffer();
-      const auto tCleanup = millis();
-
       const auto tEnd = millis();
+
       LOG_DBG("ERS",
-              "Page render (tiled): prewarm=%lums bw_render=%lums display=%lums gray_lsb=%lums "
-              "gray_msb=%lums gray_display=%lums cleanup=%lums total=%lums",
-              tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tGrayLsb - tDisplay, tGrayMsb - tGrayLsb,
-              tGrayDisplay - tGrayMsb, tCleanup - tGrayDisplay, tEnd - t0);
+              "Page render (tiled async): prewarm=%lums bw_render=%lums display=%lums gray_render=%lums "
+              "wait=%lums gray_write=%lums gray_display=%lums cleanup=%lums total=%lums (planes buffered: %d)",
+              tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tGrayRender - tDisplay, tWait - tGrayRender,
+              tGrayWrite - tWait, tGrayDisplay - tGrayWrite, tEnd - tGrayDisplay, tEnd - t0, msbPlaneBuf ? 2 : 1);
       logSlowPageTurn(t0, tScanRender, tPrewarm, tBwRender, tDisplay, tEnd, currentSpineIndex, epub->getTitle(), fcm,
                       preEndScanArabicBytes, preEndScanArabicFontId);
+    } else {
+      // Per-strip scratch tier: blocking panels and the OOM fallback. The
+      // strip writes below need the panel idle, so wait out any pending
+      // async refresh first (no-op when the BW push above was blocking).
+      auto scratch = makeUniqueNoThrow<uint8_t[]>(static_cast<size_t>(gwBytes) * STRIP_ROWS);
+      renderer.waitRefreshComplete();
+      if (!scratch) {
+        LOG_ERR("ERS", "OOM: grayscale strip scratch (%d bytes); skipping AA this page", gwBytes * STRIP_ROWS);
+        if (overlapRefresh) {
+          // The BW refresh ran the shadow-free async path, so controller
+          // RAM's differential baseline was never rebuilt. Even with AA
+          // skipped it must be re-synced from the intact BW framebuffer, or
+          // the next differential update diffs against stale contents.
+          renderer.cleanupGrayscaleWithFrameBuffer();
+        }
+      } else {
+        // Bands may be streamed in any order: X4 windows each via setRamArea, X3
+        // via PTL.
+        renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+        for (int y = 0; y < gh; y += STRIP_ROWS) {
+          const int rows = (gh - y < STRIP_ROWS) ? (gh - y) : STRIP_ROWS;
+          renderer.beginStripTarget(scratch.get(), y, rows);
+          renderer.clearScreen(0x00);
+          renderGrayscalePass();
+          renderer.endStripTarget();
+          renderer.writeGrayscalePlaneStrip(true, scratch.get(), y, rows);
+        }
+        const auto tGrayLsb = millis();
+
+        // MSB plane.
+        renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+        for (int y = 0; y < gh; y += STRIP_ROWS) {
+          const int rows = (gh - y < STRIP_ROWS) ? (gh - y) : STRIP_ROWS;
+          renderer.beginStripTarget(scratch.get(), y, rows);
+          renderer.clearScreen(0x00);
+          renderGrayscalePass();
+          renderer.endStripTarget();
+          renderer.writeGrayscalePlaneStrip(false, scratch.get(), y, rows);
+        }
+        const auto tGrayMsb = millis();
+
+        renderer.setRenderMode(GfxRenderer::BW);
+        renderer.displayGrayBuffer();
+        const auto tGrayDisplay = millis();
+
+        // BW framebuffer is intact; re-sync controller RAM for the next
+        // differential page turn directly from it.
+        renderer.cleanupGrayscaleWithFrameBuffer();
+        const auto tCleanup = millis();
+
+        const auto tEnd = millis();
+        LOG_DBG("ERS",
+                "Page render (tiled): prewarm=%lums bw_render=%lums display=%lums gray_lsb=%lums "
+                "gray_msb=%lums gray_display=%lums cleanup=%lums total=%lums",
+                tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tGrayLsb - tDisplay, tGrayMsb - tGrayLsb,
+                tGrayDisplay - tGrayMsb, tCleanup - tGrayDisplay, tEnd - t0);
+        logSlowPageTurn(t0, tScanRender, tPrewarm, tBwRender, tDisplay, tEnd, currentSpineIndex, epub->getTitle(), fcm,
+                        preEndScanArabicBytes, preEndScanArabicFontId);
+      }
     }
   } else {
     // Fallback path for a controller without strip support. grayscale rendering

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -59,17 +59,29 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
   return {prev, next, tiltPrev || tiltNext};
 }
 
-inline void displayWithRefreshCycle(const GfxRenderer& renderer, int& pagesUntilFullRefresh) {
+// async=true starts the panel waveform and returns so the caller can overlap
+// CPU work (the grayscale plane render) with the panel's refresh time. Async
+// callers must not touch the framebuffer until renderer.waitRefreshComplete()
+// and must rebuild the differential baseline before the next differential
+// update (the tiled-grayscale cleanup path already does this).
+inline void displayWithRefreshCycle(const GfxRenderer& renderer, int& pagesUntilFullRefresh, bool async = false) {
+  const auto mode = (pagesUntilFullRefresh <= 1) ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH;
+  // forceCleanBaseOnHalf=false only on the periodic ghost-cleanup HALF: it's a
+  // full-pixel scrub of the page already on screen, not a base-clearing
+  // operation -- the forced resync it would otherwise trigger on X3 chains 2
+  // extra panel waveform passes on top of this one (~3.4s vs ~800ms measured
+  // on-device) for no visual benefit here. See HalDisplay::displayBuffer's
+  // comment. The FAST branch keeps the default (true), matching every other
+  // existing call site.
+  const bool forceCleanBaseOnHalf = mode != HalDisplay::HALF_REFRESH;
+  if (async) {
+    renderer.displayBufferAsync(mode, forceCleanBaseOnHalf);
+  } else {
+    renderer.displayBuffer(mode, forceCleanBaseOnHalf);
+  }
   if (pagesUntilFullRefresh <= 1) {
-    // forceCleanBaseOnHalf=false: this is a periodic full-pixel scrub of the
-    // page already on screen, not a base-clearing operation -- the forced
-    // resync it would otherwise trigger on X3 chains 2 extra panel waveform
-    // passes on top of this one (~3.4s vs ~800ms measured on-device) for no
-    // visual benefit here. See HalDisplay::displayBuffer's comment.
-    renderer.displayBuffer(HalDisplay::HALF_REFRESH, /*forceCleanBaseOnHalf=*/false);
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else {
-    renderer.displayBuffer();
     pagesUntilFullRefresh--;
   }
 }


### PR DESCRIPTION
## Summary
- Adds an async panel-push path (`HalDisplay::displayBufferAsync`/`waitRefreshComplete`/`supportsAsyncRefresh`, threaded through `GfxRenderer` and `ReaderUtils::displayWithRefreshCycle`) so the BW refresh waveform can run while the CPU renders the grayscale LSB/MSB planes, instead of the CPU waiting idle for the panel first.
- `EpubReaderActivity::renderContents()` tiers the grayscale plane render on free heap: two whole-plane buffers overlap both plane renders behind the refresh wait, one buffer overlaps just the LSB render (MSB streams band-by-band as before), and the original no-buffer strip-scratch path remains the fallback for blocking panels and OOM — behavior is unchanged when overlap isn't possible.
- Image pages are excluded (`overlapRefresh = ... && !pageHasImages`) since they take the blocking double-FAST path and never start an async refresh to overlap.
- `fadingFix` panels fall back to the blocking `displayBuffer()` path in `GfxRenderer::displayBufferAsync()`, matching upstream's reasoning (the async SDK primitive has no `turnOffScreen` equivalent). **Note:** `fadingFix` defaults to `1` (on), so on a fresh install the overlap tier is dormant until the user disables it in settings — this is intentional, not a gap.
- Also documents (in `.skills/SKILL.md`, symlinked as `CLAUDE.md`) a new required local simulator patch discovered while testing this: the simulator's `HalDisplay` stub needs matching `displayBufferAsync`/`waitRefreshComplete`/`supportsAsyncRefresh` methods or the sim fails to link.

## Test plan
- [x] `pio run -e default` — builds clean
- [x] `pio check --skip-packages -e default` — no cppcheck defects
- [x] `clang-format` on touched files only — no unintended reformatting (`git diff --stat` clean)
- [x] Simulator smoke test — patched the local sim HAL stub, opened test EPUBs headlessly (via a temp, uncommitted `SIM_OPEN_BOOK` main.cpp hook, since the SDL window isn't exposed to macOS Accessibility here). Confirmed: an image page (`pageHasImages=true`) correctly takes the blocking strip-scratch tier; a text-only page with `fadingFix` off correctly takes the new async 2-plane-buffer tier (`overlapRefresh=1`, `lsbPlaneBuf` allocated, log line `Page render (tiled async): ... (planes buffered: 2)`, sane timings, no crash). Manually re-verified the `beginStripTarget`/`writeGrayscalePlaneStrip` buffer-offset math against their SDK contracts.
- [ ] On-device verification: text anti-aliasing pages render correctly and measurably faster with `fadingFix` off (heap/timing/ghosting is hardware-only per this repo's testing rules); confirm no ghosting/desync from the async-refresh + strip-write interleave on both X3 and X4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e