### PR TITLE
fix: log crash summary locally before flushing crash_report.txt

### DIFF
--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -63,6 +63,16 @@ std::string displayName() { return std::string("Foulad eInk (") + (gpio.deviceIs
 // the SD card, the same way OPDS browsing/downloading already can.
 void diagLog(const std::string& line) { RollingSdLog::append(DebugLog::PATH, "[FDT] " + line, DebugLog::MAX_LINES); }
 
+// For the crash_report.txt upload/flush lifecycle specifically (see
+// flushPendingCrashReport()) -- forces through RollingSdLog's debugLoggingEnabled gate.
+// Routine FDT chatter (register/firmware-check/device-stats above) stays opt-in via
+// diagLog(), but these three lines are the only local record of an actual panic once
+// crash_report.txt itself is deleted, and per CrossPointSettings::debugLoggingEnabled's
+// own carve-out, crash reporting must survive regardless of the debug-logging preference.
+void criticalDiagLog(const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[FDT] " + line, DebugLog::MAX_LINES, /*force=*/true);
+}
+
 // Web (and on-device) Arabic font picker index -> actual stored
 // ARABIC_FONT_FAMILY value. NOT a 1:1 mapping: AMIRI(=1) was dropped from
 // flash and is skipped by both UIs (see SettingsList.h's
@@ -737,8 +747,8 @@ bool uploadCrashReport(const std::string& username, const std::string& password)
   }
   // Unlike uploadDebugLog(), diagLog() here is safe either way: this writes to
   // /debug_log.txt, a different file than the one just uploaded.
-  diagLog(ok ? "crash report upload -> ok"
-             : "crash report upload -> FAIL status=" + std::to_string(HttpDownloader::getLastFailure().detail));
+  criticalDiagLog(ok ? "crash report upload -> ok"
+                     : "crash report upload -> FAIL status=" + std::to_string(HttpDownloader::getLastFailure().detail));
   return ok;
 }
 
