### PR TITLE
fix: preselect Library on Home after leaving the OPDS browser

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -277,6 +277,8 @@ void ActivityManager::goHome(HomeMenuItem initialMenuItem) {
       initialMenuItem = HomeMenuItem::SETTINGS_MENU;
     } else if (activityName == "FileBrowser") {
       initialMenuItem = HomeMenuItem::FILE_BROWSER;
+    } else if (activityName == "OpdsBookBrowser") {
+      initialMenuItem = HomeMenuItem::FOULAD_EBOOKS;
     }
   }
   replaceActivity(std::make_unique<HomeActivity>(renderer, mappedInput, initialMenuItem));


### PR DESCRIPTION
## Summary
Found while investigating a verify-list item ("back-on-home vs back-to-browser comparison"). `ActivityManager::goHome()`'s activity-name switch preselects the right Home row when leaving RecentBooks/Settings/FileBrowser, but the `OpdsBookBrowser` branch was missing — dropped at some point when `HomeMenuItem::OPDS_BROWSER` was renamed to `FOULAD_EBOOKS`, with no matching `else if` added back.

Effect: pressing Back directly from the OPDS/Library browser lands on Home with nothing preselected, instead of highlighting the Library row like every other section does. Matches upstream CrossPoint's equivalent branch in `ActivityManager::goHome()`.

(Note: the broader "does Back behave differently after opening a book from Home vs. Library" question this verify-list item was originally about checked out fine — both paths use the same `replaceActivity`-based `goToReader()`/Back-to-`onGoHome()` flow, identically. This fix is a narrower, separate gap the investigation surfaced along the way.)

## Test plan
- [x] `pio run -e default` — builds clean
- [x] `pio check --skip-packages -e default` — no cppcheck defects
- [x] `clang-format` on touched file — no unintended reformatting
- [ ] On-device: open the OPDS/Library browser from Home, press Back without opening a book, confirm the Library row is now highlighted on Home (previously: nothing highlighted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e