### PR TITLE
feat: lend framebuffer storage during blocking section builds

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2,6 +2,7 @@
 
 #include <ArabicShaper.h>
 #include <BidiUtils.h>
+#include <BuildScratch.h>
 #include <FontDecompressor.h>
 #include <HalGPIO.h>
 #include <Logging.h>
@@ -2949,6 +2950,48 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
 uint8_t* GfxRenderer::getFrameBuffer() const { return frameBuffer; }
 
 size_t GfxRenderer::getBufferSize() const { return frameBufferSize; }
+
+void GfxRenderer::releaseFrameBufferForBuild() {
+  // Lend the framebuffer's bytes IN PLACE: the allocation is never freed, so
+  // it cannot move and repeated loans cannot fragment the heap (the previous
+  // free+realloc model measurably decayed the max contiguous block over a
+  // session). The bytes are deposited in the build-scratch registry so
+  // memory-hungry build phases (e.g. InflateReader's ~32KB ring buffer) can
+  // claim them instead of allocating.
+  uint32_t size = 0;
+  uint8_t* scratch = display.lendFrameBufferStorage(&size);
+  frameBuffer = nullptr;
+  if (scratch) {
+    buildscratch::lend(scratch, size);
+  }
+}
+
+bool GfxRenderer::restoreFrameBufferAfterBuild() {
+  buildscratch::reclaim();
+  display.returnFrameBufferStorage();  // cannot fail: the allocation was never freed
+  frameBuffer = display.getFrameBuffer();
+  return frameBuffer != nullptr;
+}
+
+GfxRenderer::FrameBufferLoan::FrameBufferLoan(GfxRenderer& renderer) : renderer_(renderer) {
+  // Nesting guard: if the framebuffer is already lent out (an outer loan),
+  // stay inert so this end() cannot return storage the outer loan still owns.
+  if (!renderer_.hasFrameBuffer()) return;
+  renderer_.releaseFrameBufferForBuild();
+  active_ = true;
+}
+
+void GfxRenderer::FrameBufferLoan::end() {
+  if (!active_) return;
+  active_ = false;
+  if (!renderer_.restoreFrameBufferAfterBuild()) {
+    // Only reachable if the framebuffer never existed, which the constructor
+    // already guards against; kept as a backstop since running blind helps
+    // nobody.
+    LOG_ERR("GFX", "Framebuffer restore failed - restarting");
+    ESP.restart();
+  }
+}
 
 // unused
 // void GfxRenderer::grayscaleRevert() const { display.grayscaleRevert(); }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -452,6 +452,36 @@ class GfxRenderer {
   // Font helpers
   const uint8_t* getGlyphBitmap(const EpdFontData* fontData, const EpdGlyph* glyph) const;
 
+  // Lend the framebuffer's bytes IN PLACE to a blocking build phase (chapter
+  // layout): the allocation is never freed, so it cannot move and repeated
+  // loans cannot fragment the heap the way a free+realloc cycle measurably
+  // did. Rendering is unavailable (getFrameBuffer() is null, hasFrameBuffer()
+  // false) until restoreFrameBufferAfterBuild(). The bytes are deposited in
+  // buildscratch so a memory-hungry build consumer (e.g. InflateReader's 32KB
+  // ring) can claim them instead of allocating from the heap.
+  void releaseFrameBufferForBuild();
+  // Reclaim the framebuffer: cannot fail (the allocation was never freed).
+  // Returns false only if the framebuffer never existed to begin with.
+  bool restoreFrameBufferAfterBuild();
+  bool hasFrameBuffer() const { return frameBuffer != nullptr; }
+
+  // RAII form of the loan above, for blocking build regions with early-return
+  // error paths: restores on scope exit (or explicitly via end()). Display the
+  // popup/screen the panel should hold BEFORE constructing one. Constructing
+  // while the framebuffer is already lent yields an inert loan (nesting-safe).
+  class FrameBufferLoan {
+   public:
+    explicit FrameBufferLoan(GfxRenderer& renderer);
+    ~FrameBufferLoan() { end(); }
+    void end();
+    FrameBufferLoan(const FrameBufferLoan&) = delete;
+    FrameBufferLoan& operator=(const FrameBufferLoan&) = delete;
+
+   private:
+    GfxRenderer& renderer_;
+    bool active_ = false;
+  };
+
   // Low level functions
   uint8_t* getFrameBuffer() const;
   size_t getBufferSize() const;

