### PR TITLE
feat: queue and flush KOReader/MidadReader Sync progress automatically

### DIFF
--- a/lib/KOReaderSync/KOReaderCredentialStore.cpp
+++ b/lib/KOReaderSync/KOReaderCredentialStore.cpp
@@ -15,6 +15,18 @@ void KOReaderCredentialStore::toJson(JsonDocument& doc) const {
   doc["serverUrl"] = getServerUrl();
   doc["matchMethod"] = static_cast<uint8_t>(getMatchMethod());
   doc["syncBehavior"] = static_cast<uint8_t>(getSyncBehavior());
+  if (pendingSync) {
+    JsonObject p = doc["pendingSync"].to<JsonObject>();
+    p["documentHash"] = pendingSync->documentHash;
+    p["xpath"] = pendingSync->xpath;
+    p["percentage"] = pendingSync->percentage;
+    p["spineIndex"] = pendingSync->spineIndex;
+    p["pageNumber"] = pendingSync->pageNumber;
+    p["totalPages"] = pendingSync->totalPages;
+    if (pendingSync->paragraphIndex) {
+      p["paragraphIndex"] = *pendingSync->paragraphIndex;
+    }
+  }
 }
 
 bool KOReaderCredentialStore::fromJson(JsonVariantConst doc) {
@@ -47,6 +59,26 @@ bool KOReaderCredentialStore::fromJson(JsonVariantConst doc) {
     LOG_DBG("KRS", "Invalid syncBehavior %u in JSON, resetting to ASK_EVERY_TIME", behavior);
     setSyncBehavior(KOReaderSyncBehavior::ASK_EVERY_TIME);
     needsResave = true;
+  }
+
+  const JsonVariantConst pendingValue = doc["pendingSync"];
+  if (!pendingValue.isNull()) {
+    PendingKOReaderSync pending;
+    pending.documentHash = pendingValue["documentHash"] | "";
+    pending.xpath = pendingValue["xpath"] | "";
+    pending.percentage = pendingValue["percentage"] | 0.0f;
+    pending.spineIndex = pendingValue["spineIndex"] | (uint16_t)0;
+    pending.pageNumber = pendingValue["pageNumber"] | (uint16_t)0;
+    pending.totalPages = pendingValue["totalPages"] | (uint16_t)1;
+    // An empty hash means a prior partial/corrupt write; drop it rather than
+    // later uploading progress attached to no document.
+    if (!pending.documentHash.empty()) {
+      const JsonVariantConst paraValue = pendingValue["paragraphIndex"];
+      if (!paraValue.isNull()) {
+        pending.paragraphIndex = paraValue.as<uint16_t>();
+      }
+      pendingSync = std::move(pending);
+    }
   }
 
   if (needsResave) {
@@ -121,4 +153,17 @@ void KOReaderCredentialStore::setSyncBehavior(KOReaderSyncBehavior behavior) {
   }
   syncBehavior = behavior;
   LOG_DBG("KRS", "Set sync behavior: %s", behavior == KOReaderSyncBehavior::SMART ? "Smart" : "Ask");
+}
+
+void KOReaderCredentialStore::setPendingSync(const PendingKOReaderSync& pending) {
+  pendingSync = pending;
+  saveToFile();
+  LOG_DBG("KRS", "Queued KOReader sync for next reconnect (doc=%s, %.1f%%)", pending.documentHash.c_str(),
+          pending.percentage * 100.0f);
+}
+
+void KOReaderCredentialStore::clearPendingSync() {
+  if (!pendingSync) return;
+  pendingSync.reset();
+  saveToFile();
 }

--- a/lib/KOReaderSync/KOReaderCredentialStore.h
+++ b/lib/KOReaderSync/KOReaderCredentialStore.h
@@ -3,12 +3,29 @@
 #include <PersistableStore.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 // Document matching method for KOReader sync
 enum class DocumentMatchMethod : uint8_t {
   FILENAME = 0,  // Match by filename (simpler, works across different file sources)
   BINARY = 1,    // Match by partial MD5 of file content (more accurate, but files must be identical)
+};
+
+// A progress upload the reader couldn't deliver live (no reliable WiFi at
+// book-close -- reading never keeps the radio up, see
+// OpdsBookBrowserActivity::onExit()), queued for the next time the device
+// happens to reconnect for some other reason. Fields mirror what
+// KOReaderSyncActivity::performUpload() sends, precomputed while the Epub was
+// still loaded so the flush itself needs no SD file access beyond this store.
+struct PendingKOReaderSync {
+  std::string documentHash;
+  std::string xpath;
+  float percentage = 0.0f;
+  uint16_t spineIndex = 0;
+  uint16_t pageNumber = 0;
+  uint16_t totalPages = 1;
+  std::optional<uint16_t> paragraphIndex;
 };
 
 // How manual "Sync Progress" resolves differences after fetching remote progress.
@@ -31,6 +48,7 @@ class KOReaderCredentialStore : public PersistableStore<KOReaderCredentialStore>
   std::string serverUrl;                                            // Custom sync server URL (empty = default)
   DocumentMatchMethod matchMethod = DocumentMatchMethod::FILENAME;  // Default to filename for compatibility
   KOReaderSyncBehavior syncBehavior = KOReaderSyncBehavior::SMART;  // Default to Smart for new configs
+  std::optional<PendingKOReaderSync> pendingSync;                   // Queued upload awaiting a reconnect; see above
 
   // Private constructor for singleton
   KOReaderCredentialStore() = default;
@@ -71,6 +89,13 @@ class KOReaderCredentialStore : public PersistableStore<KOReaderCredentialStore>
   // Sync behavior
   void setSyncBehavior(KOReaderSyncBehavior behavior);
   KOReaderSyncBehavior getSyncBehavior() const { return syncBehavior; }
+
+  // Queued upload for the next reconnect (see PendingKOReaderSync above).
+  // Overwrites any previous queued upload -- only the latest position matters.
+  void setPendingSync(const PendingKOReaderSync& pending);
+  bool hasPendingSync() const { return pendingSync.has_value(); }
+  const std::optional<PendingKOReaderSync>& getPendingSync() const { return pendingSync; }
+  void clearPendingSync();
 };
 
 // Helper macro to access credential store

