### PR TITLE
feat: add web UI for dictionary management

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -862,6 +862,22 @@ build_flags =
       back to the blocking strip-scratch tier regardless of this stub; set
       `SETTINGS.fadingFix = 0` before opening a book to actually exercise the overlap tier.
 
+   **Not patchable — the web server is a separate, out-of-sync file, not a stub.**
+   `src/network/CrossPointWebServer.cpp`/`WebDAVHandler.cpp` are NOT compiled from the
+   firmware's own `src/network/` for simulator builds; `crosspoint-simulator`'s own
+   CLAUDE.md notes it "still owns those host-side compatibility paths" and vendors a
+   full separate copy at `simulator/src/CrossPointWebServer.cpp` (a top-level `src/`
+   file there, not under `network/`). Any route/handler added to the firmware's
+   `CrossPointWebServer.cpp` — e.g. the `/dictionaries` page and `/api/dictionaries/*`
+   endpoints — silently 404 in the simulator even though `/api/status` and other
+   long-standing routes work fine, because the simulator's binary is running its own
+   older copy of the file that never learned about the new route. Confirmed via
+   `grep -c "<new route's symbol>" .pio/libdeps/simulator/simulator/src/CrossPointWebServer.cpp`
+   returning 0. Unlike the HAL-stub gaps above, this isn't a one-line patch — the
+   simulator's copy would need the new handlers ported into it too, which is real
+   effort disproportionate to most web-UI changes. Don't chase a 404 here as a
+   firmware bug; verify new CrossPointWebServer routes on-device instead.
+
    **Seeing the screen without a GUI.** SDL windows are not always exposed to the macOS
    Accessibility API, and when they aren't, `osascript` keystrokes silently go nowhere and
    the simulator cannot be driven at all (System Events reports "no windows"). Two

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 
 #include "CrossPointSettings.h"
+#include "DictionaryStore.h"
 #include "FontInstaller.h"
 #include "FouladEbooksConfig.h"
 #include "HttpDownloader.h"
@@ -22,6 +23,7 @@
 #include "SettingsList.h"
 #include "WebDAVHandler.h"
 #include "WifiCredentialStore.h"
+#include "html/DictionaryPageHtml.generated.h"
 #include "html/FilesPageHtml.generated.h"
 #include "html/FontsPageHtml.generated.h"
 #include "html/HomePageHtml.generated.h"
@@ -38,6 +40,44 @@ constexpr const char* HIDDEN_ITEMS[] = {"System Volume Information", "XTCache"};
 // (the one temp file, not the whole dir) after every relay attempt, success
 // or failure.
 constexpr char FONT_CONVERT_TMP_DIR[] = "/.crosspoint/font_convert_tmp";
+
+// Same discipline as FontInstaller::isValidFamilyName(): a language folder
+// name becomes a path component directly under DictionaryStore::DICTIONARY_ROOT
+// (see handleDictionaryUploadData()), so anything but alphanumeric/-/_ is
+// rejected outright rather than risk path traversal or a malformed directory.
+bool isValidLanguageId(const char* name) {
+  if (name == nullptr || name[0] == '\0') return false;
+  if (strstr(name, "..") != nullptr) return false;
+  if (strchr(name, '/') != nullptr) return false;
+  if (strchr(name, '\\') != nullptr) return false;
+  for (const char* p = name; *p != '\0'; ++p) {
+    const char c = *p;
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_') {
+      return false;
+    }
+  }
+  return true;
+}
+
+// StarDict sets are the only dictionary format DictionaryStore reads
+// (DictionaryStore.cpp's scan() looks for .ifo files and its siblings) --
+// reject anything outside that exact whitelist rather than let an upload
+// write an arbitrary file into the dictionary tree.
+bool isValidDictionaryFilename(const char* name) {
+  if (name == nullptr || name[0] == '\0') return false;
+  if (strstr(name, "..") != nullptr) return false;
+  if (strchr(name, '/') != nullptr) return false;
+  if (strchr(name, '\\') != nullptr) return false;
+
+  const size_t len = strlen(name);
+  static constexpr const char* kExtensions[] = {".ifo", ".idx", ".dict", ".dict.dz", ".syn"};
+  for (const char* ext : kExtensions) {
+    const size_t extLen = strlen(ext);
+    if (len > extLen && strcmp(name + len - extLen, ext) == 0) return true;
+  }
+  return false;
+}
+
 constexpr uint16_t UDP_PORTS[] = {54982, 48123, 39001, 44044, 59678};
 constexpr uint16_t LOCAL_UDP_PORT = 8134;
 
