### PR TITLE
fix: re-check heap before OPDS cover decode, not just before download

### DIFF
--- a/src/OpdsCoverCache.cpp
+++ b/src/OpdsCoverCache.cpp
@@ -12,6 +12,24 @@
 namespace {
 constexpr char CACHE_DIR[] = "/.crosspoint/opds_covers";
 constexpr char TEMP_PATH[] = "/.crosspoint/opds_covers/.tmp_cover";
+
+// Same thresholds as OpdsBookBrowserActivity.cpp's hasHeapForCoverWork() (that crash's
+// own diagnosis: a blank-panic report from 1.8.40-rc traced to an ordinary std::string
+// growth hitting the throwing global operator new under -fno-exceptions, which calls
+// std::terminate() directly -- no abort() message, hence no panic reason recorded).
+// That guard runs once per cover, before this whole function starts. It does not cover
+// THIS function's own multi-step sequence: HttpDownloader::downloadToFile() (HTTP/TLS
+// buffers) then the PNG/JPEG decoder (its own working buffers) each fragment the heap
+// further, and every std::string built in between -- including getOpdsCoverCachePath()
+// itself, called again below -- is exposed to the same failure mode regardless of how
+// healthy the heap looked when the caller's pre-loop check ran. Re-checking here, after
+// the download and before the decode, catches a heap that degraded during THIS cover's
+// own download rather than a previous one's.
+bool hasHeapForCoverDecode() {
+  constexpr uint32_t COVER_MIN_FREE_HEAP = 32 * 1024;
+  constexpr uint32_t COVER_MIN_FREE_BLOCK = 12 * 1024;
+  return ESP.getFreeHeap() > COVER_MIN_FREE_HEAP && ESP.getMaxAllocHeap() > COVER_MIN_FREE_BLOCK;
+}
 }  // namespace
 
 std::string getOpdsCoverCachePath(const std::string& entryId, int width, int height) {
@@ -44,6 +62,19 @@ bool ensureOpdsCoverCached(const OpdsEntry& entry, const std::string& username, 
       HttpDownloader::downloadToFile(entry.coverUrl, TEMP_PATH, nullptr, nullptr, username, password);
   if (downloadResult != HttpDownloader::OK) {
     LOG_ERR("OPDSCOVER", "Failed to download cover: %s", entry.coverUrl.c_str());
+    return false;
+  }
+
+  if (!hasHeapForCoverDecode()) {
+    // The download itself (HTTP/TLS buffers, chunked reads) can fragment the heap enough
+    // to make the decode below -- or even the string work already ahead of it -- unsafe,
+    // regardless of how healthy heap looked when the caller checked before starting this
+    // cover. Bail before touching the decoder; the downloaded temp file is discarded, and
+    // this cover is simply left uncached for a later, healthier visit (same trade
+    // loadGridPageCovers already makes for its own pre-loop check).
+    LOG_ERR("OPDSCOVER", "Skipping decode, low heap after download: free=%u largest=%u",
+            static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    Storage.remove(TEMP_PATH);
     return false;
   }
 


### PR DESCRIPTION
## Responding to a real crash report from tonight's on-device X3 testing (RC 1.8.75)

Panic reason blank, heap sample 55900 free / 40948 largest right before it, last logs showing \`/opds/collections\` (11 entries) fetched successfully, then four more HTTP connections with no matching \`[OPDS] FETCH\` completion line — i.e. this happened in the **collection-tile cover download loop** (\`loadGridPageCovers\` → \`ensureOpdsCoverCached\`), not a single tap-to-open-a-collection navigation.

## Why I believe this is the same bug class as a previously-diagnosed crash

A blank panic reason on this firmware means \`std::terminate()\` was called directly, not through the app's own \`abort()\`/panic hooks. This repo's own comment at \`OpdsBookBrowserActivity.cpp:842\` already diagnosed the **identical signature** once before (1.8.40-rc): an ordinary \`std::string\`/\`std::vector\` growth hit the throwing global \`operator new\` under \`-fno-exceptions\`, which has no nothrow equivalent the way \`makeUniqueNoThrow\` covers explicit buffers.

That prior fix (\`hasHeapForNavigation()\`) guards the tap-to-open path. The cover-download loop has its own equivalent guard (\`hasHeapForCoverWork()\`), but it only checks **once per cover, before** \`ensureOpdsCoverCached()\`'s full download + PNG/JPEG-decode + file-write sequence starts. The download itself (HTTP/TLS buffers, chunked reads) can fragment the heap enough to make the decode step — or the string work immediately around it — unsafe, regardless of how healthy free heap looked when the loop's pre-iteration check ran. The crash report's own heap snapshot is a periodic sample (\"a moment before\", per this repo's own \`noteHeap()\` comment), not the instant of failure, so it doesn't rule out a worse transient dip during this cover's own decode.

## The fix

Adds a second heap-floor check inside \`ensureOpdsCoverCached()\`, after the download completes and before the decode/file-write steps begin, using the same thresholds as the existing pre-loop guard. On failure, the downloaded temp file is discarded and the cover is left uncached for a later, healthier visit — the same trade the pre-loop guard already makes for a cover it never starts.

## Honesty about certainty

**This is an evidence-based hypothesis matching a previously-diagnosed root cause and code path, not a confirmed fix.** The crash report is an unsymbolized RISC-V stack dump with no function names, so I can't pinpoint the exact failing allocation the way the original 1.8.40-rc investigation could (it had a full symbolized trace). This needs on-device re-testing to confirm the crash actually stops recurring — I can't verify that myself.

## Test plan
- [x] \`pio run -e default\` — clean build
- [x] \`pio check --skip-packages -e default\` — no findings
- [x] \`clang-format\` — clean
- [ ] **On-device: does browsing OPDS collections still crash?** (you're already testing this build — this is the concrete next thing to check)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e