--- a/lib/KOReaderSync/KOReaderDocumentId.h
+++ b/lib/KOReaderSync/KOReaderDocumentId.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 
+#include "KOReaderCredentialStore.h"
+
 /**
  * Calculate KOReader document ID (partial MD5 hash).
  *
@@ -32,6 +34,16 @@ class KOReaderDocumentId {
    * @return 32-character lowercase hex MD5 of the filename
    */
   static std::string calculateFromFilename(const std::string& filePath);
+
+  /**
+   * Calculate the document hash using whichever method a KOReaderCredentialStore
+   * match-method setting selects. Shared by every caller that needs "the hash for
+   * this book, however this device is currently configured to match" instead of
+   * picking a specific algorithm itself.
+   */
+  static std::string calculateForMatchMethod(const std::string& filePath, DocumentMatchMethod method) {
+    return method == DocumentMatchMethod::FILENAME ? calculateFromFilename(filePath) : calculate(filePath);
+  }
 
  private:
   // Size of each chunk to read at each offset

--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -12,6 +12,7 @@
 #include "CrossPointSettings.h"
 #include "FouladEbooksConfig.h"
 #include "KOReaderCredentialStore.h"
+#include "KOReaderSyncClient.h"
 #include "RecentBooksStore.h"
 #include "network/HttpDownloader.h"
 #include "network/OtaUpdater.h"
@@ -572,6 +573,44 @@ void flushPendingReadingStats(const std::string& username, const std::string& pa
     flushed++;
   }
   if (flushed > 0) diagLog("flush: reported " + std::to_string(flushed) + " book(s)");