@@ -211,6 +251,14 @@ void CrossPointWebServer::begin() {
   server->on("/api/fonts/delete", HTTP_POST, [this] { handleFontDelete(); });
   server->on(
       "/api/fonts/convert", HTTP_POST, [this] { handleFontConvert(); }, [this] { handleFontConvertUploadData(); });
+
+  // Dictionary management endpoints
+  server->on("/dictionaries", HTTP_GET, [this] { handleDictionariesPage(); });
+  server->on("/api/dictionaries", HTTP_GET, [this] { handleDictionaryList(); });
+  server->on(
+      "/api/dictionaries/upload", HTTP_POST, [this] { handleDictionaryUpload(); },
+      [this] { handleDictionaryUploadData(); });
+  server->on("/api/dictionaries/delete", HTTP_POST, [this] { handleDictionaryDelete(); });
 
   // OPDS server endpoints
   server->on("/api/opds", HTTP_GET, [this] { handleGetOpdsServers(); });
@@ -2263,4 +2311,210 @@ void CrossPointWebServer::handleFontConvert() {
   sdFontSystem.markRegistryDirty();
   server->send(200, "application/json", "{\"ok\":true}");
   LOG_DBG("WEB", "Convert font complete: family=%s, files=%zu/%zu", family.c_str(), downloadedCount, files.size());
+}
+
+void CrossPointWebServer::handleDictionariesPage() const {
+  sendHtmlContent(server.get(), DictionaryPageHtml, sizeof(DictionaryPageHtml));
+  LOG_DBG("WEB", "Served dictionaries page");
+}
+
+void CrossPointWebServer::handleDictionaryList() const {
+  // Unlike fonts' lazy refreshIfDirty(), DictionaryStore has no dirty flag --
+  // scan() is the only way to pick up an upload/delete since the last load,
+  // so this always does a fresh scan (bounded by MAX_SCAN_ENTRIES, same cost
+  // as opening the on-device Dictionary app).
+  DICTIONARIES.scan();
+
+  JsonDocument doc;
+  JsonArray arr = doc["dictionaries"].to<JsonArray>();
+
+  for (const auto& entry : DICTIONARIES.getEntries()) {
+    JsonObject dObj = arr.add<JsonObject>();
+    dObj["name"] = entry.name;
+    dObj["lang"] = entry.lang;
+    dObj["languageId"] = entry.languageId;
+    dObj["wordCount"] = entry.wordCount;
+    dObj["ifoPath"] = entry.ifoPath;
+
+    unsigned long totalSize = 0;
+    const std::string* paths[] = {&entry.ifoPath, &entry.idxPath, &entry.dictPath, &entry.synPath};
+    for (const std::string* path : paths) {
+      if (path->empty()) continue;
+      HalFile f;
+      if (Storage.openFileForRead("WEB", *path, f)) {
+        totalSize += static_cast<unsigned long>(f.size());
+        f.close();
+      }
+    }
+    dObj["size"] = totalSize;
+  }
+
+  String json;
+  serializeJson(doc, json);
+  server->send(200, "application/json", json);
+}
+
+void CrossPointWebServer::handleDictionaryUploadData() {
+  HTTPUpload& upload = server->upload();
+
+  switch (upload.status) {
+    case UPLOAD_FILE_START: {
+      esp_task_wdt_reset();
+      String languageId = server->arg("languageId");
+      dictionaryUpload.file = HalFile();
+      dictionaryUpload.languageId.clear();
+      dictionaryUpload.filePath.clear();
+      dictionaryUpload.valid = false;
+      dictionaryUpload.bytesWritten = 0;
+      dictionaryUpload.bufferPos = 0;
+
+      if (!isValidLanguageId(languageId.c_str())) {
+        LOG_ERR("WEB", "Invalid dictionary language id: %s", languageId.c_str());
+        break;
+      }
+
+      String filename = upload.filename;
+      filename.replace(' ', '_');
+      // Rejects path traversal and anything outside the StarDict extension
+      // whitelist -- see isValidDictionaryFilename()'s comment.
+      if (!isValidDictionaryFilename(filename.c_str())) {
+        LOG_ERR("WEB", "Invalid dictionary filename: %s", filename.c_str());
+        break;
+      }
+
+      dictionaryUpload.languageId = languageId.c_str();
+
+      char dirPath[128];
+      snprintf(dirPath, sizeof(dirPath), "%s/%s", DictionaryStore::DICTIONARY_ROOT, languageId.c_str());
+      if (!Storage.mkdir(dirPath)) {
+        LOG_ERR("WEB", "Failed to create dictionary language dir: %s", dirPath);
+        break;
+      }
+
+      char path[192];
+      snprintf(path, sizeof(path), "%s/%s", dirPath, filename.c_str());
+      dictionaryUpload.filePath = path;
+
+      if (!Storage.openFileForWrite("WEB", path, dictionaryUpload.file)) {
+        LOG_ERR("WEB", "Failed to open dictionary file for write: %s", path);
+        break;
+      }
+
+      dictionaryUpload.valid = true;
+      LOG_DBG("WEB", "Dictionary upload started: %s -> %s", filename.c_str(), path);
+      break;
+    }
+
+    case UPLOAD_FILE_WRITE: {
+      if (!dictionaryUpload.valid) break;
+      esp_task_wdt_reset();
+
+      size_t remaining = upload.currentSize;
+      const uint8_t* src = upload.buf;
+      while (remaining > 0) {
+        size_t space = DictionaryUploadState::BUFFER_SIZE - dictionaryUpload.bufferPos;
+        size_t chunk = (remaining < space) ? remaining : space;
+        memcpy(dictionaryUpload.buffer.data() + dictionaryUpload.bufferPos, src, chunk);
+        dictionaryUpload.bufferPos += chunk;
+        src += chunk;
+        remaining -= chunk;
+
+        if (dictionaryUpload.bufferPos >= DictionaryUploadState::BUFFER_SIZE) {
+          dictionaryUpload.file.write(dictionaryUpload.buffer.data(), dictionaryUpload.bufferPos);
+          dictionaryUpload.bytesWritten += dictionaryUpload.bufferPos;
+          dictionaryUpload.bufferPos = 0;
+          esp_task_wdt_reset();
+        }
+      }
+      break;
+    }
+
+    case UPLOAD_FILE_END: {
+      if (dictionaryUpload.valid && dictionaryUpload.bufferPos > 0) {
+        dictionaryUpload.file.write(dictionaryUpload.buffer.data(), dictionaryUpload.bufferPos);
+        dictionaryUpload.bytesWritten += dictionaryUpload.bufferPos;
+        dictionaryUpload.bufferPos = 0;
+      }
+      if (dictionaryUpload.file.isOpen()) {
+        dictionaryUpload.file.close();
+      }
+
+      if (!dictionaryUpload.valid && !dictionaryUpload.filePath.empty()) {
+        Storage.remove(dictionaryUpload.filePath.c_str());
+      }
+
+      LOG_DBG("WEB", "Dictionary upload end: valid=%d, %zu bytes", dictionaryUpload.valid,
+              dictionaryUpload.bytesWritten);
+      break;
+    }
+
+    case UPLOAD_FILE_ABORTED: {
+      if (dictionaryUpload.file) {
+        dictionaryUpload.file.close();
+      }
+      if (!dictionaryUpload.filePath.empty()) {
+        Storage.remove(dictionaryUpload.filePath.c_str());
+      }
+      dictionaryUpload.valid = false;
+      LOG_DBG("WEB", "Dictionary upload aborted");
+      break;
+    }
+  }
+}
+
+void CrossPointWebServer::handleDictionaryUpload() {
+  if (dictionaryUpload.valid) {
+    DICTIONARIES.scan();
+    server->send(200, "application/json", "{\"ok\":true}");
+    LOG_DBG("WEB", "Dictionary upload complete: %s", dictionaryUpload.filePath.c_str());
+  } else {
+    server->send(400, "application/json", "{\"error\":\"Invalid dictionary file\"}");
+  }
+}
+
+void CrossPointWebServer::handleDictionaryDelete() {
+  String body = server->arg("plain");
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, body);
+
+  if (err || !doc["ifoPath"].is<const char*>()) {
+    server->send(400, "application/json", "{\"error\":\"Invalid request\"}");
+    return;
+  }
+
+  const std::string ifoPath = doc["ifoPath"].as<const char*>();
+  DICTIONARIES.scan();
+  const DictionaryEntry* target = nullptr;
+  for (const auto& entry : DICTIONARIES.getEntries()) {
+    if (entry.ifoPath == ifoPath) {
+      target = &entry;
+      break;
+    }
+  }
+
+  if (!target) {
+    server->send(404, "application/json", "{\"error\":\"Dictionary not found\"}");
+    return;
+  }
+
+  // A language folder can hold more than one dictionary set, so only this
+  // entry's own files are removed -- never the whole directory (matching
+  // FontInstaller::deleteFamily()'s whole-directory removal would delete
+  // sibling dictionaries sharing the same languageId).
+  const std::string paths[] = {target->ifoPath, target->idxPath, target->dictPath, target->synPath};
+  DICTIONARIES.clearActiveIfMatches(ifoPath);
+  bool removedAny = false;
+  for (const auto& path : paths) {
+    if (path.empty()) continue;
+    if (Storage.remove(path.c_str())) removedAny = true;
+  }
+
+  if (removedAny) {
+    DICTIONARIES.scan();
+    server->send(200, "application/json", "{\"ok\":true}");
+    LOG_DBG("WEB", "Deleted dictionary: %s", ifoPath.c_str());
+  } else {
+    server->send(500, "application/json", "{\"error\":\"Delete failed\"}");
+    LOG_ERR("WEB", "Failed to delete dictionary: %s", ifoPath.c_str());
+  }
 }

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -117,6 +117,13 @@ class CrossPointWebServer {
   void handleFontConvert();
   void handleFontConvertUploadData();
 
+  // Dictionary management handlers
+  void handleDictionariesPage() const;
+  void handleDictionaryList() const;
+  void handleDictionaryUpload();
+  void handleDictionaryUploadData();
+  void handleDictionaryDelete();
+
   // Font upload state
   struct FontUploadState {
     HalFile file;
@@ -131,6 +138,24 @@ class CrossPointWebServer {
 
     FontUploadState() { buffer.resize(BUFFER_SIZE); }
   } fontUpload;
+
+  // Dictionary upload state. Unlike fonts (single-magic-bytes check), a
+  // StarDict set has no shared magic to validate on first chunk -- the
+  // per-extension whitelist and languageId sanitization happen in
+  // UPLOAD_FILE_START (see handleDictionaryUploadData()), so there is no
+  // magicChecked equivalent here.
+  struct DictionaryUploadState {
+    HalFile file;
+    std::string languageId;
+    std::string filePath;
+    bool valid = false;
+    size_t bytesWritten = 0;
+    static constexpr size_t BUFFER_SIZE = 4096;
+    std::vector<uint8_t> buffer;
+    size_t bufferPos = 0;
+
+    DictionaryUploadState() { buffer.resize(BUFFER_SIZE); }
+  } dictionaryUpload;
 
   // Convert-font upload state: the raw TTF/OTF is staged to a scratch path
   // (not installed as a font directly) before being relayed to foulad-ebooks.

--- a/src/network/html/DictionaryPage.html
+++ b/src/network/html/DictionaryPage.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Midad - Fonts</title>
+    <title>Midad - Dictionaries</title>
     <style>
       :root {
         --font-color: #171717;
@@ -87,16 +87,35 @@
         background-color: var(--accent-hover-color);
         color: var(--accent-text-color);
       }
-      .family {
+      .device-info {
+        color: var(--label-color);
+        font-size: 0.85em;
+        margin: -12px 0 20px;
+      }
+      .dict {
         border-bottom: 1px solid var(--border-color);
         padding: 12px 0;
         display: flex;
         justify-content: space-between;
         align-items: center;
+        gap: 12px;
       }
-      .family:last-child { border-bottom: none; }
-      .family-info { flex: 1; }
-      .family-meta { color: var(--label-color); font-size: 0.9em; }
+      .dict:last-child { border-bottom: none; }
+      .dict-badge {
+        flex: 0 0 auto;
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        font-size: 0.8em;
+        color: white;
+        text-transform: uppercase;
+      }
+      .dict-info { flex: 1; }
+      .dict-meta { color: var(--label-color); font-size: 0.9em; }
       .btn {
         padding: 6px 16px;
         border: none;
@@ -128,14 +147,7 @@
         color: var(--font-color);
       }
       .upload-form input[type="file"] { flex: 1; min-width: 200px; }
-      .upload-form select {
-        padding: 6px 10px;
-        border: 1px solid var(--border-color);
-        border-radius: 4px;
-        background: var(--bg);
-        color: var(--font-color);
-      }
-      #status, #convertStatus {
+      #status {
         margin-top: 10px;
         padding: 8px;
         border-radius: 4px;
@@ -153,46 +165,31 @@
       <a href="/">Home</a>
       <a href="/files">File Manager</a>
       <a href="/settings">Settings</a>
-      <a href="/fonts" class="active">Fonts</a>
-      <a href="/dictionaries">Dictionaries</a>
+      <a href="/fonts">Fonts</a>
+      <a href="/dictionaries" class="active">Dictionaries</a>
+    </div>
+
+    <p class="device-info">Serial # <span id="serial">...</span></p>
+
+    <div class="card">
+      <h2>Installed Dictionaries</h2>
+      <div id="dicts"><p class="empty">Loading...</p></div>
     </div>
 
     <div class="card">
-      <h2>Installed Fonts</h2>
-      <div id="families"><p class="empty">Loading...</p></div>
-    </div>
-
-    <div class="card">
-      <h2>Upload Font</h2>
+      <h2>Upload Dictionary</h2>
+      <p class="dict-meta" style="margin: 0 0 12px;">
+        Select every file of a StarDict set (.ifo, .idx, .dict or .dict.dz,
+        optional .syn) and give the language folder a short name -- dictionaries
+        that share a folder appear together on the device.
+      </p>
       <form class="upload-form" id="uploadForm">
-        <input type="file" id="fontFiles" webkitdirectory directory multiple required />
+        <input type="text" id="languageId" placeholder="Language folder, e.g. en-ar" required />
+        <input type="file" id="dictFiles" multiple required />
         <button type="submit" class="btn btn-primary">Upload</button>
       </form>
-      <p id="pickedInfo" class="family-meta" style="margin: 8px 0 0;"></p>
+      <p id="pickedInfo" class="dict-meta" style="margin: 8px 0 0;"></p>
       <div id="status"></div>
-    </div>
-
-    <div class="card">
-      <h2>Convert a Font</h2>
-      <p class="family-meta" style="margin: 0 0 12px;">
-        Requires the device to be connected to the internet.
-      </p>
-      <form class="upload-form" id="convertForm">
-        <input type="file" id="convertFontFile" accept=".ttf,.otf" required />
-        <input type="text" id="convertFamilyName" placeholder="Font name" required />
-        <select id="convertLanguage">
-          <option value="arabic">Arabic</option>
-          <option value="english">English</option>
-        </select>
-        <details style="margin: 8px 0;">
-          <summary class="family-meta" style="cursor: pointer;">Optional styles (Bold / Italic / Bold Italic)</summary>
-          <label class="family-meta">Bold: <input type="file" id="convertFontBold" accept=".ttf,.otf" /></label><br />
-          <label class="family-meta">Italic: <input type="file" id="convertFontItalic" accept=".ttf,.otf" /></label><br />
-          <label class="family-meta">Bold Italic: <input type="file" id="convertFontBoldItalic" accept=".ttf,.otf" /></label>
-        </details>
-        <button type="submit" class="btn btn-primary">Convert</button>
-      </form>
-      <div id="convertStatus"></div>
     </div>
 
   <script>
@@ -202,44 +199,64 @@
       return bytes + ' B';
     }
 
-    async function loadFonts() {
-      const el = document.getElementById('families');
+    // Deterministic color from a language code, so the same code always gets
+    // the same badge without shipping any flag/icon assets.
+    function colorForLang(code) {
+      let hash = 0;
+      for (const c of (code || '?')) hash = (hash * 31 + c.charCodeAt(0)) & 0xffffffff;
+      const hue = Math.abs(hash) % 360;
+      return 'hsl(' + hue + ', 55%, 42%)';
+    }
+
+    function badgeText(code) {
+      if (!code) return '?';
+      return code.replace(/[^A-Za-z]/g, '').slice(0, 3) || '?';
+    }
+
+    async function loadDictionaries() {
+      const el = document.getElementById('dicts');
       try {
-        const res = await fetch('/api/fonts');
+        const res = await fetch('/api/dictionaries');
         const data = await res.json();
-        // Build rows with DOM APIs and textContent so on-device family names
-        // (which can contain arbitrary characters) cannot break markup or
-        // execute script via innerHTML / inline onclick interpolation.
+        // Build rows with DOM APIs and textContent so on-device dictionary
+        // names (arbitrary characters) cannot break markup or execute script.
         el.replaceChildren();
-        if (!data.families || data.families.length === 0) {
+        if (!data.dictionaries || data.dictionaries.length === 0) {
           const p = document.createElement('p');
           p.className = 'empty';
-          p.textContent = 'No fonts installed';
+          p.textContent = 'No dictionaries installed';
           el.appendChild(p);
           return;
         }
-        for (const f of data.families) {
+        for (const d of data.dictionaries) {
           const row = document.createElement('div');
-          row.className = 'family';
+          row.className = 'dict';
+
+          const badge = document.createElement('div');
+          badge.className = 'dict-badge';
+          badge.style.background = colorForLang(d.lang);
+          badge.textContent = badgeText(d.lang);
+          row.appendChild(badge);
 
           const info = document.createElement('div');
-          info.className = 'family-info';
+          info.className = 'dict-info';
           const h3 = document.createElement('h3');
-          h3.textContent = f.name;
+          h3.textContent = d.name;
           info.appendChild(h3);
           const meta = document.createElement('span');
-          meta.className = 'family-meta';
-          const sizes = (f.sizes || []).join(', ');
-          const filesSizes = (f.files || []).map(fi => formatSize(fi.size)).join(' + ');
-          meta.textContent = sizes + 'pt · ' + filesSizes;
+          meta.className = 'dict-meta';
+          meta.textContent = d.languageId + ' · ' + d.wordCount.toLocaleString() + ' words · ' + formatSize(d.size);
           info.appendChild(meta);
 
           const btn = document.createElement('button');
           btn.className = 'btn btn-danger';
           btn.textContent = 'Delete';
-          // Capture name in the closure rather than interpolating into onclick.
-          const familyName = f.name;
-          btn.addEventListener('click', () => deleteFamily(familyName));
+          // Keyed on ifoPath, not name/languageId: a display name (from the
+          // .ifo's bookname field) isn't necessarily the filename, so it can't
+          // be used to reconstruct which files to remove.
+          const ifoPath = d.ifoPath;
+          const dictName = d.name;
+          btn.addEventListener('click', () => deleteDictionary(ifoPath, dictName));
 
           row.appendChild(info);
           row.appendChild(btn);
@@ -249,22 +266,22 @@
         el.replaceChildren();
         const p = document.createElement('p');
         p.className = 'empty';
-        p.textContent = 'Failed to load font list';
+        p.textContent = 'Failed to load dictionary list';
         el.appendChild(p);
       }
     }
 
-    async function deleteFamily(name) {
-      if (!confirm('Delete font family "' + name + '"?')) return;
+    async function deleteDictionary(ifoPath, name) {
+      if (!confirm('Delete dictionary "' + name + '"?')) return;
       const status = document.getElementById('status');
       status.className = '';
       status.style.display = 'block';
       status.textContent = 'Deleting ' + name + '...';
       try {
-        const res = await fetch('/api/fonts/delete', {
+        const res = await fetch('/api/dictionaries/delete', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({family: name})
+          body: JSON.stringify({ifoPath: ifoPath})
         });
         if (res.ok) {
           status.className = 'status-ok';
@@ -277,60 +294,53 @@
         status.className = 'status-err';
         status.textContent = 'Delete error: ' + err.message;
       }
-      await loadFonts();
+      await loadDictionaries();
     }
 
-    // Derive family name from a .cpfont filename: take everything before the
-    // last '-' or '_' (that separator precedes the size suffix, e.g. Bookerly_12.cpfont).
-    function familyFromFilename(name) {
-      const stem = name.replace(/\.cpfont$/i, '');
-      const cut = Math.max(stem.lastIndexOf('-'), stem.lastIndexOf('_'));
-      return cut > 0 ? stem.slice(0, cut) : stem;
-    }
-
-    // Sanitize to match firmware's [A-Za-z0-9_-]+ pattern.
-    function sanitizeFamily(raw) {
+    // Sanitize to match firmware's [A-Za-z0-9_-]+ pattern for the folder name.
+    function sanitizeLanguageId(raw) {
       return raw.replace(/[^A-Za-z0-9_-]/g, '_');
     }
 
-    function cpfontFilesOnly(fileList) {
-      return Array.from(fileList).filter(f => /\.cpfont$/i.test(f.name));
+    const DICT_EXT_RE = /\.(ifo|idx|dict|dict\.dz|syn)$/i;
+    function dictFilesOnly(fileList) {
+      return Array.from(fileList).filter(f => DICT_EXT_RE.test(f.name));
     }
 
-    document.getElementById('fontFiles').addEventListener('change', function() {
+    document.getElementById('dictFiles').addEventListener('change', function() {
       const info = document.getElementById('pickedInfo');
-      const files = cpfontFilesOnly(this.files);
+      const files = dictFilesOnly(this.files);
       if (files.length === 0) {
-        info.textContent = 'No .cpfont files found in the selected folder.';
+        info.textContent = 'No StarDict files (.ifo/.idx/.dict/.syn) found in the selection.';
         return;
       }
-      const family = sanitizeFamily(familyFromFilename(files[0].name));
-      info.textContent = files.length + ' file' + (files.length === 1 ? '' : 's') +
-        ' → family "' + family + '"';
+      info.textContent = files.length + ' file' + (files.length === 1 ? '' : 's') + ' selected';
     });
 
     document.getElementById('uploadForm').addEventListener('submit', async function(e) {
       e.preventDefault();
       const status = document.getElementById('status');
-      const files = cpfontFilesOnly(document.getElementById('fontFiles').files);
+      const languageId = sanitizeLanguageId(document.getElementById('languageId').value.trim());
+      const files = dictFilesOnly(document.getElementById('dictFiles').files);
+
+      if (!languageId) {
+        status.className = 'status-err';
+        status.style.display = 'block';
+        status.textContent = 'Enter a language folder name.';
+        return;
+      }
       if (files.length === 0) {
         status.className = 'status-err';
         status.style.display = 'block';
-        status.textContent = 'No .cpfont files selected.';
+        status.textContent = 'No StarDict files selected.';
         return;
       }
-
-      // A directory picker may include files from multiple family subfolders.
-      // Reject that up front — otherwise files[0]'s family is silently reused
-      // for every upload, corrupting the install layout.
-      const families = [...new Set(files.map(f => sanitizeFamily(familyFromFilename(f.name))))];
-      if (families.length !== 1) {
+      if (!files.some(f => /\.ifo$/i.test(f.name))) {
         status.className = 'status-err';
         status.style.display = 'block';
-        status.textContent = 'Please select files from a single font family.';
+        status.textContent = 'Selection is missing the .ifo file.';
         return;
       }
-      const family = families[0];
 
       status.className = '';
       status.style.display = 'block';
@@ -339,21 +349,21 @@
       for (const file of files) {
         status.textContent = 'Uploading ' + (uploaded + 1) + '/' + files.length + ': ' + file.name;
         const formData = new FormData();
-        formData.append('family', family);
+        formData.append('languageId', languageId);
         formData.append('file', file, file.name);
         try {
-          const res = await fetch('/api/fonts/upload', { method: 'POST', body: formData });
+          const res = await fetch('/api/dictionaries/upload', { method: 'POST', body: formData });
           const data = await res.json();
           if (!data.ok) {
             status.className = 'status-err';
             status.textContent = 'Failed on ' + file.name + ': ' + (data.error || 'unknown error');
-            await loadFonts();
+            await loadDictionaries();
             return;
           }
         } catch (err) {
           status.className = 'status-err';
           status.textContent = 'Upload error on ' + file.name + ': ' + err.message;
-          await loadFonts();
+          await loadDictionaries();
           return;
         }
         uploaded++;
@@ -361,69 +371,25 @@
 
       status.className = 'status-ok';
       status.textContent = 'Uploaded ' + uploaded + ' file' + (uploaded === 1 ? '' : 's') +
-        ' to family "' + family + '".';
-      await loadFonts();
+        ' to "' + languageId + '".';
+      document.getElementById('languageId').value = '';
+      document.getElementById('dictFiles').value = '';
+      document.getElementById('pickedInfo').textContent = '';
+      await loadDictionaries();
     });
 
-    document.getElementById('convertForm').addEventListener('submit', async function(e) {
-      e.preventDefault();
-      const status = document.getElementById('convertStatus');
-      const fileInput = document.getElementById('convertFontFile');
-      const family = sanitizeFamily(document.getElementById('convertFamilyName').value.trim());
-      const language = document.getElementById('convertLanguage').value;
-
-      if (!fileInput.files[0] || !family) {
-        status.className = 'status-err';
-        status.style.display = 'block';
-        status.textContent = 'Pick a .ttf/.otf file and enter a font name.';
-        return;
-      }
-
-      status.className = '';
-      status.style.display = 'block';
-      status.textContent = 'Converting... this can take a couple of minutes. Keep this page open.';
-
-      // Order matters: the device reads the 'family'/'language' fields in the
-      // WebServer upload callback that fires WHILE the 'font' file part streams,
-      // so they must appear BEFORE the file in the multipart body or they read
-      // back empty (device rejects with "Invalid font file, family name, or
-      // language"). Matches the working /api/fonts/upload form above.
-      const formData = new FormData();
-      formData.append('family', family);
-      formData.append('language', language);
-      formData.append('font', fileInput.files[0], fileInput.files[0].name);
-      // Optional style files -- the device relays each to the conversion
-      // service, which packs all supplied styles into one multi-style family.
-      const styleInputs = [
-        ['font_bold', 'convertFontBold'],
-        ['font_italic', 'convertFontItalic'],
-        ['font_bolditalic', 'convertFontBoldItalic'],
-      ];
-      for (const [field, id] of styleInputs) {
-        const input = document.getElementById(id);
-        if (input && input.files[0]) formData.append(field, input.files[0], input.files[0].name);
-      }
-
+    async function loadSerial() {
       try {
-        const res = await fetch('/api/fonts/convert', { method: 'POST', body: formData });
+        const res = await fetch('/api/status');
         const data = await res.json();
-        if (data.ok) {
-          status.className = 'status-ok';
-          status.textContent = 'Converted and installed as "' + family + '".';
-          fileInput.value = '';
-          document.getElementById('convertFamilyName').value = '';
-        } else {
-          status.className = 'status-err';
-          status.textContent = data.error || 'Conversion failed.';
-        }
-      } catch (err) {
-        status.className = 'status-err';
-        status.textContent = 'Conversion error: ' + err.message;
+        document.getElementById('serial').textContent = data.serial;
+      } catch (e) {
+        document.getElementById('serial').textContent = 'unknown';
       }
-      await loadFonts();
-    });
+    }
 
-    loadFonts();
+    loadSerial();
+    loadDictionaries();
   </script>
   </body>
 </html>

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1528,6 +1528,7 @@
   <a href="/files" class="active">File Manager</a>
   <a href="/settings">Settings</a>
   <a href="/fonts">Fonts</a>
+  <a href="/dictionaries">Dictionaries</a>
 </div>
 
 <div class="page-header">

--- a/src/network/html/HomePage.html
+++ b/src/network/html/HomePage.html
@@ -122,6 +122,7 @@
       <a href="/files">File Manager</a>
       <a href="/settings">Settings</a>
       <a href="/fonts">Fonts</a>
+      <a href="/dictionaries">Dictionaries</a>
     </div>
 
     <div class="card">

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -306,6 +306,7 @@
     <a href="/files">File Manager</a>
     <a href="/settings" class="active">Settings</a>
     <a href="/fonts">Fonts</a>
+    <a href="/dictionaries">Dictionaries</a>
   </div>
 
   <div id="message" class="message"></div>


### PR DESCRIPTION
## Summary

Task #12 from the plan ("dictionary web UI parity"). Turned out there's no upstream CrossPoint dictionary web page to reach parity with — this fork's dictionary feature was ported from a different project (`cpr-vcodex`), and neither it nor upstream ever had browser-based dictionary management. The real reference was this fork's own **Fonts** page, which this closely mirrors.

- New `/dictionaries` page + `/api/dictionaries` (list), `/api/dictionaries/upload` (multipart upload), `/api/dictionaries/delete`.
- **Upload**: validates the language-folder name and StarDict file extensions (`.ifo/.idx/.dict/.dict.dz/.syn`) with the same path-traversal-safe discipline as `FontInstaller::isValidFamilyName`/`isValidCpfontFilename`.
- **Delete**: keyed on `ifoPath` (not name/languageId) — a dictionary's display name comes from its `.ifo` bookname field and isn't necessarily its filename, and a language folder can hold multiple dictionary sets, so only the target entry's own files are removed, never the whole folder.
- **Image previews**: dictionary files carry no image metadata and the download catalog has no image field, so per your call there's nothing to fetch — a small per-language color badge is generated client-side from a hash of the StarDict `lang` code instead. Zero server changes, zero firmware flash cost.
- **Serial number**: reused the existing `/api/status` endpoint, same pattern as the Home page.
- Added the new page to every existing page's nav-links.

## A real gap found and documented

New routes on `/dictionaries` and `/api/dictionaries` 404 in the simulator even though `/api/status` and other long-standing routes work — turns out `crosspoint-simulator` vendors a **separate, out-of-sync copy** of `CrossPointWebServer.cpp` (confirmed via `grep` on the simulator's vendored file: zero matches for the new symbols) rather than compiling the firmware's own version. This isn't a one-line HAL-stub patch like the other simulator gotchas — syncing the simulator's copy is real effort disproportionate to most web-UI changes. Documented in `.skills/SKILL.md` so a future session doesn't chase this as a firmware bug.

## Test plan
- [x] `pio run -e default` — builds clean
- [x] `pio check --skip-packages -e default` — no cppcheck defects
- [x] `clang-format` on touched files only — no unintended reformatting
- [x] Confirmed the HTML→generated-header build step picked up the new page automatically (`DictionaryPageHtml.generated.h` produced by the existing `pio run` pre-build step)
- [ ] HTTP-level testing wasn't possible in the simulator (see above) — new handlers closely mirror the already-shipped, working font-management handlers (same buffering/validation/JSON shape), which reduces but doesn't eliminate the risk of skipping that. **On-device verification needed**: load `/dictionaries`, upload a real StarDict set, confirm it appears in the on-device Dictionary app, delete it via the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e