--- a/lib/Memory/BuildScratch.cpp
+++ b/lib/Memory/BuildScratch.cpp
@@ -1,0 +1,51 @@
+#include "BuildScratch.h"
+
+#include <Logging.h>
+
+#include <atomic>
+
+namespace buildscratch {
+namespace {
+uint8_t* block = nullptr;
+size_t blockLen = 0;
+// atomic exchange so an opportunistic claim from another task can never
+// double-hand-out the block (single core, but FreeRTOS preempts).
+std::atomic<bool> claimed{false};
+}  // namespace
+
+void lend(uint8_t* buf, const size_t len) {
+  if (block) {
+    LOG_ERR("SCR", "Build scratch lent twice; ignoring second lend");
+    return;
+  }
+  block = buf;
+  blockLen = len;
+  claimed.store(false);
+}
+
+void reclaim() {
+  if (claimed.load()) {
+    // A consumer still holds the block. The storage stays valid (it is the
+    // framebuffer allocation, never freed) but its contents are about to be
+    // clobbered; the consumer's output will be garbage. Loud log so a
+    // lifetime bug is visible instead of a silent corrupt decode.
+    LOG_ERR("SCR", "Build scratch reclaimed while still claimed");
+  }
+  block = nullptr;
+  blockLen = 0;
+  claimed.store(false);
+}
+
+uint8_t* claim(const size_t minLen, size_t* lenOut) {
+  if (!block || blockLen < minLen) return nullptr;
+  bool expected = false;
+  if (!claimed.compare_exchange_strong(expected, true)) return nullptr;
+  if (lenOut) *lenOut = blockLen;
+  return block;
+}
+
+void release(const uint8_t* p) {
+  if (p && p == block) claimed.store(false);
+}
+
+}  // namespace buildscratch

--- a/lib/Memory/BuildScratch.h
+++ b/lib/Memory/BuildScratch.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Registry for the framebuffer bytes lent out during a build phase
+// (GfxRenderer::FrameBufferLoan). The lender (GfxRenderer) deposits the block
+// with lend()/reclaim(); a memory-hungry consumer (e.g. InflateReader's 32KB
+// ring buffer) may claim() it instead of allocating from the heap.
+//
+// Exactly one claimant at a time; claim() returns nullptr when the block is
+// absent or already claimed, and consumers must fall back to the heap. The
+// underlying storage is the framebuffer allocation itself, which is never
+// freed -- so even the pathological case (reclaim() while still claimed, which
+// logs an error) reads garbage, never freed memory.
+namespace buildscratch {
+
+// Lender side (GfxRenderer only).
+void lend(uint8_t* buf, size_t len);
+void reclaim();
+
+// Consumer side: exclusive claim of the whole block if it is at least minLen
+// bytes; nullptr means "use the heap". Release with the same pointer.
+uint8_t* claim(size_t minLen, size_t* lenOut = nullptr);
+void release(const uint8_t* p);
+
+}  // namespace buildscratch

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -1,5 +1,6 @@
 #include "ZipFile.h"
 
+#include <BuildScratch.h>
 #include <HalStorage.h>
 #include <InflateReader.h>
 #include <Logging.h>
@@ -13,6 +14,30 @@ struct ZipInflateCtx {
   uint8_t* readBuf = nullptr;
   size_t readBufSize = 0;
 };