+}
+
+void flushPendingKOReaderSync() {
+  if (!wifiConnected()) return;
+  if (!KOREADER_STORE.hasPendingSync()) return;
+  // Credentials may have been cleared (sign-out, re-pairing) since the item was
+  // queued; a stale queue entry would otherwise retry forever with NO_CREDENTIALS.
+  if (!KOREADER_STORE.hasCredentials()) {
+    KOREADER_STORE.clearPendingSync();
+    return;
+  }
+
+  const PendingKOReaderSync& pending = *KOREADER_STORE.getPendingSync();
+
+  KOReaderProgress progress;
+  progress.document = pending.documentHash;
+  progress.progress = pending.xpath;
+  progress.percentage = pending.percentage;
+
+  // Rich CrossPoint position, same as the manual sync's live upload -- see
+  // KOReaderSyncActivity::performUpload().
+  KOReaderRichPosition pos;
+  const float pct = pending.percentage < 0.0f ? 0.0f : pending.percentage > 1.0f ? 1.0f : pending.percentage;
+  pos.pctQ = static_cast<uint32_t>(pct * 1000000.0f + 0.5f);
+  pos.spineIndex = pending.spineIndex;
+  pos.pageNumber = pending.pageNumber;
+  pos.totalPages = pending.totalPages;
+  pos.paragraphIndex = pending.paragraphIndex;
+  pos.xpath = pending.xpath;
+  progress.position = std::move(pos);
+
+  const auto result = KOReaderSyncClient::updateProgress(progress);
+  if (result == KOReaderSyncClient::OK) {
+    KOREADER_STORE.clearPendingSync();
+    diagLog("KOReader sync flushed (doc=" + pending.documentHash + ")");
+  }
+  // Failure (offline mid-request, server error): leave it queued for the next
+  // reconnect, same as every other flushPending* function here.
 }
 
 void uploadDebugLog(const std::string& username, const std::string& password) {

--- a/src/FouladDeviceTracking.h
+++ b/src/FouladDeviceTracking.h
@@ -60,6 +60,17 @@ void reportReadingStats(const std::string& username, const std::string& password
 // registerDevice(); same no-op-when-offline behavior.
 void flushPendingReadingStats(const std::string& username, const std::string& password);
 
+// Delivers a KOReader/MidadReader Sync progress upload queued by
+// EpubReaderActivity::onExit() (see PendingKOReaderSync in
+// KOReaderCredentialStore.h) -- reading never keeps WiFi connected, so this is
+// the reliable moment for it too, same reasoning as flushPendingReadingStats()
+// above. Uses KOReaderCredentialStore's own credentials, not the Foulad
+// eBooks ones passed to every other function here: KOReader Sync's server can
+// be any KOSync-compatible host, not just midad.one. No-op when nothing is
+// queued, WiFi is down, or credentials were cleared since queueing (the queue
+// entry is dropped in that last case rather than retried forever).
+void flushPendingKOReaderSync();
+
 // Uploads the on-SD shared debug log (see util/DebugLog.h) to the server,
 // where it's visible to Foulad eBooks admins only -- never to the device's
 // own owner -- so a report of "the reader crashed" or "covers won't load"

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1329,6 +1329,12 @@ void OpdsBookBrowserActivity::performSearch(const std::string& query) {
 }
 
 void OpdsBookBrowserActivity::reportDeviceTrackingOnConnect() {
+  // Not gated on server.url below like the rest of this function: KOReader
+  // Sync's server is independently configured (any KOSync-compatible host,
+  // not necessarily midad.one), so this is worth attempting on WiFi coming up
+  // for ANY OPDS server, Foulad eBooks or not.
+  FouladDeviceTracking::flushPendingKOReaderSync();
+
   if (server.url != FOULAD_EBOOKS_URL) return;
   FouladDeviceTracking::registerDevice(server.username, server.password);
   // Reading itself never keeps WiFi connected (see onExit() below), so this

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -167,6 +167,11 @@ void CrossPointWebServerActivity::onNetworkModeSelected(const NetworkMode mode) 
 }
 
 void CrossPointWebServerActivity::reportDeviceTrackingOnConnect() {
+  // Not gated on a Foulad eBooks account below: KOReader Sync's server is
+  // independently configured, so this is worth attempting whenever WiFi comes
+  // up here, same reasoning as OpdsBookBrowserActivity's version of this call.
+  FouladDeviceTracking::flushPendingKOReaderSync();
+
   const auto& servers = OPDS_STORE.getServers();
   const auto it =
       std::find_if(servers.begin(), servers.end(), [](const OpdsServer& s) { return s.url == FOULAD_EBOOKS_URL; });

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -37,6 +37,7 @@
 #include "FouladEbooksConfig.h"
 #include "FouladReadingPosition.h"
 #include "KOReaderCredentialStore.h"
+#include "KOReaderDocumentId.h"
 #include "KOReaderSyncActivity.h"
 #include "MappedInputManager.h"
 #include "OpdsServerStore.h"
@@ -376,6 +377,36 @@ void EpubReaderActivity::onExit() {
                                     static_cast<float>(progressPercent), section ? section->currentPage : -1,
                                     section ? section->estimatedTotalPages() : -1, readAt, ageSeconds, remote);
       }
+    }
+  }
+
+  // KOReader/MidadReader Sync: queue this session's position the same way the
+  // manual "Sync" menu item uploads it (see launchKOReaderSync()), so a device
+  // that's read but never pressed Sync still shows up server-side eventually.
+  // Queued rather than sent live for the same reason as the Foulad reading-
+  // position block above: WiFi is torn down before the reader even opens, so a
+  // live attempt here would almost always no-op. FouladDeviceTracking::
+  // flushPendingKOReaderSync() delivers it the next time the device reconnects
+  // for any reason. Gated on pageTurnedThisSession so opening a book and
+  // immediately backing out doesn't overwrite a real remote position with
+  // nothing.
+  if (epub && pageTurnedThisSession && KOREADER_STORE.hasCredentials()) {
+    const CrossPointPosition localPos = getCurrentPosition();
+    const SavedProgressPosition localProgress = ProgressMapper::toSavedProgress(epub, localPos);
+    const std::string documentHash =
+        KOReaderDocumentId::calculateForMatchMethod(epub->getPath(), KOREADER_STORE.getMatchMethod());
+    if (!documentHash.empty()) {
+      PendingKOReaderSync pending;
+      pending.documentHash = documentHash;
+      pending.xpath = localProgress.xpath;
+      pending.percentage = localProgress.percentage;
+      pending.spineIndex = static_cast<uint16_t>(localPos.spineIndex);
+      pending.pageNumber = static_cast<uint16_t>(localPos.pageNumber);
+      pending.totalPages = static_cast<uint16_t>(localPos.totalPages > 0 ? localPos.totalPages : 1);
+      if (localPos.hasParagraphIndex) {
+        pending.paragraphIndex = localPos.paragraphIndex;
+      }
+      KOREADER_STORE.setPendingSync(pending);
     }
   }
 

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -14,6 +14,7 @@
 
 #include "Epub/Section.h"
 #include "EpubReaderUtils.h"
