### PR TITLE
feat: touch input foundation + Home screen touch (DO NOT MERGE without touch hardware)

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2622,6 +2622,37 @@ int GfxRenderer::getScreenHeight() const {
   return panelWidth;
 }
 
+void GfxRenderer::tapToLogical(const float nx, const float ny, int& outX, int& outY) const {
+  int phyX = static_cast<int>(nx * panelWidth);
+  int phyY = static_cast<int>(ny * panelHeight);
+  if (phyX < 0) phyX = 0;
+  if (phyX > panelWidth - 1) phyX = panelWidth - 1;
+  if (phyY < 0) phyY = 0;
+  if (phyY > panelHeight - 1) phyY = panelHeight - 1;
+
+  // rotateCoordinates()'s inverse, case for case -- see that function's own comments
+  // for the forward transform each of these undoes.
+  switch (orientation) {
+    case Portrait:
+      outX = panelHeight - 1 - phyY;
+      outY = phyX;
+      break;
+    case PortraitInverted:
+      outX = phyY;
+      outY = panelWidth - 1 - phyX;
+      break;
+    case LandscapeClockwise:
+      outX = panelWidth - 1 - phyX;
+      outY = panelHeight - 1 - phyY;
+      break;
+    case LandscapeCounterClockwise:
+    default:
+      outX = phyX;
+      outY = phyY;
+      break;
+  }
+}
+
 // Translate a logical rect through rotateCoordinates and take the bounding
 // box of its four corners on the physical panel. Output coords are inclusive
 // and clamped. Returns false if the rect ends up fully off-panel.

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -281,6 +281,12 @@ class GfxRenderer {
   // Screen ops
   int getScreenWidth() const;
   int getScreenHeight() const;
+  // Maps a touch point normalized 0..1 in the panel's native (physical) frame -- the
+  // form InputManager/HalGPIO report touch in -- to logical screen coordinates in the
+  // CURRENT orientation, i.e. the same coordinate space drawText/drawRoundedRect/etc.
+  // already use. This is rotateCoordinates()'s inverse; touch callers should never do
+  // their own orientation math.
+  void tapToLogical(float nx, float ny, int& outX, int& outY) const;
   // forceCleanBaseOnHalf: see HalDisplay::displayBuffer's own comment. Defaults
   // to true (existing behavior); the reader's periodic ghost-cleanup refresh
   // is the one caller that passes false.

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -225,6 +225,22 @@ unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 
 unsigned long HalGPIO::getPowerButtonHeldTime() const { return inputMgr.getPowerButtonHeldTime(); }
 
+bool HalGPIO::hasTouch() const { return inputMgr.hasTouch(); }
+
+bool HalGPIO::wasTouchTap(float& nx, float& ny) const { return inputMgr.wasTouchTap(nx, ny); }
+
+bool HalGPIO::isTouchTapCandidate(float& nx, float& ny, unsigned long& heldMs) const {
+  return inputMgr.isTouchTapCandidate(nx, ny, heldMs);
+}
+
+bool HalGPIO::isTouchHeldAt(float& nx, float& ny) const { return inputMgr.isTouchHeldAt(nx, ny); }
+
+unsigned long HalGPIO::lastTouchHeldMs() const { return inputMgr.lastTouchHeldMs(); }
+
+bool HalGPIO::wasSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) const {
+  return inputMgr.wasSwipe(nxStart, nyStart, nxEnd, nyEnd);
+}
+
 void HalGPIO::startDeepSleep() {
   // Ensure that the power button has been released to avoid immediately turning back on if you're holding it
   while (inputMgr.isPressed(BTN_POWER)) {

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -80,6 +80,17 @@ class HalGPIO {
   // Should only be called when wakeup reason is PowerButton.
   void verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPressAllowed);
 
+  // Capacitive touch pass-through -- inert (always returns false/0) on boards without a
+  // touch controller configured, per InputManager's own contract. MappedInputManager is
+  // the only intended caller (see the HAL rule in CLAUDE.md); never call InputManager
+  // directly from activity/theme code.
+  bool hasTouch() const;
+  bool wasTouchTap(float& nx, float& ny) const;
+  bool isTouchTapCandidate(float& nx, float& ny, unsigned long& heldMs) const;
+  bool isTouchHeldAt(float& nx, float& ny) const;
+  unsigned long lastTouchHeldMs() const;
+  bool wasSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) const;
+
   // Check if USB is connected
   bool isUsbConnected() const;
 

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -3,7 +3,19 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
+#include <algorithm>
+#include <cstdlib>
+
 #include "CrossPointSettings.h"
+#include "components/UITheme.h"
+
+namespace {
+constexpr float LEFT_EDGE_BACK_GESTURE_FRAC_X = 0.25f;
+constexpr float BOTTOM_EDGE_HOME_GESTURE_FRAC_Y = 0.14f;
+constexpr float TOP_EDGE_MENU_GESTURE_FRAC_Y = 0.14f;
+constexpr unsigned long TOUCH_DOWN_SELECT_DELAY_MS = 90;
+constexpr unsigned long TOUCH_HELD_OVERRIDE_WINDOW_MS = 250;
+}  // namespace
 
 bool MappedInputManager::isNavDirectionSwapped() const {
   // Key the swap on the orientation the screen is *actually* rendered at, not the persisted reader
@@ -105,9 +117,199 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
   return false;
 }
 
-bool MappedInputManager::wasPressed(const Button button) const { return mapButton(button, &HalGPIO::wasPressed); }
+bool MappedInputManager::hasTouch() const { return gpio.hasTouch(); }
 
-bool MappedInputManager::wasReleased(const Button button) const { return mapButton(button, &HalGPIO::wasReleased); }
+void MappedInputManager::rememberTouchHeldTime() const {
+  touchHeldOverrideValid = true;
+  touchHeldOverrideMs = gpio.lastTouchHeldMs();
+  touchHeldOverrideAt = millis();
+}
+
+bool MappedInputManager::wasScreenTapped(int& x, int& y) const {
+  float nx = 0.0f;
+  float ny = 0.0f;
+  if (!gpio.wasTouchTap(nx, ny)) return false;
+  renderer.tapToLogical(nx, ny, x, y);
+  rememberTouchHeldTime();
+  return true;
+}
+
+bool MappedInputManager::wasScreenTouchDown(int& x, int& y) const {
+  float nx = 0.0f;
+  float ny = 0.0f;
+  unsigned long heldMs = 0;
+  if (!gpio.isTouchTapCandidate(nx, ny, heldMs)) return false;
+  if (heldMs < TOUCH_DOWN_SELECT_DELAY_MS) return false;
+  renderer.tapToLogical(nx, ny, x, y);
+  return true;
+}
+
+bool MappedInputManager::isScreenTouchHeld(int& x, int& y) const {
+  float nx = 0.0f;
+  float ny = 0.0f;
+  if (!gpio.isTouchHeldAt(nx, ny)) return false;
+  renderer.tapToLogical(nx, ny, x, y);
+  return true;
+}
+
+bool MappedInputManager::wasTapInRect(const int x, const int y, const int width, const int height) const {
+  int tx = 0;
+  int ty = 0;
+  return wasScreenTapped(tx, ty) && tx >= x && tx < x + width && ty >= y && ty < y + height;
+}
+
+bool MappedInputManager::listItemFromPoint(const int x, const int y, int& index, const int itemCount,
+                                           const int selectedIndex, const int listTop, const int listHeight,
+                                           const bool hasSubtitle) const {
+  (void)x;
+  if (itemCount <= 0) return false;
+  if (y < listTop || y >= listTop + listHeight) return false;
+
+  const int rowStep = GUI.getListRowStep(hasSubtitle);
+  if (rowStep <= 0) return false;
+
+  const int pageItems = GUI.getListPageItems(listHeight, hasSubtitle);
+  if (pageItems <= 0) return false;
+  const int pageStart = std::max(0, selectedIndex / pageItems) * pageItems;
+  const int row = (y - listTop) / rowStep;
+  const int tapped = pageStart + row;
+  if (row < 0 || row >= pageItems || tapped >= itemCount) return false;
+  index = tapped;
+  return true;
+}
+
+bool MappedInputManager::wasListItemTapped(int& index, const int itemCount, const int selectedIndex, const int listTop,
+                                           const int listHeight, const bool hasSubtitle) const {
+  int tx = 0;
+  int ty = 0;
+  return wasScreenTapped(tx, ty) &&
+         listItemFromPoint(tx, ty, index, itemCount, selectedIndex, listTop, listHeight, hasSubtitle);
+}
+
+bool MappedInputManager::wasListItemTouchedDown(int& index, const int itemCount, const int selectedIndex,
+                                                const int listTop, const int listHeight, const bool hasSubtitle) const {
+  int tx = 0;
+  int ty = 0;
+  return wasScreenTouchDown(tx, ty) &&
+         listItemFromPoint(tx, ty, index, itemCount, selectedIndex, listTop, listHeight, hasSubtitle);
+}
+
+MappedInputManager::RowTouch MappedInputManager::rowTouch(int& row, const int top, const int rowStep,
+                                                          const int rowCount, const int xStart, const int xEnd,
+                                                          const int rowHeight) const {
+  if (rowStep <= 0 || rowCount <= 0) return RowTouch::None;
+  const auto hit = [&](const int x, const int y) {
+    if (x < xStart || x >= xEnd || y < top) return false;
+    const int r = (y - top) / rowStep;
+    if (r >= rowCount) return false;
+    if (rowHeight > 0 && (y - top) % rowStep >= rowHeight) return false;
+    row = r;
+    return true;
+  };
+  int x = 0;
+  int y = 0;
+  if (wasScreenTouchDown(x, y) && hit(x, y)) return RowTouch::Down;
+  if (wasScreenTapped(x, y) && hit(x, y)) return RowTouch::Tap;
+  return RowTouch::None;
+}
+
+MappedInputManager::RowTouch MappedInputManager::colTouch(int& col, const int left, const int colStep,
+                                                          const int colCount, const int yStart, const int yEnd,
+                                                          const int colWidth) const {
+  if (colStep <= 0 || colCount <= 0) return RowTouch::None;
+  const auto hit = [&](const int x, const int y) {
+    if (y < yStart || y >= yEnd || x < left) return false;
+    const int c = (x - left) / colStep;
+    if (c >= colCount) return false;
+    if (colWidth > 0 && (x - left) % colStep >= colWidth) return false;
+    col = c;
+    return true;
+  };
+  int x = 0;
+  int y = 0;
+  if (wasScreenTouchDown(x, y) && hit(x, y)) return RowTouch::Down;
+  if (wasScreenTapped(x, y) && hit(x, y)) return RowTouch::Tap;
+  return RowTouch::None;
+}
+
+bool MappedInputManager::decodeSwipe(int& sx, int& sy, int& ex, int& ey) const {
+  float nxs = 0.0f;
+  float nys = 0.0f;
+  float nxe = 0.0f;
+  float nye = 0.0f;
+  if (!gpio.wasSwipe(nxs, nys, nxe, nye)) return false;
+  renderer.tapToLogical(nxs, nys, sx, sy);
+  renderer.tapToLogical(nxe, nye, ex, ey);
+  return true;
+}
+
+MappedInputManager::SwipeDir MappedInputManager::wasSwipe() const {
+  int sx = 0;
+  int sy = 0;
+  int ex = 0;
+  int ey = 0;
+  if (!decodeSwipe(sx, sy, ex, ey)) return SwipeDir::None;
+  const int dx = ex - sx;
+  const int dy = ey - sy;
+  if (std::abs(dx) >= std::abs(dy)) {
+    return dx < 0 ? SwipeDir::Left : SwipeDir::Right;
+  }
+  return dy < 0 ? SwipeDir::Up : SwipeDir::Down;
+}
+
+bool MappedInputManager::wasBackGesture() const {
+  // Back = left-to-right swipe starting near the left edge. Edge-anchored so that
+  // mid-screen horizontal swipes stay available to activities that consume
+  // SwipeDir::Left/Right (e.g. percent selection, image viewer).
+  int sx = 0;
+  int sy = 0;
+  int ex = 0;
+  int ey = 0;
+  if (!decodeSwipe(sx, sy, ex, ey)) return false;
+  const bool hit = sx <= renderer.getScreenWidth() * LEFT_EDGE_BACK_GESTURE_FRAC_X && ex > sx &&
+                   std::abs(ex - sx) > std::abs(ey - sy);
+  if (hit) rememberTouchHeldTime();
+  return hit;
+}
+
+bool MappedInputManager::wasMenuGesture() const {
+  // Downward swipe starting at the top edge (mirror of the bottom-edge home gesture).
+  int sx = 0;
+  int sy = 0;
+  int ex = 0;
+  int ey = 0;
+  if (!decodeSwipe(sx, sy, ex, ey)) return false;
+  const int topEdgeBottom = static_cast<int>(renderer.getScreenHeight() * TOP_EDGE_MENU_GESTURE_FRAC_Y);
+  const bool hit = sy <= topEdgeBottom && ey > sy && std::abs(ey - sy) > std::abs(ex - sx);
+  if (hit) rememberTouchHeldTime();
+  return hit;
+}
+
+bool MappedInputManager::wasHomeGesture() const {
+  int sx = 0;
+  int sy = 0;
+  int ex = 0;
+  int ey = 0;
+  if (decodeSwipe(sx, sy, ex, ey)) {
+    const int bottomEdgeTop =
+        renderer.getScreenHeight() - static_cast<int>(renderer.getScreenHeight() * BOTTOM_EDGE_HOME_GESTURE_FRAC_Y);
+    if (sy >= bottomEdgeTop && ey < sy && std::abs(ey - sy) > std::abs(ex - sx)) {
+      rememberTouchHeldTime();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MappedInputManager::wasPressed(const Button button) const {
+  if (button == Button::Back && wasBackGesture()) return true;
+  return mapButton(button, &HalGPIO::wasPressed);
+}
+
+bool MappedInputManager::wasReleased(const Button button) const {
+  if (button == Button::Back && wasBackGesture()) return true;
+  return mapButton(button, &HalGPIO::wasReleased);
+}
 
 bool MappedInputManager::isPressed(const Button button) const { return mapButton(button, &HalGPIO::isPressed); }
 
@@ -115,7 +317,14 @@ bool MappedInputManager::wasAnyPressed() const { return gpio.wasAnyPressed(); }
 
 bool MappedInputManager::wasAnyReleased() const { return gpio.wasAnyReleased(); }
 
-unsigned long MappedInputManager::getHeldTime() const { return gpio.getHeldTime(); }
+unsigned long MappedInputManager::getHeldTime() const {
+  if (!gpio.wasAnyPressed() && !gpio.wasAnyReleased() && touchHeldOverrideValid &&
+      millis() - touchHeldOverrideAt <= TOUCH_HELD_OVERRIDE_WINDOW_MS) {
+    return touchHeldOverrideMs;
+  }
+  touchHeldOverrideValid = false;
+  return gpio.getHeldTime();
+}
 
 MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const char* confirm, const char* previous,
                                                          const char* next, const bool rtlSwap) const {

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -2,6 +2,8 @@
 
 #include <HalGPIO.h>
 
+#include <cstdint>
+
 class GfxRenderer;
 
 class MappedInputManager {
@@ -27,6 +29,12 @@ class MappedInputManager {
     ScrollNext,
     ScrollPrevious
   };
+  enum class SwipeDir { None, Left, Right, Up, Down };
+  // Combined touch interaction for a band of equal rows/columns with caller-supplied
+  // geometry -- the shared hit-test for lists the theme helpers do not cover directly
+  // (custom row heights, option prompts, menus). Down = a held tap-candidate is on a
+  // row/col (update the selection highlight); Tap = a tap released on one (activate).
+  enum class RowTouch : uint8_t { None, Down, Tap };
 
   struct Labels {
     const char* btn1;
@@ -44,6 +52,47 @@ class MappedInputManager {
   bool wasAnyPressed() const;
   bool wasAnyReleased() const;
   unsigned long getHeldTime() const;
+
+  // --- Touch bridge (Path 2 of docs/contributing/touch-and-ui.md): adds tap/hold/swipe
+  // support to hand-rolled theme rendering without restructuring the activity. All
+  // coordinates are LOGICAL screen coordinates (orientation already applied via
+  // GfxRenderer::tapToLogical) -- never touch raw normalized panel coordinates or the
+  // SDK InputManager directly; go through HalGPIO/these helpers only. ---
+
+  // True when the device has a touch panel. Rarely needed directly -- the helpers below
+  // simply never fire without one.
+  bool hasTouch() const;
+  // A completed tap (press + release), with logical coords.
+  bool wasScreenTapped(int& x, int& y) const;
+  // Touch-down (held past a short debounce, not yet released): draw a selection highlight.
+  bool wasScreenTouchDown(int& x, int& y) const;
+  // Live contact position while the finger is down (drag tracking).
+  bool isScreenTouchHeld(int& x, int& y) const;
+  // One-off hit test on a rectangle (a single button, a banner).
+  bool wasTapInRect(int x, int y, int width, int height) const;
+  // Taps on a standard UITheme list; does the row/paging math for you.
+  bool wasListItemTapped(int& index, int itemCount, int selectedIndex, int listTop, int listHeight,
+                         bool hasSubtitle) const;
+  // Same geometry as wasListItemTapped, touch-down phase (highlight before activate).
+  bool wasListItemTouchedDown(int& index, int itemCount, int selectedIndex, int listTop, int listHeight,
+                              bool hasSubtitle) const;
+  // rowHeight limits the hit to the top rowHeight px of each step (0 = the full step, no
+  // gap band).
+  RowTouch rowTouch(int& row, int top, int rowStep, int rowCount, int xStart = 0, int xEnd = INT32_MAX,
+                    int rowHeight = 0) const;
+  // Horizontal variant for side-by-side button pairs (confirmation prompts).
+  RowTouch colTouch(int& col, int left, int colStep, int colCount, int yStart, int yEnd, int colWidth = 0) const;
+  // Raw swipe direction, if a caller needs one beyond the global gestures below.
+  SwipeDir wasSwipe() const;
+  // Global gestures, handled once for every screen -- do not reimplement these in an
+  // activity. Home: up-swipe starting in the bottom 14%, checked by ActivityManager::loop()
+  // itself (pops to Home; override via Activity::handleHomeGesture()). Back: right-swipe
+  // starting in the left 25%, folded directly into wasPressed(Button::Back)/
+  // wasReleased(Button::Back) below, so existing button-era activities gain back-swipe
+  // support with zero changes. Menu: down-swipe starting in the top 14%, exposed here for
+  // activities that have a menu to check for themselves (the reader does this).
+  bool wasHomeGesture() const;
+  bool wasMenuGesture() const;
   // rtlSwap: true for a genuinely horizontal previous/next pair (e.g. STR_DIR_LEFT/
   // STR_DIR_RIGHT) that should mirror sides under Arabic, matching NavNext/
   // NavPrevious's own RTL flip. Pass false for a vertical up/down pair (e.g.
@@ -71,4 +120,19 @@ class MappedInputManager {
   const GfxRenderer& renderer;
 
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;
+
+  // Fetch the pending swipe (if any) and map both endpoints to logical screen coords.
+  bool decodeSwipe(int& sx, int& sy, int& ex, int& ey) const;
+  bool wasBackGesture() const;
+  bool listItemFromPoint(int x, int y, int& index, int itemCount, int selectedIndex, int listTop, int listHeight,
+                         bool hasSubtitle) const;
+  // A gesture (back/home/menu) consumes the underlying touch-down/release edge without a
+  // matching physical-button transition, so getHeldTime() would otherwise report a stale
+  // value right after one fires. Latches the touch's held duration for a short window so
+  // callers that check getHeldTime() immediately after a gesture-driven action (e.g. a
+  // long-press vs short-press branch) still see a sensible number.
+  void rememberTouchHeldTime() const;
+  mutable bool touchHeldOverrideValid = false;
+  mutable unsigned long touchHeldOverrideMs = 0;
+  mutable unsigned long touchHeldOverrideAt = 0;
 };

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -253,6 +253,8 @@ void HomeActivity::freeCoverBuffer() {
 }
 
 void HomeActivity::loop() {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+
   // Anti-drift whitening: a static e-ink image slowly drifts gray over minutes
   // even with the Sunlight Fading Fix ON (confirmed on-device by photo) -- the
   // pigment relaxes regardless of the panel gate being powered down. A FAST
@@ -279,7 +281,43 @@ void HomeActivity::loop() {
     requestUpdate();
   });
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+  bool activate = mappedInput.wasReleased(MappedInputManager::Button::Confirm);
+
+  // Touch: tapping/holding a menu tile selects + (on release) activates it, the same
+  // as Confirm. Scoped to !metrics.homeContinueReadingInMenu (FouladTheme, this fork's
+  // only shipping theme) for now -- LyraTheme's own "Continue Reading" first-tile echo
+  // of the cover-row selection isn't touch-mapped yet, falls back to button/Confirm only
+  // there. Geometry mirrors render()'s own drawButtonMenu() Rect and buttonCount exactly.
+  if (mappedInput.hasTouch() && !metrics.homeContinueReadingInMenu) {
+    const Rect menuRect{
+        0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, renderer.getScreenWidth(),
+        renderer.getScreenHeight() - (metrics.headerHeight + metrics.homeTopPadding + metrics.verticalSpacing +
+                                      metrics.homeMenuTopOffset + metrics.buttonHintsHeight)};
+    constexpr int kMenuItemCount = 4;  // eBooks, Stats, Apps, Settings -- matches loop()'s Confirm branch
+
+    int tx = 0;
+    int ty = 0;
+    int hit = -1;
+    bool isTap = false;
+    if (mappedInput.wasScreenTouchDown(tx, ty)) {
+      hit = GUI.hitTestButtonMenu(renderer, menuRect, kMenuItemCount, tx, ty);
+    } else if (mappedInput.wasScreenTapped(tx, ty)) {
+      hit = GUI.hitTestButtonMenu(renderer, menuRect, kMenuItemCount, tx, ty);
+      isTap = hit >= 0;
+    }
+    if (hit >= 0) {
+      const int tappedIndex = static_cast<int>(recentBooks.size()) + hit;
+      if (isTap) {
+        selectorIndex = tappedIndex;
+        activate = true;
+      } else if (selectorIndex != tappedIndex) {
+        selectorIndex = tappedIndex;
+        requestUpdate();
+      }
+    }
+  }
+
+  if (activate) {
     if (selectorIndex < recentBooks.size()) {
       // The last recents tile becomes a "+N more" stack when the store holds more
       // books than the row shows (see FouladTheme); confirming it opens the full

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -261,6 +261,10 @@ int BaseTheme::getListPageItems(int contentHeight, bool hasSubtitle) const {
   return contentHeight / rowHeight;
 }
 
+int BaseTheme::getListRowStep(bool hasSubtitle) const {
+  return hasSubtitle ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
+}
+
 void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                          const std::function<std::string(int index)>& rowTitle,
                          const std::function<std::string(int index)>& rowSubtitle,
@@ -751,6 +755,22 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
     // Invert text when the tile is selected, to contrast with the filled background
     renderer.drawText(UI_10_FONT_ID, textX, textY, label, selectedIndex != i);
   }
+}
+
+int BaseTheme::hitTestButtonMenu(const GfxRenderer&, Rect rect, const int buttonCount, const int x, const int y) const {
+  if (x < rect.x + BaseMetrics::values.contentSidePadding ||
+      x >= rect.x + rect.width - BaseMetrics::values.contentSidePadding) {
+    return -1;
+  }
+  const int rowStep = BaseMetrics::values.menuRowHeight + BaseMetrics::values.menuSpacing;
+  if (rowStep <= 0) return -1;
+  const int firstTileY = BaseMetrics::values.verticalSpacing + rect.y;
+  if (y < firstTileY) return -1;
+  const int offset = y - firstTileY;
+  const int row = offset / rowStep;
+  if (row < 0 || row >= buttonCount) return -1;
+  if (offset % rowStep >= BaseMetrics::values.menuRowHeight) return -1;  // in the inter-row gap
+  return row;
 }
 
 Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -230,6 +230,11 @@ class BaseTheme {
                                const char* btn4) const;
   virtual void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
   virtual int getListPageItems(int contentHeight, bool hasSubtitle) const;
+  // Pixel height of one drawList() row -- the same value getListPageItems() divides
+  // contentHeight by, exposed on its own for touch hit-testing (MappedInputManager's
+  // list-touch helpers need it to turn a tap Y into a row index without duplicating
+  // this metric lookup).
+  virtual int getListRowStep(bool hasSubtitle) const;
   virtual void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                         const std::function<std::string(int index)>& rowTitle,
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
@@ -248,6 +253,11 @@ class BaseTheme {
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon) const;
+  // Given a point already known to be a tap/touch-down (logical screen coordinates,
+  // e.g. from MappedInputManager::wasScreenTapped), resolves which drawButtonMenu() item
+  // it lands on, or -1 for none. Each override MUST mirror its own drawButtonMenu()'s
+  // geometry exactly -- the two are a layout/hit-test pair, keep them in sync.
+  virtual int hitTestButtonMenu(const GfxRenderer& renderer, Rect rect, int buttonCount, int x, int y) const;
   virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
   virtual void drawOptionPopup(const GfxRenderer& renderer, const char* title, const std::vector<std::string>& options,
                                int selectedIndex) const;

--- a/src/components/themes/foulad/FouladTheme.cpp
+++ b/src/components/themes/foulad/FouladTheme.cpp
@@ -566,3 +566,30 @@ void FouladTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, const int but
     }
   }
 }
+
+int FouladTheme::hitTestButtonMenu(const GfxRenderer& renderer, Rect rect, const int buttonCount, const int x,
+                                   const int y) const {
+  if (buttonCount <= 0) return -1;
+  // Mirrors drawButtonMenu() above line for line -- keep barY/tileWidth/slotIndex in sync
+  // with it exactly. kGlyphStripHeight is that function's own local constant, duplicated
+  // here since it is not file-scope there.
+  constexpr int kGlyphStripHeight = 20;
+  const int barY = renderer.getScreenHeight() - kMenuBandHeight - kGlyphStripHeight;
+  if (y < barY || y >= barY + kMenuBandHeight) return -1;
+
+  const int totalGaps = kMenuGap * (buttonCount - 1);
+  const int tileWidth = (rect.width - kMenuPadding * 2 - totalGaps) / buttonCount;
+  const int step = tileWidth + kMenuGap;
+  if (step <= 0) return -1;
+
+  const int barLeft = rect.x + kMenuPadding;
+  if (x < barLeft) return -1;
+  const int offset = x - barLeft;
+  const int slot = offset / step;
+  if (slot < 0 || slot >= buttonCount) return -1;
+  if (offset % step >= tileWidth) return -1;  // in the inter-tile gap
+
+  // Invert drawButtonMenu()'s slotIndex = rtl ? buttonCount - 1 - i : i -- the mapping is
+  // its own inverse, so the same expression converts a hit slot back to the logical index.
+  return I18N.isRtl() ? buttonCount - 1 - slot : slot;
+}

--- a/src/components/themes/foulad/FouladTheme.h
+++ b/src/components/themes/foulad/FouladTheme.h
@@ -33,4 +33,5 @@ class FouladTheme : public LyraTheme {
   void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                       const std::function<std::string(int index)>& buttonLabel,
                       const std::function<UIIcon(int index)>& rowIcon) const override;
+  int hitTestButtonMenu(const GfxRenderer& renderer, Rect rect, int buttonCount, int x, int y) const override;
 };

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -248,6 +248,27 @@ int LyraTheme::getListPageItems(int contentHeight, bool hasSubtitle) const {
   return contentHeight / rowHeight;
 }
 
+int LyraTheme::getListRowStep(bool hasSubtitle) const {
+  return hasSubtitle ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
+}
+
+int LyraTheme::hitTestButtonMenu(const GfxRenderer&, Rect rect, const int buttonCount, const int x, const int y) const {
+  // Mirrors drawButtonMenu() above: tileRect.x = rect.x + contentSidePadding, no extra
+  // verticalSpacing offset on tileRect.y (unlike BaseTheme's own version).
+  if (x < rect.x + LyraMetrics::values.contentSidePadding ||
+      x >= rect.x + rect.width - LyraMetrics::values.contentSidePadding) {
+    return -1;
+  }
+  const int rowStep = LyraMetrics::values.menuRowHeight + LyraMetrics::values.menuSpacing;
+  if (rowStep <= 0) return -1;
+  if (y < rect.y) return -1;
+  const int offset = y - rect.y;
+  const int row = offset / rowStep;
+  if (row < 0 || row >= buttonCount) return -1;
+  if (offset % rowStep >= LyraMetrics::values.menuRowHeight) return -1;
+  return row;
+}
+
 void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                          const std::function<std::string(int index)>& rowTitle,
                          const std::function<std::string(int index)>& rowSubtitle,

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -93,6 +93,8 @@ class LyraTheme : public BaseTheme {
   void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,
                   bool selected) const override;
   int getListPageItems(int contentHeight, bool hasSubtitle) const override;
+  int getListRowStep(bool hasSubtitle) const override;
+  int hitTestButtonMenu(const GfxRenderer& renderer, Rect rect, int buttonCount, int x, int y) const override;
   void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                 const std::function<std::string(int index)>& rowTitle,
                 const std::function<std::string(int index)>& rowSubtitle,


### PR DESCRIPTION
## DO NOT merge without touch hardware — no touch-capable device exists in this fork yet

Ports upstream CrossPoint's `MappedInputManager` touch bridge (Path 2 of their \`docs/contributing/touch-and-ui.md\`: layers tap/hold/swipe onto **existing** hand-rolled theme rendering, no framework rewrite) and wires it into the Home screen menu using our own FouladTheme, per direction to use \"our theme\" rather than switch to upstream's separate FreeInkUI component framework (Path 1).

## New infrastructure (each piece verified as far as possible without touch hardware)

- **`GfxRenderer::tapToLogical()`** — maps a normalized touch point to logical screen coordinates. Verified as the exact mathematical inverse of this fork's own \`rotateCoordinates()\` for all four orientations by hand-deriving each case algebraically, then confirming it matches upstream's implementation term-for-term (not copied on faith).
- **`HalGPIO` touch pass-through** — thin wrappers over \`InputManager\`'s existing touch API (\`hasTouch\`/\`wasTouchTap\`/\`isTouchTapCandidate\`/\`isTouchHeldAt\`/\`lastTouchHeldMs\`/\`wasSwipe\`), inert on non-touch boards per its own contract.
- **`MappedInputManager`**: ported upstream's touch/gesture primitives verbatim (\`wasScreenTapped\`, \`wasScreenTouchDown\`, \`isScreenTouchHeld\`, \`wasTapInRect\`, \`wasListItemTapped\`/\`TouchedDown\`, \`rowTouch\`, \`colTouch\`, \`wasSwipe\`, \`wasHomeGesture\`, \`wasMenuGesture\`), merged alongside (not overwriting) this fork's existing RTL-aware \`NavNext\`/\`NavPrevious\`/\`ScrollNext\`/\`ScrollPrevious\` logic that upstream doesn't have. \`ScreenLeft/Right/Up/Down\` + \`mapDirectionalLabels()\` intentionally **not** ported — out of scope for this slice (button-remapping ergonomics, not touch).
- **`BaseTheme::getListRowStep()`/`hitTestButtonMenu()`** (+ `LyraTheme` override) — generic geometry exposed for touch hit-testing, matching the existing \`getListPageItems()\` pattern.

## The part that actually matters: `FouladTheme::hitTestButtonMenu()`

This fork's real, only shipping theme. Its \`drawButtonMenu()\` turned out to render a **horizontal bottom bar with RTL slot-reordering**, not the vertical list \`BaseTheme\`/\`LyraTheme\` use — caught by reading the actual implementation before writing hit-test code, not assumed from the other two themes' pattern. (An earlier version of this work would have used the wrong geometry entirely — vertical row hit-testing against a horizontal bar.) Hand-verified: the tile-partition math (480px screen, 4 items, 16px padding, 8px gaps → four 106px tiles, no overlap, no gap collision) and the RTL slot-index inversion (self-inverse; a slot-0 tap correctly resolves to logical item 3 when mirrored).

## Home screen wiring

\`HomeActivity::loop()\`: touch-down on a menu tile updates the selection highlight; a completed tap selects and activates it (the same switch statement \`Confirm\` already used, now reached via an \`activate\` flag either input source can set). Scoped to \`!metrics.homeContinueReadingInMenu\` (true for FouladTheme; LyraTheme's own \"Continue Reading\" first-tile echo of the cover-row selection isn't touch-mapped yet). Recent-book cover-tile tapping is **not** wired up in this slice — menu only.

## Simulator patch (ephemeral, needs documenting)

Patches the simulator's vendored \`HalGPIO.h\` with matching inert touch stubs — gitignored, needs re-applying after a libdeps re-fetch, same category as the existing patches a–e in \`.skills/SKILL.md\`. Not yet added there (follow-up).

## Test plan
- [x] \`pio run -e default\` — clean build
- [x] \`pio run -e simulator\` — clean build + link (required the HalGPIO stub patch, confirming the simulator's own documented \"HAL stub rule\")
- [x] \`pio check --skip-packages -e default\` — no findings
- [x] \`clang-format\` — clean
- [x] Simulator boots and renders Home with zero regressions — but the touch code path is inert there (\`InputManager\`'s touch stubs return \`false\`), so this only confirms no crash, not that hit-test geometry is correct on a real panel
- [ ] **On-device: does a real finger tap on a real Sticky/X4 Pro unit land on the tile it looks like it should?** Geometry is hand-traced correct, not device-tested
- [ ] Recent-book cover-tile touch (deferred to a follow-up slice)
- [ ] Add the simulator HalGPIO patch to \`.skills/SKILL.md\`'s documented list

Depends on PR #122 (ESP32-S3 foundation) for actual touch-capable hardware to test against.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e