+
+namespace {
+// Opportunistically use the framebuffer's lent bytes as the inflate ring
+// instead of a fresh 32KB heap allocation, when a build phase
+// (GfxRenderer::FrameBufferLoan) currently has them lent out -- e.g. chapter
+// HTML extraction during a section build. Falls back to nullptr (caller uses
+// InflateReader::init(true), which self-allocates) when no loan is active or
+// the block is already claimed. RAII so every early-return path in the two
+// call sites below still releases the claim.
+class ScopedBuildScratchRing {
+ public:
+  ScopedBuildScratchRing() { ring_ = buildscratch::claim(InflateReader::RING_BYTES); }
+  ~ScopedBuildScratchRing() {
+    if (ring_) buildscratch::release(ring_);
+  }
+  ScopedBuildScratchRing(const ScopedBuildScratchRing&) = delete;
+  ScopedBuildScratchRing& operator=(const ScopedBuildScratchRing&) = delete;
+
+  uint8_t* get() const { return ring_; }
+
+ private:
+  uint8_t* ring_ = nullptr;
+};
+}  // namespace
 
 namespace {
 constexpr uint16_t ZIP_METHOD_STORED = 0;
@@ -404,13 +429,18 @@ uint8_t* ZipFile::readFileToMemory(const char* filename, size_t* size, const boo
       return nullptr;
     }
 
+    // Declared before ctx so it outlives it: ctx's InflateReader never frees a
+    // ring it doesn't own (initWithRing), so destruction order only matters
+    // for handing the claim back after the reader's last use.
+    ScopedBuildScratchRing scratchRing;
     ZipInflateCtx ctx;
     ctx.file = &file;
     ctx.fileRemaining = deflatedDataSize;
     ctx.readBuf = fileReadBuffer;
     ctx.readBufSize = 1024;
 
-    if (!ctx.reader.init(true)) {
+    const bool inflateReady = scratchRing.get() ? ctx.reader.initWithRing(scratchRing.get()) : ctx.reader.init(true);
+    if (!inflateReady) {
       LOG_ERR("ZIP", "Failed to init inflate reader");
       free(fileReadBuffer);
       free(data);
@@ -496,13 +526,18 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
       return false;
     }
 
+    // Declared before ctx so it outlives it: ctx's InflateReader never frees a
+    // ring it doesn't own (initWithRing), so destruction order only matters
+    // for handing the claim back after the reader's last use.
+    ScopedBuildScratchRing scratchRing;
     ZipInflateCtx ctx;
     ctx.file = &file;
     ctx.fileRemaining = deflatedDataSize;
     ctx.readBuf = fileReadBuffer;
     ctx.readBufSize = chunkSize;
 
-    if (!ctx.reader.init(true)) {
+    const bool inflateReady = scratchRing.get() ? ctx.reader.initWithRing(scratchRing.get()) : ctx.reader.init(true);
+    if (!inflateReady) {
       LOG_ERR("ZIP", "Failed to init inflate reader");
       free(outputBuffer);
       free(fileReadBuffer);
@@ -555,7 +590,7 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
 
     free(outputBuffer);
     free(fileReadBuffer);
-    return success;  // ctx.reader destructor frees the ring buffer
+    return success;  // ctx.reader/scratchRing destructors release the ring buffer
   }
 
   LOG_ERR("ZIP", "Unsupported compression method");

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -77,6 +77,10 @@ void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
+uint8_t* HalDisplay::lendFrameBufferStorage(uint32_t* sizeOut) { return einkDisplay.lendBuildStorage(sizeOut); }
+
+void HalDisplay::returnFrameBufferStorage() { einkDisplay.returnBuildStorage(); }
+
 void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer) {
   einkDisplay.copyGrayscaleBuffers(lsbBuffer, msbBuffer);
 }

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -60,6 +60,14 @@ class HalDisplay {
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 
+  // Lend the framebuffer's ~48 KB STORAGE to a memory-hungry phase (chapter
+  // builds) without freeing it: the allocation never moves, so repeated loans
+  // cannot fragment the heap (free+realloc measurably did). No display calls
+  // between lend and return; the panel keeps its last refreshed image. The
+  // buffer comes back white -- redraw fully. Returns nullptr if already lent.
+  uint8_t* lendFrameBufferStorage(uint32_t* sizeOut);
+  void returnFrameBufferStorage();
+
   // X3 grayscale preconditioning (OEM "AA-pre-BW(mid)" settle pass), windowed
   // to the gray region in physical panel coordinates (no-arg = full frame).
   // Call after the BW base frame is displayed and before the grayscale planes

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -479,10 +479,14 @@ unsigned cpuMhzNow() {
 
 void EpubReaderActivity::showBuildPopup() {
   // Mid-build indexing popup: only during render()'s blocking build-to-target
-  // phase (buildPopupPending), at most once. The parser's popup callback lives
-  // as long as the build and keeps firing from background buildSomeMore ticks;
-  // without this gate it would draw the popup over an already-displayed page.
-  if (!buildPopupPending) return;
+  // phase (buildPopupPending), at most once, and only when the framebuffer
+  // isn't on loan. If it fires while the loan is active (e.g. the parser's
+  // size-based call during startBuild), pending stays set and the deadline
+  // check retries after the loan. The parser's popup callback lives as long
+  // as the build and keeps firing from background buildSomeMore ticks;
+  // without the buildPopupPending gate it would draw over an already-
+  // displayed page.
+  if (!buildPopupPending || !renderer.hasFrameBuffer()) return;
   GUI.drawPopup(renderer, tr(STR_INDEXING));
   // HALF-clear the popup when the page replaces it, else "INDEXING" ghosts.
   pagesUntilFullRefresh = 1;
@@ -1682,16 +1686,25 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         // The popup's own refresh is a plain FAST, so force the page that replaces it onto the HALF
         // ghost-cleanup path -- otherwise the "INDEXING" text ghosts under the rendered page.
         pagesUntilFullRefresh = 1;
-        const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
+        // No popup redraws while the framebuffer is lent to the build below;
+        // the panel holds the popup displayed above (e-ink is persistent).
+        const auto popupFn = [this]() {
+          if (renderer.hasFrameBuffer()) GUI.drawPopup(renderer, tr(STR_INDEXING));
+        };
+        // Lend the framebuffer's 48 KB to the blocking full build; restored
+        // (white) at scope exit, and the page render below redraws everything.
+        GfxRenderer::FrameBufferLoan loan(renderer);
         if (!section->createSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                         SETTINGS.extraParagraphSpacing, SETTINGS.effParagraphAlignment(), viewportWidth,
                                         viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
                                         SETTINGS.imageRendering, SETTINGS.focusReadingEnabled, popupFn)) {
           LOG_ERR("ERS", "Failed to persist page data to SD");
           section.reset();
+          loan.end();  // restore before anything draws
           showBuildError();
           return;
         }
+        loan.end();
       } else {
         // Lay out just enough to show the landing page; loop() builds the rest behind it. Show the
         // indexing popup up front only when the build will actually be slow: a large spine (its
@@ -1732,10 +1745,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         // phase so a background build in loop() can never draw over a page.
         buildPopupPending = !showPopup;
         const unsigned long buildStartMs = millis();
-        if (!section->startBuild(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
-                                 SETTINGS.extraParagraphSpacing, SETTINGS.effParagraphAlignment(), viewportWidth,
-                                 viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                 SETTINGS.imageRendering, SETTINGS.focusReadingEnabled, [this] { showBuildPopup(); })) {
+        bool started;
+        {
+          // Lend the framebuffer's 48 KB to startBuild only (the spine HTML
+          // inflation peak). The chunk loop below runs without it so the popup
+          // can draw mid-build; background chunks never had the loan either.
+          GfxRenderer::FrameBufferLoan loan(renderer);
+          started =
+              section->startBuild(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
+                                  SETTINGS.extraParagraphSpacing, SETTINGS.effParagraphAlignment(), viewportWidth,
+                                  viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
+                                  SETTINGS.imageRendering, SETTINGS.focusReadingEnabled, [this] { showBuildPopup(); });
+        }
+        if (!started) {
           LOG_ERR("ERS", "Failed to start section build");
           section.reset();
           buildPopupPending = false;


### PR DESCRIPTION
## Summary
- Ports CrossPoint 1.5's framebuffer-lend-for-build feature: `Section::createSectionFile`/`startBuild` are blocking and never touch the display, so the ~48KB framebuffer sits idle exactly when chapter HTML parse/layout needs scratch headroom most.
- `GfxRenderer` gains `releaseFrameBufferForBuild()`/`restoreFrameBufferAfterBuild()`/`hasFrameBuffer()` and an RAII `FrameBufferLoan`, backed by new `HalDisplay::lendFrameBufferStorage()`/`returnFrameBufferStorage()` passthroughs to the SDK's existing `lendBuildStorage()`/`returnBuildStorage()` (single-buffer-mode primitive, already present in `freeink-sdk`). The allocation is lent **in place**, never freed and reallocated — repeated loans can't fragment the heap the way a free+realloc cycle measurably did upstream.
- New `lib/Memory/BuildScratch.{h,cpp}`: a small registry (`lend`/`reclaim`/`claim`/`release`) the lender deposits the block into, so a memory-hungry build-phase consumer can claim it instead of allocating from the heap. Exactly one claimant at a time; `claim()` returns `nullptr` (use the heap) when no loan is active or the block is already taken.
- The real consumer: `ZipFile.cpp`'s two streaming-inflate call sites (chapter HTML extraction — the actual work that happens inside the loan window) now try `buildscratch::claim(InflateReader::RING_BYTES)` for their 32KB ring buffer via `InflateReader::initWithRing()` before falling back to the existing self-allocated `init(true)`. A small RAII `ScopedBuildScratchRing` releases the claim on every early-return path.
- `EpubReaderActivity.cpp` wraps both build call sites (`createSectionFile`'s full-build path and `startBuild`'s incremental-build path) in the loan, and gates the mid-build indexing popup (`showBuildPopup()`/`popupFn`) on `hasFrameBuffer()` so it can't draw into a lent buffer — it just retries once the loan ends, matching upstream's reasoning.

## Test plan
- [x] `pio run -e default` — builds clean
- [x] `pio check --skip-packages -e default` — no cppcheck defects
- [x] `clang-format` on touched files only — no unintended reformatting
- [x] Simulator smoke test — the simulator's `HalDisplay` already had `lendFrameBufferStorage`/`returnFrameBufferStorage` stubbed (no patch needed this time), so no `CLAUDE.md` update was required. Opened a fresh (uncached) test EPUB headlessly and confirmed via temporary debug logging: the loan engages during `startBuild` (`lend scratch=0x... size=48000`), `ZipFile`'s inflate ring **claims that exact address**, and the restore/page-render completes with no crash, no OOM, no error — end-to-end confirmation the real consumer wiring works, not just that the loan/restore no-ops.
- [ ] On-device verification: heap headroom during large-book section builds (hardware-only per this repo's testing rules — the simulator has a flat 1MB heap and can't reproduce fragmentation behavior); confirm the mid-build popup still displays correctly when a build is slow enough to trigger it while the loan is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e