+#include "FouladDeviceTracking.h"
 #include "KOReaderCredentialStore.h"
 #include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
@@ -25,11 +26,6 @@
 #include "fontIds.h"
 
 namespace {
-std::string calculateDocumentHashForMethod(const std::string& path, const DocumentMatchMethod method) {
-  return method == DocumentMatchMethod::FILENAME ? KOReaderDocumentId::calculateFromFilename(path)
-                                                 : KOReaderDocumentId::calculate(path);
-}
-
 DocumentMatchMethod alternateMatchMethod(const DocumentMatchMethod method) {
   return method == DocumentMatchMethod::FILENAME ? DocumentMatchMethod::BINARY : DocumentMatchMethod::FILENAME;
 }
@@ -122,6 +118,14 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
 
   LOG_DBG("KOSync", "WiFi connected, starting sync");
 
+  // The radio is up anyway -- opportunistically deliver any progress queued
+  // from a DIFFERENT book closed since the last reconnect (single-slot queue,
+  // see PendingKOReaderSync; this book's own upload below always wins if it
+  // happens to be the same document). Harmless no-op the vast majority of the
+  // time -- there is usually nothing queued once the manual Sync flow is what
+  // got the radio up in the first place.
+  FouladDeviceTracking::flushPendingKOReaderSync();
+
   {
     RenderLock lock(*this);
     state = SYNCING;
@@ -144,7 +148,7 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
 void KOReaderSyncActivity::performSync() {
   // Calculate document hash based on user's preferred method
   const DocumentMatchMethod primaryMethod = KOREADER_STORE.getMatchMethod();
-  documentHash = calculateDocumentHashForMethod(epubPath, primaryMethod);
+  documentHash = KOReaderDocumentId::calculateForMatchMethod(epubPath, primaryMethod);
   if (documentHash.empty()) {
     {
       RenderLock lock(*this);
@@ -175,7 +179,7 @@ void KOReaderSyncActivity::performSync() {
 
   if (smartSyncEnabled()) {
     const DocumentMatchMethod altMethod = alternateMatchMethod(primaryMethod);
-    const std::string altHash = calculateDocumentHashForMethod(epubPath, altMethod);
+    const std::string altHash = KOReaderDocumentId::calculateForMatchMethod(epubPath, altMethod);
     if (!altHash.empty() && altHash != documentHash) {
       KOReaderProgress altProgress;
       const auto altResult = KOReaderSyncClient::getProgress(altHash, altProgress);
@@ -545,7 +549,7 @@ void KOReaderSyncActivity::loop() {
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
       // Calculate hash if not done yet
       if (documentHash.empty()) {
-        documentHash = calculateDocumentHashForMethod(epubPath, KOREADER_STORE.getMatchMethod());
+        documentHash = KOReaderDocumentId::calculateForMatchMethod(epubPath, KOREADER_STORE.getMatchMethod());
       }
       performUpload();
     }

--- a/src/activities/reader/MidadSyncActivity.cpp
+++ b/src/activities/reader/MidadSyncActivity.cpp
@@ -39,6 +39,10 @@ void MidadSyncActivity::onWifiSelectionComplete(const bool success) {
     returnToReader();
     return;
   }
+  // The radio is up for this activity's own sync anyway -- opportunistically
+  // deliver any KOReader Sync progress queued from a book closed since the
+  // last reconnect (see EpubReaderActivity::onExit()).
+  FouladDeviceTracking::flushPendingKOReaderSync();
   // A book that was only ever opened from Home has no catalog id, even though it
   // may well be in the library. Rather than telling the user to go and open it from
   // Library -- which is a chore that exists only because of how the id happens to be


### PR DESCRIPTION
## Summary
Addresses the concrete finding from foulad-ebooks' first real-device MidadReader Sync test (`replies/2026-08-08-eink-midad-reader-sync-first-test.md`): **no `PUT /syncs/progress` request had ever reached the server** because KOReader/MidadReader Sync only fires from the manual "Sync" menu item.

- Confirmed separately: `koMatchMethod` is already handled correctly on our side (`FouladDeviceTracking.cpp:334-341` parses it as a bounds-checked numeric index, same as every other enum setting) — the server-side `koMatchMethod: 0` they saw was their own now-fixed string-vs-index bug silently coercing to 0 client-side, not a firmware gap.
- **Why queue-and-flush, not a live push from `onExit()`:** reading never keeps WiFi connected — it's torn down before the reader even opens (`OpdsBookBrowserActivity::onExit()`) — so a live call from the reader's `onExit()` would almost always no-op, exactly like the existing `FouladReadingPosition` sync already is (and its own `fetch()` "pull on open" half turned out to be dead code, never called, while investigating this).
- `EpubReaderActivity::onExit()` now queues this session's position into a new single-slot `KOReaderCredentialStore::PendingKOReaderSync` (computed while the Epub is still loaded, gated on `hasCredentials()` and `pageTurnedThisSession` so opening-then-immediately-backing-out doesn't overwrite a real remote position with nothing).
- `FouladDeviceTracking::flushPendingKOReaderSync()` delivers it using `KOReaderCredentialStore`'s own credentials (not the Foulad eBooks OPDS ones every other `flushPending*` function takes — KOReader Sync's server can be any KOSync-compatible host). Wired into every existing "device just reconnected" site: `OpdsBookBrowserActivity` and `CrossPointWebServerActivity`'s `reportDeviceTrackingOnConnect()`, plus opportunistically from `MidadSyncActivity`/`KOReaderSyncActivity`'s own WiFi-connect paths (the radio's already up for their own sync).
- Extracted `KOReaderDocumentId::calculateForMatchMethod()` as a shared helper (previously a local lambda duplicated in `KOReaderSyncActivity.cpp`), so the manual flow and the new queueing path can't disagree about how a hash is computed.

## Known limitation
Single-slot queue: closing book A then book B before ever reconnecting loses A's queued update (B's overwrites it). Acceptable for v1 — the manual Sync button remains available for anything more precise — but worth a proper per-document queue later if this turns out to matter in practice.

## Test plan
- [x] `pio run -e default` — builds clean
- [x] `pio check --skip-packages -e default` — no cppcheck defects
- [x] `clang-format` on touched files only — no unintended reformatting
- [x] Simulator smoke test — verified the `PendingKOReaderSync` JSON round-trip through actual SD file I/O (save → reload from disk → every field byte-for-byte correct: document hash, xpath, percentage, spine/page/total, optional paragraph index) and `clearPendingSync()` correctly clears it.
- [ ] On-device: open a book with MidadReader Sync credentials configured, read a page, close it (queues), then browse the OPDS library or open the file-transfer server (flushes) — confirm `PUT /syncs/progress` actually reaches midad.one this time, addressing the test plan in the foulad-ebooks reply directly. Note for whoever runs this: the push won't happen the instant the book closes — it needs a reconnect first (browsing/downloading/web-transfer), by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e