### PR TITLE
feat: point-size font selection

### DIFF
--- a/lib/EpdFont/SdCardFontManager.cpp
+++ b/lib/EpdFont/SdCardFontManager.cpp
@@ -28,16 +28,13 @@ int SdCardFontManager::computeFontId(uint32_t contentHash, const char* familyNam
   return id != 0 ? id : 1;  // 0 is reserved as "not found" sentinel
 }
 
-bool SdCardFontManager::loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t fontSizeEnum) {
+bool SdCardFontManager::loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t pointSize) {
   // Unload any previously loaded family first
   if (!loadedFamilyName_.empty()) {
     unloadAll(renderer);
   }
 
-  // Select the physical point size closest to the built-in reader sizes. Some
-  // CJK font packs only ship larger sizes, so ordinal selection can make
-  // MEDIUM load 18pt+ and produce oversized pages on small devices.
-  const SdCardFontFileInfo* selected = family.findClosestReaderSize(fontSizeEnum);
+  const SdCardFontFileInfo* selected = family.findNearestSize(pointSize);
   if (!selected) {
     LOG_ERR("SDMGR", "Family %s has no files to load", family.name.c_str());
     return false;
@@ -66,8 +63,8 @@ bool SdCardFontManager::loadFamily(const SdCardFontFamilyInfo& family, GfxRender
   renderer.registerSdCardFont(fontId, font);
   loaded_.push_back({font, fontId, selected->pointSize});
 
-  LOG_DBG("SDMGR", "Loaded %s size=%u id=%d styles=%u (sizeEnum=%u)", selected->path.c_str(), selected->pointSize,
-          fontId, font->styleCount(), fontSizeEnum);
+  LOG_DBG("SDMGR", "Loaded %s size=%u id=%d styles=%u (wanted=%u)", selected->path.c_str(), selected->pointSize, fontId,
+          font->styleCount(), pointSize);
 
   EpdFontFamily fontFamily(font->getEpdFont(0), font->getEpdFont(1), font->getEpdFont(2), font->getEpdFont(3));
   renderer.insertFont(fontId, fontFamily);

--- a/lib/EpdFont/SdCardFontManager.h
+++ b/lib/EpdFont/SdCardFontManager.h
@@ -15,12 +15,11 @@ class SdCardFontManager {
   SdCardFontManager(const SdCardFontManager&) = delete;
   SdCardFontManager& operator=(const SdCardFontManager&) = delete;
 
-  // Load the font file whose physical point size is closest to the reader
-  // fontSizeEnum (SMALL=12, MEDIUM=14, LARGE=16, EXTRA_LARGE=18). Only one
-  // .cpfont file is loaded; other sizes remain on disk. This keeps resident
-  // interval + kern/ligature tables to one size's worth of memory.
+  // Load the font file whose physical point size is closest to `pointSize`.
+  // Only one .cpfont file is loaded; other sizes remain on disk. This keeps
+  // resident interval + kern/ligature tables to one size's worth of memory.
   // Returns true on success.
-  bool loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t fontSizeEnum);
+  bool loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t pointSize);
 
   // Unload everything, unregister from renderer.
   void unloadAll(GfxRenderer& renderer);

--- a/lib/EpdFont/SdCardFontRegistry.cpp
+++ b/lib/EpdFont/SdCardFontRegistry.cpp
@@ -15,52 +15,14 @@ const SdCardFontFileInfo* SdCardFontFamilyInfo::findFile(uint8_t size, uint8_t s
   return nullptr;
 }
 
-const SdCardFontFileInfo* SdCardFontFamilyInfo::findClosestReaderSize(const uint8_t fontSizeEnum,
-                                                                      const uint8_t style) const {
-  if (files.empty()) return nullptr;
-
-  // Collect sizes matching the requested style, sorted ascending.
-  std::vector<uint8_t> sizes;
-  for (const auto& f : files) {
-    if (f.style != style) continue;
-    sizes.push_back(f.pointSize);
-  }
-  if (sizes.empty()) return nullptr;
-  std::sort(sizes.begin(), sizes.end());
-
-  // When the family provides at least 4 sizes, use ordinal (index-based)
-  // selection so custom-built font sets (e.g. 10/12/14/16) map SMALL to
-  // the smallest file, not to a hardcoded 12pt target.
-  if (sizes.size() >= 4) {
-    uint8_t idx = fontSizeEnum;
-    if (idx >= sizes.size()) idx = sizes.size() - 1;
-    return findFile(sizes[idx], style);
-  }
-
-  // Fewer sizes than enum slots (e.g. CJK packs with only 2-3 sizes):
-  // fall back to closest-match against the built-in reader targets.
-  uint8_t target = 14;
-  switch (fontSizeEnum) {
-    case 0:
-      target = 12;
-      break;
-    case 2:
-      target = 16;
-      break;
-    case 3:
-      target = 18;
-      break;
-    case 1:
-    default:
-      target = 14;
-      break;
-  }
-
+const SdCardFontFileInfo* SdCardFontFamilyInfo::findNearestSize(const uint8_t pointSize, const uint8_t style) const {
+  // The reader stores an actual point size, so an exact match is the norm and
+  // falls out of the delta search below (delta 0).
   const SdCardFontFileInfo* best = nullptr;
   uint8_t bestDelta = 255;
   for (const auto& f : files) {
     if (f.style != style) continue;
-    const uint8_t delta = f.pointSize > target ? f.pointSize - target : target - f.pointSize;
+    const uint8_t delta = f.pointSize > pointSize ? f.pointSize - pointSize : pointSize - f.pointSize;
     if (!best || delta < bestDelta || (delta == bestDelta && f.pointSize < best->pointSize)) {
       best = &f;
       bestDelta = delta;

--- a/lib/EpdFont/SdCardFontRegistry.h
+++ b/lib/EpdFont/SdCardFontRegistry.h
@@ -18,7 +18,10 @@ struct SdCardFontFamilyInfo {
   std::vector<SdCardFontFileInfo> files;
 
   const SdCardFontFileInfo* findFile(uint8_t size, uint8_t style = 0) const;
-  const SdCardFontFileInfo* findClosestReaderSize(uint8_t fontSizeEnum, uint8_t style = 0) const;
+  // Nearest-match lookup by actual point size (not an enum slot) -- an exact
+  // match is the norm and falls out of the delta search at delta 0. Ties
+  // resolve to the smaller size.
+  const SdCardFontFileInfo* findNearestSize(uint8_t pointSize, uint8_t style = 0) const;
   bool hasSize(uint8_t size) const;
   std::vector<uint8_t> availableSizes() const;
 };

--- a/src/ArabicFontSystem.cpp
+++ b/src/ArabicFontSystem.cpp
@@ -39,6 +39,27 @@ constexpr int
 // pinned Arabic body text to 12pt UI type for anyone reading with an SD-card
 // Latin font -- Arabic Font Size appeared to do nothing (user report, and the
 // reason SD Arabic overrides ignoring the size setting went unnoticed too).
+// SdCardFontManager::loadFamily() now takes a physical point size (the LATIN
+// reader's point-size migration -- see ReaderFontSizes.h), not a FONT_SIZE enum
+// slot. Arabic sizing is UNTOUCHED by that migration -- arabicFontSize /
+// effArabicFontSize() still return a SMALL/MEDIUM/LARGE/EXTRA_LARGE slot -- so
+// translate to the slot's target point size here rather than changing what
+// effArabicFontSize() returns. Matches kBuiltinArabicReadingFontIds' own column
+// order (12/14/16/18 = Small/Medium/Large/X-Large).
+uint8_t arabicSizeEnumToPointSize(const uint8_t sizeEnum) {
+  switch (sizeEnum) {
+    case CrossPointSettings::SMALL:
+      return 12;
+    case CrossPointSettings::LARGE:
+      return 16;
+    case CrossPointSettings::EXTRA_LARGE:
+      return 18;
+    case CrossPointSettings::MEDIUM:
+    default:
+      return 14;
+  }
+}
+
 void applyArabicMappings(GfxRenderer& renderer, const int readingFontId) {
   renderer.clearArabicFontIdMappings();
   // matchLatinBaseline=true: UI labels sit on the requested Latin font's baseline so
@@ -137,7 +158,7 @@ void ArabicFontSystem::ensureLoaded(GfxRenderer& renderer) {
   }
 
   const auto* family = registry_.findFamily(wantedFamily);
-  if (family && manager_.loadFamily(*family, renderer, SETTINGS.effArabicFontSize())) {
+  if (family && manager_.loadFamily(*family, renderer, arabicSizeEnumToPointSize(SETTINGS.effArabicFontSize()))) {
     LOG_DBG("ARFS", "Loaded Arabic font family: %s (sizeEnum=%u)", wantedFamily, SETTINGS.effArabicFontSize());
     loadedSdSizeEnum_ = SETTINGS.effArabicFontSize();
     applyArabicMappings(renderer, manager_.getFontId(wantedFamily));

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -8,10 +8,12 @@
 #include <Serialization.h>
 
 #include <cstring>
+#include <iterator>
 #include <mutex>
 #include <string>
 
 #include "I18nKeys.h"
+#include "ReaderFontSizes.h"
 #include "SettingsList.h"
 #include "fontIds.h"
 
@@ -167,8 +169,10 @@ void CrossPointSettings::toJson(JsonDocument& doc) const {
   doc["frontButtonConfirm"] = frontButtonConfirm;
   doc["frontButtonLeft"] = frontButtonLeft;
   doc["frontButtonRight"] = frontButtonRight;
-  // Font family — uses dynamic getter/setter in SettingsList so the generic loop skips it.
+  // Font family and size — both use dynamic getter/setters in SettingsList (the
+  // option lists depend on the SD font registry), so the generic loop skips them.
   doc["fontFamily"] = fontFamily;
+  doc["fontSize"] = fontPointSize;
   // SD card font family name — not in SettingsList, save manually
   if (sdFontFamilyName[0] != '\0') {
     doc["sdFontFamilyName"] = sdFontFamilyName;
@@ -258,6 +262,17 @@ bool CrossPointSettings::fromJson(JsonVariantConst doc) {
   frontButtonRight =
       clamp(doc["frontButtonRight"] | (uint8_t)FRONT_HW_RIGHT, FRONT_BUTTON_HARDWARE_COUNT, FRONT_HW_RIGHT);
   CrossPointSettings::validateFrontButtonMapping(*this);
+
+  // Reader font size — an actual point size since the point-size migration. Files
+  // written before it hold the old SMALL/MEDIUM/LARGE/EXTRA_LARGE slot in 0..3; no
+  // font is renderable at those sizes, so the range is unambiguous and folds to the
+  // point sizes those slots used to mean. Drop this once pre-migration upgrades are done.
+  uint8_t storedFontSize = doc["fontSize"] | DEFAULT_FONT_POINT_SIZE;
+  if (storedFontSize <= LEGACY_FONT_SIZE_MAX) {
+    storedFontSize = 12 + storedFontSize * 2;  // 0,1,2,3 -> 12,14,16,18
+    _needsResaveAfterLoad = true;
+  }
+  fontPointSize = storedFontSize;
 
   // Font family — uses dynamic getter/setter in SettingsList so the generic loop skips it.
   const uint8_t storedFontFamily = doc["fontFamily"] | (uint8_t)0;
@@ -418,7 +433,14 @@ bool CrossPointSettings::loadFromBinaryFile() {
       }
     }
     if (++settingsRead >= fileSettingsCount) break;
-    readAndValidate(inputFile, fontSize, FONT_SIZE_COUNT);
+    {
+      // This binary format predates the point-size migration: the on-disk byte
+      // is the old SMALL/MEDIUM/LARGE/EXTRA_LARGE slot (0..3), same fold as
+      // fromJson()'s legacy handling.
+      uint8_t legacyFontSize = MEDIUM;
+      readAndValidate(inputFile, legacyFontSize, FONT_SIZE_COUNT);
+      fontPointSize = 12 + legacyFontSize * 2;  // 0,1,2,3 -> 12,14,16,18
+    }
     if (++settingsRead >= fileSettingsCount) break;
     readAndValidate(inputFile, lineSpacing, LINE_COMPRESSION_COUNT);
     if (++settingsRead >= fileSettingsCount) break;
@@ -522,6 +544,13 @@ int CrossPointSettings::getRefreshFrequency() const {
   }
 }
 
+void CrossPointSettings::clearSdFontFamily() {
+  sdFontFamilyName[0] = '\0';
+  fontPointSize =
+      snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), fontPointSize);
+  saveToFile();
+}
+
 int CrossPointSettings::getReaderFontId() const {
   // Check SD card font first (eff* so a per-book override wins -- see the
   // per-book overrides block in CrossPointSettings.h)
@@ -532,28 +561,20 @@ int CrossPointSettings::getReaderFontId() const {
     // Fall through to built-in if SD font not found
   }
 
-  if (effFontFamily() == LEXENDDECA) {
-    switch (effFontSize()) {
-      case SMALL:
-        return LEXENDDECA_12_FONT_ID;
-      case MEDIUM:
-      default:
-        return LEXENDDECA_14_FONT_ID;
-      case LARGE:
-        return LEXENDDECA_16_FONT_ID;
-      case EXTRA_LARGE:
-        return LEXENDDECA_18_FONT_ID;
-    }
-  }
-  switch (effFontSize()) {
-    case SMALL:
+  // Both FONT_FAMILY values resolve here identically: Bitter's glyph data was
+  // stripped from flash (see FONT_FAMILY's comment in CrossPointSettings.h), so
+  // BITTER renders as Lexend Deca too. Only the point size varies.
+  const uint8_t pt =
+      snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), effFontSize());
+  switch (pt) {
+    case 12:
       return LEXENDDECA_12_FONT_ID;
-    case MEDIUM:
+    case 16:
+      return LEXENDDECA_16_FONT_ID;
+    case 18:
+      return LEXENDDECA_18_FONT_ID;
+    case 14:
     default:
       return LEXENDDECA_14_FONT_ID;
-    case LARGE:
-      return LEXENDDECA_16_FONT_ID;
-    case EXTRA_LARGE:
-      return LEXENDDECA_18_FONT_ID;
   }
 }

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -138,8 +138,15 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   enum FONT_FAMILY { BITTER = 0, LEXENDDECA = 1, FONT_FAMILY_COUNT };
   static constexpr uint8_t LEGACY_OPENDYSLEXIC = 2;
   static constexpr uint8_t BUILTIN_FONT_COUNT = FONT_FAMILY_COUNT;
-  // Font size options
+  // The LATIN reading font size is a point size (fontPointSize below), not this
+  // enum -- see ReaderFontSizes.h. This enum survives ONLY because arabicFontSize
+  // / bookArabicFontSize still use it (the Arabic size picker stays a fixed
+  // 4-slot SMALL/MEDIUM/LARGE/EXTRA_LARGE choice). Legacy 1.4-and-earlier files
+  // stored the Latin size in this same 0..3 shape too; fromJson() folds that
+  // range up into a point size (see LEGACY_FONT_SIZE_MAX).
   enum FONT_SIZE { SMALL = 0, MEDIUM = 1, LARGE = 2, EXTRA_LARGE = 3, FONT_SIZE_COUNT };
+  static constexpr uint8_t LEGACY_FONT_SIZE_MAX = 3;
+  static constexpr uint8_t DEFAULT_FONT_POINT_SIZE = 14;
   // Arabic reading-font family options (built-in only; SD card fonts use
   // sdArabicFontFamilyName). Independent of FONT_FAMILY/fontFamily above -- see
   // ArabicFontSystem. Reuses FONT_SIZE (Small/Medium/Large/X-Large) for arabicFontSize.
@@ -269,7 +276,12 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   uint8_t frontButtonRight = FRONT_HW_RIGHT;
   // Reader font settings
   uint8_t fontFamily = BITTER;
-  uint8_t fontSize = MEDIUM;
+  // Point size of the LATIN reading font. Only sizes the active family actually
+  // ships are selectable in the UI (see ReaderFontSizes.h / SettingsList.h's
+  // buildFontSizeSetting()); SdCardFontSystem::ensureLoaded() snaps this to the
+  // nearest available size (and persists the snap) whenever the family changes.
+  // The Arabic reading font size is unaffected -- see arabicFontSize below.
+  uint8_t fontPointSize = DEFAULT_FONT_POINT_SIZE;
   uint8_t lineSpacing = NORMAL;
   uint8_t paragraphAlignment = JUSTIFIED;
   // Auto-sleep timeout setting (default 10 minutes). Legacy sleepTimeout enum values are migration-only.
@@ -412,7 +424,13 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   // font family even when the global setting points at an SD family.
   static constexpr uint8_t BOOK_NO_OVERRIDE = 0xFF;
   static constexpr char BOOK_FORCE_BUILTIN_FAMILY[2] = "\x01";
+  // A point size (see fontPointSize above), NOT a FONT_SIZE enum slot, despite
+  // the shared BOOK_NO_OVERRIDE sentinel shape. snapToNearestPointSize() at
+  // render/load time keeps an override that the active family can't render
+  // exactly (e.g. after switching to an SD family with a sparser size set) safe.
   uint8_t bookFontSize = BOOK_NO_OVERRIDE;
+  // Arabic reading-font size override -- still a FONT_SIZE enum slot, unlike
+  // bookFontSize above. Arabic sizing is untouched by the point-size migration.
   uint8_t bookArabicFontSize = BOOK_NO_OVERRIDE;
   // Which BUILT-IN Arabic family this book uses when the built-in path is
   // active (bookSdArabicFontFamilyName forced-builtin or global has no SD
@@ -429,7 +447,11 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   char bookSdFontFamilyName[32] = "";
   char bookSdArabicFontFamilyName[32] = "";
 
-  uint8_t effFontSize() const { return bookFontSize != BOOK_NO_OVERRIDE ? bookFontSize : fontSize; }
+  // Effective LATIN reading-font point size (per-book override, else the global
+  // fontPointSize). Name kept as effFontSize() rather than effFontPointSize() --
+  // it predates the point-size migration and every call site already expects
+  // this name; only the returned value's meaning changed (slot -> point size).
+  uint8_t effFontSize() const { return bookFontSize != BOOK_NO_OVERRIDE ? bookFontSize : fontPointSize; }
   uint8_t effArabicFontSize() const {
     return bookArabicFontSize != BOOK_NO_OVERRIDE ? bookArabicFontSize : arabicFontSize;
   }
@@ -507,7 +529,7 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
 
   // Callback to resolve SD card font IDs. Set by SdCardFontSystem::begin().
   // Returns font ID or 0 if not found.
-  using SdFontIdResolver = int (*)(void* ctx, const char* familyName, uint8_t fontSize);
+  using SdFontIdResolver = int (*)(void* ctx, const char* familyName, uint8_t pointSize);
   SdFontIdResolver sdFontIdResolver = nullptr;
   void* sdFontResolverCtx = nullptr;
 
@@ -515,6 +537,12 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
     return (shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP) ? 10 : 400;
   }
   int getReaderFontId() const;
+
+  // Drop the SD font selection and fall back to the built-in family. The reader
+  // point size comes back into BUILTIN_READER_POINT_SIZES with it, since that is
+  // the only set a built-in family ships -- otherwise the settings UI would keep
+  // offering a size nothing renders at. Both fields are persisted in one write.
+  void clearSdFontFamily();
 
   // If count_only is true, returns the number of settings items that would be written.
   uint8_t writeSettings(HalFile& file, bool count_only = false) const;

--- a/src/FontInstaller.cpp
+++ b/src/FontInstaller.cpp
@@ -141,8 +141,7 @@ FontInstaller::Error FontInstaller::deleteFamily(const char* familyName) {
 
   // If this was the active font, clear the setting
   if (strcmp(SETTINGS.sdFontFamilyName, familyName) == 0) {
-    SETTINGS.sdFontFamilyName[0] = '\0';
-    SETTINGS.saveToFile();
+    SETTINGS.clearSdFontFamily();
     LOG_DBG("FONT", "Cleared active SD font (deleted family: %s)", familyName);
   }
 

--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -102,7 +102,7 @@ void addSettingsReport(JsonObject settings) {
   settings["darkModeEnabled"] = s.darkModeEnabled;
   // Reader
   settings["fontFamily"] = s.fontFamily;
-  settings["fontSize"] = s.fontSize;
+  settings["fontSize"] = s.fontPointSize;
   settings["arabicFontFamily"] = arabicFontFamilyToDisplayIndex(s.arabicFontFamily);
   settings["arabicFontSize"] = s.arabicFontSize;
   settings["lineSpacing"] = s.lineSpacing;
@@ -242,7 +242,11 @@ void applySettingsFromServer(JsonObjectConst settings) {
     }
   }
 
-  applyEnum(s.fontSize, "fontSize", S::FONT_SIZE_COUNT);
+  // fontSize (wire key, unchanged) is now a point size, not a bounded enum slot --
+  // an out-of-range/unavailable value is made safe at load/render time by
+  // snapToNearestPointSize() (see SdCardFontSystem::ensureLoaded), so a plain
+  // sanity range is enough here rather than an exact enum-count bound.
+  applyRange(s.fontPointSize, "fontSize", 6, 72);
   applyEnum(s.arabicFontSize, "arabicFontSize", S::FONT_SIZE_COUNT);
   applyEnum(s.lineSpacing, "lineSpacing", S::LINE_COMPRESSION_COUNT);
   applyRange(s.screenMargin, "screenMargin", 5, 40);

--- a/src/ReaderFontSizes.cpp
+++ b/src/ReaderFontSizes.cpp
@@ -1,0 +1,27 @@
+#include "ReaderFontSizes.h"
+
+#include <iterator>
+
+std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName) {
+  if (registry && sdFamilyName && sdFamilyName[0] != '\0') {
+    if (const auto* family = registry->findFamily(sdFamilyName)) {
+      auto sizes = family->availableSizes();
+      if (!sizes.empty()) return sizes;
+    }
+  }
+  return {std::begin(BUILTIN_READER_POINT_SIZES), std::end(BUILTIN_READER_POINT_SIZES)};
+}
+
+uint8_t snapToNearestPointSize(const uint8_t* sizes, const size_t count, const uint8_t pt) {
+  if (!sizes || count == 0) return pt;
+  uint8_t best = sizes[0];
+  uint8_t bestDelta = best > pt ? best - pt : pt - best;
+  for (size_t i = 1; i < count; i++) {
+    const uint8_t delta = sizes[i] > pt ? sizes[i] - pt : pt - sizes[i];
+    if (delta < bestDelta) {
+      best = sizes[i];
+      bestDelta = delta;
+    }
+  }
+  return best;
+}

--- a/src/ReaderFontSizes.h
+++ b/src/ReaderFontSizes.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <SdCardFontRegistry.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Point sizes the built-in LATIN reading font family ships (see fontIds.h:
+// LEXENDDECA_12/14/16/18_FONT_ID). Used both as the selectable set when no SD
+// font family is active, and as the snap target when one is.
+inline constexpr uint8_t BUILTIN_READER_POINT_SIZES[] = {12, 14, 16, 18};
+
+// Selectable point sizes for the current family: an SD family's actually-
+// installed sizes when one is active and known to `registry`, otherwise
+// BUILTIN_READER_POINT_SIZES. Never empty.
+std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName);
+
+// Nearest value in `sizes` to `pt` (ties favor the earlier/smaller entry, same
+// tie-break as SdCardFontFamilyInfo::findNearestSize()). Returns `pt` unchanged
+// if `sizes` is empty/null -- callers that always pass BUILTIN_READER_POINT_SIZES
+// or a non-empty readerFontPointSizes() result never hit that case.
+uint8_t snapToNearestPointSize(const uint8_t* sizes, size_t count, uint8_t pt);
+inline uint8_t snapToNearestPointSize(const std::vector<uint8_t>& sizes, const uint8_t pt) {
+  return sizes.empty() ? pt : snapToNearestPointSize(sizes.data(), sizes.size(), pt);
+}

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -3,24 +3,48 @@
 #include <GfxRenderer.h>
 #include <Logging.h>
 
+#include <iterator>
+
 #include "CrossPointSettings.h"
+#include "ReaderFontSizes.h"
 
 namespace {
 
-static uint8_t fontSizeEnumFromSettings() {
-  uint8_t e = SETTINGS.effFontSize();                   // per-book override wins when set
-  if (e >= CrossPointSettings::FONT_SIZE_COUNT) e = 1;  // default to MEDIUM
-  return e;
+// Snap the point size actually in effect to `availablePointSize` (the nearest
+// size the active family can render) and persist the snap, so the settings UI
+// (and next boot) show the real value rather than one nothing renders at.
+//
+// The correction target mirrors effFontSize()'s own source of truth: when a
+// book-level SIZE override is active, the wanted size came from
+// SETTINGS.bookFontSize (RAM-only, see CrossPointSettings' per-book block), so
+// the correction lands there too. A book-level FAMILY override alone does not
+// redirect the correction -- the wanted size in that case still came from the
+// global fontPointSize, and persisting a synthetic per-book size override would
+// silently freeze this book's rendered size against future global changes. No-op
+// when availablePointSize is 0 (lookup found nothing) or already matches.
+void snapEffectiveFontPointSizeTo(const uint8_t availablePointSize) {
+  if (availablePointSize == 0) return;
+  const bool bookSizeOverrideActive = SETTINGS.bookFontSize != CrossPointSettings::BOOK_NO_OVERRIDE;
+  if (bookSizeOverrideActive) {
+    if (SETTINGS.bookFontSize != availablePointSize) {
+      LOG_DBG("SDFS", "Per-book font size unavailable, snapping to %u", availablePointSize);
+      SETTINGS.bookFontSize = availablePointSize;
+    }
+    return;
+  }
+  if (availablePointSize == SETTINGS.fontPointSize) return;
+  LOG_DBG("SDFS", "Font size %u unavailable, snapping to %u", SETTINGS.fontPointSize, availablePointSize);
+  SETTINGS.fontPointSize = availablePointSize;
+  SETTINGS.saveToFile();
 }
 
 // A family failed to load / disappeared: clear whichever setting asked for it.
 // A bad per-book override must not wipe the user's global font choice.
-static void clearWantedFamily() {
+void clearWantedFamily() {
   if (SETTINGS.bookSdFontFamilyName[0] != '\0') {
     SETTINGS.bookSdFontFamilyName[0] = '\0';
   } else {
-    SETTINGS.sdFontFamilyName[0] = '\0';
-    SETTINGS.saveToFile();
+    SETTINGS.clearSdFontFamily();
   }
 }
 
@@ -31,26 +55,27 @@ void SdCardFontSystem::begin(GfxRenderer& renderer) {
 
   // Register this system as the SD font ID resolver in settings.
   // Uses a static trampoline since CrossPointSettings stores a plain function pointer.
-  SETTINGS.sdFontIdResolver = [](void* ctx, const char* familyName, uint8_t fontSizeEnum) -> int {
-    return static_cast<SdCardFontSystem*>(ctx)->resolveFontId(familyName, fontSizeEnum);
+  SETTINGS.sdFontIdResolver = [](void* ctx, const char* familyName, uint8_t pointSize) -> int {
+    return static_cast<SdCardFontSystem*>(ctx)->resolveFontId(familyName, pointSize);
   };
   SETTINGS.sdFontResolverCtx = this;
 
-  // If user has a saved SD font selection, load it
+  // If user has a saved SD font selection, load it. eff* so a per-book override
+  // set before begin() (should not normally happen at boot, but keeps this
+  // consistent with ensureLoaded()) still wins.
   if (SETTINGS.sdFontFamilyName[0] != '\0') {
     const auto* family = registry_.findFamily(SETTINGS.sdFontFamilyName);
     if (family) {
-      if (manager_.loadFamily(*family, renderer, fontSizeEnumFromSettings())) {
+      if (manager_.loadFamily(*family, renderer, SETTINGS.effFontSize())) {
+        snapEffectiveFontPointSizeTo(manager_.currentPointSize());
         LOG_DBG("SDFS", "Loaded SD card font family: %s", SETTINGS.sdFontFamilyName);
       } else {
         LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", SETTINGS.sdFontFamilyName);
-        SETTINGS.sdFontFamilyName[0] = '\0';
-        SETTINGS.saveToFile();
+        SETTINGS.clearSdFontFamily();
       }
     } else {
       LOG_DBG("SDFS", "SD font family not found on card: %s (clearing)", SETTINGS.sdFontFamilyName);
-      SETTINGS.sdFontFamilyName[0] = '\0';
-      SETTINGS.saveToFile();
+      SETTINGS.clearSdFontFamily();
     }
   }
 
@@ -71,12 +96,16 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
   // eff* so per-book overrides win (see CrossPointSettings per-book block).
   const char* wantedFamily = SETTINGS.effSdFontFamilyName();
   const std::string& currentFamily = manager_.currentFamilyName();
-  const uint8_t sizeEnum = fontSizeEnumFromSettings();
+  const uint8_t wantedPointSize = SETTINGS.effFontSize();
 
   if (wantedFamily[0] == '\0') {
     if (!currentFamily.empty()) {
       manager_.unloadAll(renderer);
     }
+    // No SD family active (globally or per-book): make sure the point size in
+    // effect is one the built-in family actually ships.
+    snapEffectiveFontPointSizeTo(
+        snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), wantedPointSize));
     return;
   }
 
@@ -92,11 +121,12 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
       clearWantedFamily();
       return;
     }
-    const auto* selected = family->findClosestReaderSize(sizeEnum);
+    const auto* selected = family->findNearestSize(wantedPointSize);
     const uint8_t wantedPt = selected ? selected->pointSize : 0;
+    snapEffectiveFontPointSizeTo(wantedPt);
     if (!registryWasDirty && wantedPt == manager_.currentPointSize()) return;
-    LOG_DBG("SDFS", "Reloading %s: size %u -> %u (enum %u)%s", wantedFamily, manager_.currentPointSize(), wantedPt,
-            sizeEnum, registryWasDirty ? " [registry dirty]" : "");
+    LOG_DBG("SDFS", "Reloading %s: size %u -> %u%s", wantedFamily, manager_.currentPointSize(), wantedPt,
+            registryWasDirty ? " [registry dirty]" : "");
   }
 
   if (!currentFamily.empty()) {
@@ -105,7 +135,8 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
 
   const auto* family = registry_.findFamily(wantedFamily);
   if (family) {
-    if (manager_.loadFamily(*family, renderer, sizeEnum)) {
+    if (manager_.loadFamily(*family, renderer, wantedPointSize)) {
+      snapEffectiveFontPointSizeTo(manager_.currentPointSize());
       LOG_DBG("SDFS", "Loaded SD font family: %s", wantedFamily);
     } else {
       LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", wantedFamily);
@@ -117,9 +148,10 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
   }
 }
 
-int SdCardFontSystem::resolveFontId(const char* familyName, uint8_t /*fontSizeEnum*/) const {
-  // The manager loads exactly one size (closest to SETTINGS.fontSize), so the
-  // enum is implicit — always return the single loaded font ID for this family.
-  // ensureLoaded() must have been called with the current settings before this.
+int SdCardFontSystem::resolveFontId(const char* familyName, uint8_t /*pointSize*/) const {
+  // The manager loads exactly one size (closest to SETTINGS.fontPointSize), so
+  // the requested size is implicit — always return the single loaded font ID
+  // for this family. ensureLoaded() must have been called with the current
+  // settings before this.
   return manager_.getFontId(familyName);
 }

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -22,9 +22,9 @@ class SdCardFontSystem {
   /// Also re-discovers if the registry has been marked dirty (e.g. by web upload).
   void ensureLoaded(GfxRenderer& renderer);
 
-  /// Resolve an SD card font ID from family name + fontSize enum.
+  /// Resolve an SD card font ID from family name + point size.
   /// Returns 0 if not found. Used by CrossPointSettings::getReaderFontId().
-  int resolveFontId(const char* familyName, uint8_t fontSizeEnum) const;
+  int resolveFontId(const char* familyName, uint8_t pointSize) const;
 
   /// Access the registry (e.g. for settings UI to enumerate available fonts).
   const SdCardFontRegistry& registry() const { return registry_; }

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -8,11 +8,13 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "CrossPointSettings.h"
 #include "KOReaderCredentialStore.h"
+#include "ReaderFontSizes.h"
 #include "activities/settings/SettingsActivity.h"
 
 // Build the font family setting dynamically. When registry is non-null, SD card fonts
@@ -105,6 +107,38 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
     }
   };
 
+  return s;
+}
+
+// Build the LATIN reading-font size setting dynamically. Selectable point sizes
+// depend on the active family: the fixed built-in set (BUILTIN_READER_POINT_SIZES)
+// when no SD family is selected, or the SD family's actually-installed sizes
+// otherwise (see ReaderFontSizes.h). Mirrors buildFontFamilySetting() above's
+// dynamic-enum-with-lambda-getter/setter shape. Arabic Font Size is untouched --
+// it stays the static SMALL/MEDIUM/LARGE/EXTRA_LARGE enum entry below.
+inline SettingInfo buildFontSizeSetting(const SdCardFontRegistry* registry) {
+  const std::vector<uint8_t> sizes = readerFontPointSizes(registry, SETTINGS.sdFontFamilyName);
+  std::vector<std::string> labels;
+  labels.reserve(sizes.size());
+  for (const uint8_t pt : sizes) labels.push_back(std::to_string(pt) + " pt");  // "pt" deliberately untranslated
+
+  SettingInfo s;
+  s.nameId = StrId::STR_FONT_SIZE;
+  s.type = SettingType::ENUM;
+  s.enumStringValues = std::move(labels);
+  s.key = "fontSize";
+  s.category = StrId::STR_CAT_READER;
+
+  s.valueGetter = [sizes]() -> uint8_t {
+    const uint8_t pt = snapToNearestPointSize(sizes, SETTINGS.fontPointSize);
+    for (int i = 0; i < static_cast<int>(sizes.size()); i++) {
+      if (sizes[i] == pt) return static_cast<uint8_t>(i);
+    }
+    return 0;
+  };
+  s.valueSetter = [sizes](uint8_t v) {
+    if (v < sizes.size()) SETTINGS.fontPointSize = sizes[v];
+  };
   return s;
 }
 
@@ -267,9 +301,10 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
     // version when SD fonts are installed.
     v.push_back(SettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily, {StrId::STR_LEXEND_DECA},
                                   "fontFamily", StrId::STR_CAT_READER));
-    v.push_back(SettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
-                                  {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE, StrId::STR_X_LARGE},
-                                  "fontSize", StrId::STR_CAT_READER));
+    // Placeholder -- replaced unconditionally below with buildFontSizeSetting(),
+    // since the selectable point sizes depend on the active family (built-in
+    // fixed set, or an SD family's actually-installed sizes), not a fixed enum.
+    v.push_back(SettingInfo::Enum(StrId::STR_FONT_SIZE, nullptr, {}, "fontSize", StrId::STR_CAT_READER));
     v.push_back(SettingInfo::Enum(StrId::STR_ARABIC_FONT_SIZE, &CrossPointSettings::arabicFontSize,
                                   {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE, StrId::STR_X_LARGE},
                                   "arabicFontSize", StrId::STR_CAT_READER));
@@ -485,6 +520,15 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
     auto it = std::find_if(v.begin(), v.end(), [](const SettingInfo& s) { return s.nameId == StrId::STR_FONT_FAMILY; });
     if (it != v.end()) {
       *it = buildFontFamilySetting(registry);
+    }
+  }
+  // Unconditional (unlike font-family's SD-fonts-installed guard above): the
+  // built-in point-size set is dynamic too (BUILTIN_READER_POINT_SIZES), not a
+  // fixed enum, so this always needs the registry-aware build.
+  {
+    auto it = std::find_if(v.begin(), v.end(), [](const SettingInfo& s) { return s.nameId == StrId::STR_FONT_SIZE; });
+    if (it != v.end()) {
+      *it = buildFontSizeSetting(registry);
     }
   }
   return v;

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -5,6 +5,7 @@
 #include <I18n.h>
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <utility>
 
@@ -14,6 +15,7 @@
 #include "FouladEbooksConfig.h"
 #include "MappedInputManager.h"
 #include "OpdsServerStore.h"
+#include "ReaderFontSizes.h"
 #include "ReaderPomodoro.h"
 #include "SdCardFontSystem.h"
 #include "components/UITheme.h"
@@ -219,12 +221,25 @@ std::string EpubReaderMenuActivity::globalLabel(const char* effectiveValueLabel)
 std::string EpubReaderMenuActivity::valueLabel(const MenuAction action) const {
   switch (action) {
     case MenuAction::FONT_SIZE: {
-      const uint8_t book = isArabicBook ? SETTINGS.bookArabicFontSize : SETTINGS.bookFontSize;
-      const uint8_t global = isArabicBook ? SETTINGS.arabicFontSize : SETTINGS.fontSize;
-      return book == CrossPointSettings::BOOK_NO_OVERRIDE
-                 ? globalLabel(
-                       I18N.get(kSizeLabels[std::min<uint8_t>(global, CrossPointSettings::FONT_SIZE_COUNT - 1)]))
-                 : I18N.get(kSizeLabels[book]);
+      if (isArabicBook) {
+        const uint8_t book = SETTINGS.bookArabicFontSize;
+        const uint8_t global = SETTINGS.arabicFontSize;
+        return book == CrossPointSettings::BOOK_NO_OVERRIDE
+                   ? globalLabel(
+                         I18N.get(kSizeLabels[std::min<uint8_t>(global, CrossPointSettings::FONT_SIZE_COUNT - 1)]))
+                   : I18N.get(kSizeLabels[book]);
+      }
+      // Latin: point-size based (see ReaderFontSizes.h), not the fixed enum --
+      // the selectable/snapped sizes depend on whichever family is effectively
+      // active for this book (per-book family override, else the global one).
+      const std::vector<uint8_t> sizes = readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.effSdFontFamilyName());
+      char buf[16];
+      if (SETTINGS.bookFontSize == CrossPointSettings::BOOK_NO_OVERRIDE) {
+        snprintf(buf, sizeof(buf), "%u pt", snapToNearestPointSize(sizes, SETTINGS.fontPointSize));
+        return globalLabel(buf);
+      }
+      snprintf(buf, sizeof(buf), "%u pt", snapToNearestPointSize(sizes, SETTINGS.bookFontSize));
+      return buf;
     }
     case MenuAction::FONT_NAME: {
       if (isArabicBook) {
@@ -304,9 +319,46 @@ void EpubReaderMenuActivity::openSettingEditor(const MenuAction action) {
 
   switch (action) {
     case MenuAction::FONT_SIZE:
-      showEnumPopup(StrId::STR_FONT_SIZE_GENERIC, kSizeLabels, CrossPointSettings::FONT_SIZE_COUNT,
-                    isArabicBook ? SETTINGS.bookArabicFontSize : SETTINGS.bookFontSize,
-                    isArabicBook ? SETTINGS.arabicFontSize : SETTINGS.fontSize);
+      if (isArabicBook) {
+        showEnumPopup(StrId::STR_FONT_SIZE_GENERIC, kSizeLabels, CrossPointSettings::FONT_SIZE_COUNT,
+                      SETTINGS.bookArabicFontSize, SETTINGS.arabicFontSize);
+        break;
+      }
+      {
+        // Latin: the option list is a dynamic set of point sizes (built-in fixed
+        // set, or an SD family's actually-installed sizes -- see
+        // ReaderFontSizes.h), not showEnumPopup's fixed StrId-label shape, so
+        // this popup is built directly rather than reusing that helper.
+        const std::vector<uint8_t> sizes =
+            readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.effSdFontFamilyName());
+        std::vector<std::string> options;
+        options.reserve(sizes.size() + 1);
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%u pt", snapToNearestPointSize(sizes, SETTINGS.fontPointSize));
+        options.push_back(globalLabel(buf));
+        for (const uint8_t pt : sizes) options.push_back(std::to_string(pt) + " pt");
+
+        int current = 0;
+        if (SETTINGS.bookFontSize != CrossPointSettings::BOOK_NO_OVERRIDE) {
+          const uint8_t snapped = snapToNearestPointSize(sizes, SETTINGS.bookFontSize);
+          for (size_t i = 0; i < sizes.size(); i++) {
+            if (sizes[i] == snapped) {
+              current = static_cast<int>(1 + i);
+              break;
+            }
+          }
+        }
+
+        optionPopup.show(StrId::STR_FONT_SIZE_GENERIC, options, current, [this, sizes](const int idx) {
+          const uint8_t newValue = (idx == 0 || sizes.empty()) ? CrossPointSettings::BOOK_NO_OVERRIDE
+                                                               : sizes[std::min<size_t>(idx - 1, sizes.size() - 1)];
+          if (SETTINGS.bookFontSize != newValue) {
+            SETTINGS.bookFontSize = newValue;
+            bookSettingsChanged = true;
+          }
+          requestUpdate();
+        });
+      }
       break;
     case MenuAction::TEXT_ALIGN:
       showEnumPopup(StrId::STR_TEXT_ALIGNMENT, kAlignLabels, CrossPointSettings::PARAGRAPH_ALIGNMENT_COUNT,

--- a/src/util/BookReaderSettings.h
+++ b/src/util/BookReaderSettings.h
@@ -19,18 +19,33 @@
 namespace BookReaderSettings {
 
 constexpr char FILE_NAME[] = "/book_settings.bin";
-// Layout v3: 'B' 'K' version, then fontSize, arabicFontSize, lineSpacing,
+// Layout v4: 'B' 'K' version, then fontSize, arabicFontSize, lineSpacing,
 // paragraphAlignment, arabicFontFamily, fontFamily (0xFF = inherit), then the
 // two 32-byte family names ("" = inherit, "\x01" = force built-in -- same
-// encoding as the fields). v2 lacked the fontFamily byte (there was only one
-// built-in Latin family, so "force built-in" alone was unambiguous -- once
-// Bitter/Lexend Deca added a second one, WHICH built-in needed its own byte,
-// same reasoning as arabicFontFamily in v2). v1 lacked arabicFontFamily too.
-// Both v1 and v2 are still readable.
-constexpr uint8_t FORMAT_VERSION = 3;
+// encoding as the fields). The byte LAYOUT is unchanged from v3 (still 73
+// bytes) -- only buf[3]'s MEANING changed: v4 stores the LATIN reading font's
+// actual point size (mirrors CrossPointSettings::fontPointSize), where v3 and
+// earlier stored the old SMALL/MEDIUM/LARGE/EXTRA_LARGE slot (0..3). A v1-v3
+// sidecar's buf[3] is folded the same way CrossPointSettings::fromJson() folds
+// the legacy global value (12 + slot * 2) so an old per-book override doesn't
+// silently become a nonsensically tiny point size; a v4 sidecar's buf[3] is
+// read straight through with no enum-count bounds check (any value 0-254 is a
+// plausible point size candidate -- snapToNearestPointSize() at render/load
+// time is what actually keeps an unavailable value safe). buf[4] (arabicFontSize)
+// is untouched by this -- Arabic sizing stays the fixed enum in every version.
+// v2 lacked the fontFamily byte (there was only one built-in Latin family, so
+// "force built-in" alone was unambiguous -- once Bitter/Lexend Deca added a
+// second one, WHICH built-in needed its own byte, same reasoning as
+// arabicFontFamily in v2). v1 lacked arabicFontFamily too. v1, v2, and v3 are
+// all still readable.
+constexpr uint8_t FORMAT_VERSION = 4;
 constexpr size_t PAYLOAD_SIZE = 3 + 6 + 32 + 32;
 constexpr size_t V1_PAYLOAD_SIZE = 3 + 4 + 32 + 32;
 constexpr size_t V2_PAYLOAD_SIZE = 3 + 5 + 32 + 32;
+// v3's payload is the same size as v4's (only buf[3]'s meaning changed between
+// them) -- kept as a separate name purely for readability at the version-check
+// site below, not because the byte count differs.
+constexpr size_t V3_PAYLOAD_SIZE = PAYLOAD_SIZE;
 
 inline uint8_t sanitizeEnum(const uint8_t v, const uint8_t count) {
   return v < count ? v : CrossPointSettings::BOOK_NO_OVERRIDE;
@@ -49,18 +64,31 @@ inline void applyToSettings(const std::string& bookCachePath) {
   if (buf[0] != 'B' || buf[1] != 'K') return;
   const bool v1 = buf[2] == 1 && got == static_cast<int>(V1_PAYLOAD_SIZE);
   const bool v2 = buf[2] == 2 && got == static_cast<int>(V2_PAYLOAD_SIZE);
-  const bool v3 = buf[2] == FORMAT_VERSION && got == static_cast<int>(PAYLOAD_SIZE);
-  if (!v1 && !v2 && !v3) return;
-  const size_t namesAt = v3 ? 9 : (v2 ? 8 : 7);
+  const bool v3 = buf[2] == 3 && got == static_cast<int>(V3_PAYLOAD_SIZE);
+  const bool v4 = buf[2] == FORMAT_VERSION && got == static_cast<int>(PAYLOAD_SIZE);
+  if (!v1 && !v2 && !v3 && !v4) return;
+  const size_t namesAt = (v3 || v4) ? 9 : (v2 ? 8 : 7);
 
-  SETTINGS.bookFontSize = sanitizeEnum(buf[3], CrossPointSettings::FONT_SIZE_COUNT);
+  if (v4) {
+    // v4: buf[3] is a raw point size (or BOOK_NO_OVERRIDE) already.
+    SETTINGS.bookFontSize = buf[3];
+  } else {
+    // v1-v3: buf[3] holds the legacy SMALL/MEDIUM/LARGE/EXTRA_LARGE slot (0..3)
+    // -- fold it the same way CrossPointSettings::fromJson() folds the legacy
+    // global value, so an old per-book override doesn't silently become a
+    // nonsensically tiny point size.
+    const uint8_t legacySlot = sanitizeEnum(buf[3], CrossPointSettings::FONT_SIZE_COUNT);
+    SETTINGS.bookFontSize = legacySlot == CrossPointSettings::BOOK_NO_OVERRIDE
+                                ? CrossPointSettings::BOOK_NO_OVERRIDE
+                                : static_cast<uint8_t>(12 + legacySlot * 2);
+  }
   SETTINGS.bookArabicFontSize = sanitizeEnum(buf[4], CrossPointSettings::FONT_SIZE_COUNT);
   SETTINGS.bookLineSpacing = sanitizeEnum(buf[5], CrossPointSettings::LINE_COMPRESSION_COUNT);
   SETTINGS.bookParagraphAlignment = sanitizeEnum(buf[6], CrossPointSettings::PARAGRAPH_ALIGNMENT_COUNT);
-  if (v2 || v3) {
+  if (v2 || v3 || v4) {
     SETTINGS.bookArabicFontFamily = sanitizeEnum(buf[7], CrossPointSettings::ARABIC_FONT_FAMILY_COUNT);
   }
-  if (v3) {
+  if (v3 || v4) {
     SETTINGS.bookFontFamily = sanitizeEnum(buf[8], CrossPointSettings::FONT_FAMILY_COUNT);
   }
   memcpy(SETTINGS.bookSdFontFamilyName, buf + namesAt, sizeof(SETTINGS.bookSdFontFamilyName));


### PR DESCRIPTION
## Summary
- Ports upstream CrossPoint `91900484` ("feat: point-size font selection (#2720)"): the reading-font-size setting is now a real point size (`fontPointSize`) instead of a SMALL/MEDIUM/LARGE/EXTRA_LARGE enum slot, with UI options generated dynamically from whichever family is active (built-in Lexend Deca sizes, or an SD family's actually-installed sizes)
- Legacy enum values in `settings.json` and old `book_settings.bin` sidecars (v1-v3) fold into point sizes on load (`12 + slot*2`); a new v4 sidecar format stores the raw point size directly
- Fork-specific work beyond upstream's diff: per-book size/family overrides (`BookReaderSettings` v3→v4 bump), `ArabicFontSystem`'s enum-to-point-size translation shim at the `SdCardFontManager::loadFamily()` call boundary (Arabic sizing itself stays the fixed enum), and `FouladDeviceTracking`'s server-sync path range-validating `fontSize` (6-72) instead of enum-bounding it
- Arabic Font Size is untouched — still `STR_SMALL/MEDIUM/LARGE/EXTRA_LARGE`

## Test plan
- [x] `pio run -e default` — clean build
- [x] `pio check --skip-packages -e default` — no new findings (2 pre-existing low-severity style notes in `SdCardFontManager.cpp`, unrelated to this change)
- [x] `clang-format` — no diff
- [x] Independent file-by-file review of every changed file against upstream's actual commit (not the stale "fork-designed" plan description) and against this fork's own per-book override system
- [x] Fixed one real bug found during review: `SdCardFontSystem.cpp`'s snap-and-persist correction was redirecting into the per-book `bookFontSize` field whenever *any* book override was active (including a family-only override with no size override), silently manufacturing a persisted per-book size lock the user never chose and decoupling that book from future global font-size changes. Narrowed the condition to only redirect when a book-level *size* override is actually the source of the wanted size, matching `effFontSize()`'s own precedence rule
- [ ] Simulator smoke test of the Text Settings font-size picker (not yet attempted)
- [ ] On-device verification (heap headroom, all 4 orientations, actual e-ink rendering)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e