@@ -748,13 +758,13 @@ void flushPendingCrashReport(const std::string& username, const std::string& pas
   // See readCrashReportSummary(): capture the panic reason locally before the SD
   // copy is deleted below, since the upload+delete can happen on a boot after the
   // one the user actually has eyes on.
-  diagLog("crash summary: " + readCrashReportSummary());
+  criticalDiagLog("crash summary: " + readCrashReportSummary());
   // Delivered: drop the local copy so the next connection does not resend it.
   // Deliberately only on success -- a failed upload leaves the file for the next
   // attempt, which is the whole point of queueing it rather than requiring the
   // user to be looking at the crash screen at the moment they have WiFi.
   Storage.remove(CRASH_REPORT_PATH);
-  diagLog("crash report flushed and cleared");
+  criticalDiagLog("crash report flushed and cleared");
 }
 
 void reportDeviceStats(const std::string& username, const std::string& password) {

--- a/src/FouladDeviceTracking.cpp
+++ b/src/FouladDeviceTracking.cpp
@@ -675,6 +675,34 @@ std::string readCrashReportVersion() {
   return head.substr(start, end == std::string::npos ? std::string::npos : end - start);
 }
 
+// Condenses the "Panic reason" and "Heap before panic" lines out of crash_report.txt
+// for the debug log -- readCrashReportVersion()'s technique (small bounded read, not
+// the full multi-KB report with its backtrace/last-logs sections). This is what lets
+// a "crash happened but I can't find crash_report.txt" report get diagnosed at all:
+// flushPendingCrashReport() deletes the SD copy once it's uploaded, which can be a
+// LATER boot than the one that crashed -- so a user checking the SD card afterward
+// finds nothing, even though the crash was real and the report made it to the server.
+// Logging this summary into debug_log.txt (the file users already pull off the device)
+// before deletion keeps the panic reason visible locally too.
+std::string readCrashReportSummary() {
+  HalFile f;
+  if (!Storage.openFileForRead(TAG, CRASH_REPORT_PATH, f)) return "(unreadable)";
+  char buf[512] = {};
+  const int read = f.read(reinterpret_cast<uint8_t*>(buf), sizeof(buf) - 1);
+  if (read <= 0) return "(unreadable)";
+  const std::string head(buf, static_cast<size_t>(read));
+
+  auto extractLine = [&](const char* prefix) -> std::string {
+    const size_t at = head.find(prefix);
+    if (at == std::string::npos) return "?";
+    const size_t start = at + strlen(prefix);
+    const size_t end = head.find_first_of("\r\n", start);
+    return head.substr(start, end == std::string::npos ? std::string::npos : end - start);
+  };
+
+  return "reason=[" + extractLine("Panic reason: ") + "] heap=[" + extractLine("Heap before panic: ") + "]";
+}
+
 bool uploadCrashReport(const std::string& username, const std::string& password) {
   if (!wifiConnected() || username.empty() || password.empty()) return false;
   if (!Storage.exists(CRASH_REPORT_PATH)) return false;
@@ -717,6 +745,10 @@ bool uploadCrashReport(const std::string& username, const std::string& password)
 void flushPendingCrashReport(const std::string& username, const std::string& password) {
   if (!Storage.exists(CRASH_REPORT_PATH)) return;  // nothing waiting
   if (!uploadCrashReport(username, password)) return;
+  // See readCrashReportSummary(): capture the panic reason locally before the SD
+  // copy is deleted below, since the upload+delete can happen on a boot after the
+  // one the user actually has eyes on.
+  diagLog("crash summary: " + readCrashReportSummary());
   // Delivered: drop the local copy so the next connection does not resend it.
   // Deliberately only on success -- a failed upload leaves the file for the next
   // attempt, which is the whole point of queueing it rather than requiring the

--- a/src/OpdsCoverCache.cpp
+++ b/src/OpdsCoverCache.cpp
@@ -8,6 +8,8 @@
 #include <PngToBmpConverter.h>
 
 #include "network/HttpDownloader.h"
+#include "util/DebugLog.h"
+#include "util/RollingSdLog.h"
 
 namespace {
 constexpr char CACHE_DIR[] = "/.crosspoint/opds_covers";
@@ -74,6 +76,15 @@ bool ensureOpdsCoverCached(const OpdsEntry& entry, const std::string& username, 
     // loadGridPageCovers already makes for its own pre-loop check).
     LOG_ERR("OPDSCOVER", "Skipping decode, low heap after download: free=%u largest=%u",
             static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    // Forced through the debugLoggingEnabled gate (see RollingSdLog::append) -- this is
+    // the exact defensive bail this fix exists for (OpdsBookBrowserActivity.cpp's
+    // hasHeapForNavigation()/hasHeapForCoverWork() comments have the full crash history),
+    // and a near-miss save is worth as much locally as the crash it prevented.
+    RollingSdLog::append(
+        DebugLog::PATH,
+        "[OPDSCOVER] Skipping decode, low heap after download: free=" + std::to_string(ESP.getFreeHeap()) +
+            " largest=" + std::to_string(ESP.getMaxAllocHeap()) + " url=" + entry.coverUrl,
+        DebugLog::MAX_LINES, /*force=*/true);
     Storage.remove(TEMP_PATH);
     return false;
   }

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -97,13 +97,22 @@ int moveVerticalInGrid(const int currentIndex, const int totalItems, const int c
 // (see util/DebugLog.h). Lets the user grab a diagnostic log via File
 // Browser/File Transfer without needing a live serial connection, the same way
 // they already can for a crash.
-void saveOpdsDiagnosticLog(const std::string& context) {
-  if (!DebugLogging::enabled()) return;
+//
+// force=true bypasses the debugLoggingEnabled gate (see RollingSdLog::append) --
+// reserved for the heap-guard trip points below (hasHeapForCoverWork/
+// hasHeapForNavigation), which are the exact defense that heads off the
+// throwing-`new`-under-`-fno-exceptions` crash class documented at
+// hasHeapForNavigation()'s definition. A near-miss save is as diagnostically
+// valuable as the crash it prevented, and the sessions that need it most are
+// the ones where nobody thought to turn debug logging on ahead of time. Routine
+// fetch/parse/auth failures below stay opt-in.
+void saveOpdsDiagnosticLog(const std::string& context, bool force = false) {
+  if (!force && !DebugLogging::enabled()) return;
   std::string info = "[OPDS-ERROR] CrossPoint version: " CROSSPOINT_VERSION;
   info += " | Context: " + context;
   info += "\nLast logs:\n" + getLastLogs();
 
-  RollingSdLog::append(DebugLog::PATH, info, DebugLog::MAX_LINES);
+  RollingSdLog::append(DebugLog::PATH, info, DebugLog::MAX_LINES, force);
   LOG_INF("OPDS", "Saved diagnostic log to %s", DebugLog::PATH);
 }
 
@@ -901,8 +910,9 @@ void OpdsBookBrowserActivity::loadGridPageCovers(const GridLayout& layout, const
         // chance to abort. The uncached covers stay uncached and are picked up on a
         // later visit, when the walk that fragmented the heap is behind us.
         saveOpdsDiagnosticLog("Cover fetch stopped early, low heap: free=" + std::to_string(ESP.getFreeHeap()) +
-                              " largest=" + std::to_string(ESP.getMaxAllocHeap()) + " at book " +
-                              std::to_string(i - pageStart + 1) + "/" + std::to_string(totalToProcess));
+                                  " largest=" + std::to_string(ESP.getMaxAllocHeap()) + " at book " +
+                                  std::to_string(i - pageStart + 1) + "/" + std::to_string(totalToProcess),
+                              /*force=*/true);
         LOG_ERR("OPDS", "Cover fetch stopped early (free heap %u)", static_cast<unsigned>(ESP.getFreeHeap()));
         break;
       }
@@ -1107,6 +1117,9 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
               " prev=" + (feedPrevUrl.empty() ? "-" : feedPrevUrl));
   } else {
     LOG_ERR("OPDS", "Skipped FETCH diagnostic log, low heap: free=%u", static_cast<unsigned>(ESP.getFreeHeap()));
+    saveOpdsDiagnosticLog(
+        "Skipped FETCH diagnostic log, low heap: free=" + std::to_string(ESP.getFreeHeap()) + " url=" + url,
+        /*force=*/true);
   }
   requestUpdate();
 }
@@ -1117,6 +1130,9 @@ void OpdsBookBrowserActivity::navigateToEntry(const OpdsEntry& entry) {
   // the way explicit buffers do. Declining up front beats a silent abort mid-navigation.
   if (!hasHeapForNavigation()) {
     LOG_ERR("OPDS", "Navigation stopped early, low heap: free=%u", static_cast<unsigned>(ESP.getFreeHeap()));
+    saveOpdsDiagnosticLog(
+        "Navigation stopped early, low heap: free=" + std::to_string(ESP.getFreeHeap()) + " entry=" + entry.id,
+        /*force=*/true);
     state = BrowserState::ERROR;
     errorMessage = tr(STR_MEMORY_ERROR);
     requestUpdate();

--- a/src/util/RollingSdLog.h
+++ b/src/util/RollingSdLog.h
@@ -23,8 +23,15 @@ namespace RollingSdLog {
 // single call, fragmenting the heap further before the growth that aborted.
 constexpr uint32_t MIN_SAFE_HEAP_BYTES = 32768;
 
-inline void append(const char* path, const std::string& line, size_t maxLines) {
-  if (!DebugLogging::enabled() || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
+// force=true bypasses the debugLoggingEnabled gate (still subject to maxLines and the
+// heap-safety floor above). Mirrors CrossPointSettings::debugLoggingEnabled's own
+// carve-out for crash_report.txt: routine per-subsystem chatter stays opt-in so ordinary
+// users don't get SD clutter, but a one-shot event that heads off or explains an actual
+// crash must survive regardless -- those are exactly the sessions where nobody thought to
+// turn debug logging on ahead of time. Use sparingly: reserved for panic-adjacent
+// diagnostics (heap-guard trip points, crash summaries), not routine subsystem logging.
+inline void append(const char* path, const std::string& line, size_t maxLines, bool force = false) {
+  if ((!force && !DebugLogging::enabled()) || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
 
   const String existing = Storage.readFile(path);
   const char* data = existing.c_str();


### PR DESCRIPTION
## Summary
- `flushPendingCrashReport()` uploads `crash_report.txt` to the server, then deletes the SD copy — but that upload+delete can happen on a **later boot** than the one that actually crashed (device needs WiFi + login to flush). A user who checks the SD card after that later boot finds nothing, even though the crash was real and the report reached the server.
- Diagnosed from a live device log (`debug_log_5.txt`): shows `[FDT] crash report upload -> ok` / `crash report flushed and cleared` two boots after the actual crash (which happened right after browsing `/opds/collections`), with no local trace left of the panic reason.
- Adds `readCrashReportSummary()` (mirrors `readCrashReportVersion()`'s bounded-read technique) to extract the `Panic reason:` and `Heap before panic:` lines, logged into `debug_log.txt` immediately before the SD copy is removed.

**Follow-up in this branch:** the first pass above still went through `diagLog()`, which — like every other diagnostic breadcrumb in this codebase (SLEEP/OPDS/COVER/FDT/etc.) — is gated behind `CrossPointSettings::debugLoggingEnabled` (off by default). That silently defeated the whole point: the sessions that need this most are exactly the ones where nobody thought to turn debug logging on ahead of time. `debugLoggingEnabled`'s own doc comment already carves out `crash_report.txt` from this gate ("must always work regardless of this setting") — this extends that same carve-out to the crash-adjacent diagnostics:
- Added an opt-in `force` bypass to `RollingSdLog::append()` (still subject to the existing heap-safety floor).
- Used it for the whole crash-reporting lifecycle (`FouladDeviceTracking.cpp`: upload ok/FAIL, crash summary, flushed-and-cleared).
- Used it for every heap-guard trip point in the recent OPDS crash-hardening work: `hasHeapForCoverWork()`, `hasHeapForNavigation()` (both call sites — the FETCH-log skip and the `navigateToEntry()` bail itself, the exact site of the documented 1.8.40-rc crash), and `OpdsCoverCache`'s `hasHeapForCoverDecode()` (from #127). A near-miss save is diagnostically worth as much as the crash it prevented.
- Routine per-subsystem logging (register/firmware-check/reading-stats, SLEEP/BATTERY/GYM/READERPERF, routine OPDS fetch/parse/auth failures) stays opt-in, unchanged — this only forces through lines that are part of an actual panic or the defensive bail that averted one.

## Test plan
- [x] `pio run -e default` — clean build
- [x] `pio check` (cppcheck) — no defects
- [x] `clang-format` — applied, no logic changes
- [ ] On-device: trigger a panic (or a heap-guard bail) with Debug Logging **off**, confirm `debug_log.txt` now contains the `[FDT]`/`[OPDS]`/`[OPDSCOVER]` line anyway, and that `crash_report.txt` still always writes regardless