### PR TITLE
fix: stop RollingSdLog::append() from rebuilding the whole file every call

### DIFF
--- a/src/util/RollingSdLog.h
+++ b/src/util/RollingSdLog.h
@@ -8,9 +8,10 @@
 
 #include "util/DebugLogging.h"
 
-// Shared read-modify-write implementation behind ReaderPerfLog, SleepDiagLog,
-// and GameInputDiagLog. Read-modify-write since HalStorage has no append mode;
-// bounded by maxLines so the cost stays small even after a long session.
+// Shared logger behind ReaderPerfLog, SleepDiagLog, GameInputDiagLog, and the rest of
+// DebugLog.h's subsystems. The common case is a cheap O_APPEND write of one line; trimming
+// back to maxLines needs a read-modify-write of the whole file and only runs occasionally
+// (see trim() below), not on every call.
 namespace RollingSdLog {
 
 // Skip the write (rather than crash) when free heap is too tight. Under
@@ -23,19 +24,40 @@ namespace RollingSdLog {
 // single call, fragmenting the heap further before the growth that aborted.
 constexpr uint32_t MIN_SAFE_HEAP_BYTES = 32768;
 
-// force=true bypasses the debugLoggingEnabled gate (still subject to maxLines and the
-// heap-safety floor above). Mirrors CrossPointSettings::debugLoggingEnabled's own
-// carve-out for crash_report.txt: routine per-subsystem chatter stays opt-in so ordinary
-// users don't get SD clutter, but a one-shot event that heads off or explains an actual
-// crash must survive regardless -- those are exactly the sessions where nobody thought to
-// turn debug logging on ahead of time. Use sparingly: reserved for panic-adjacent
-// diagnostics (heap-guard trip points, crash summaries), not routine subsystem logging.
-inline void append(const char* path, const std::string& line, size_t maxLines, bool force = false) {
-  if ((!force && !DebugLogging::enabled()) || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
+// A second, later real-device crash report (blank panic reason, free heap a healthy-looking
+// 54428 bytes but largest contiguous block only 22516) had this exact function's rebuilt
+// std::string sitting in the panic stack dump. MIN_SAFE_HEAP_BYTES above only checks total
+// free heap; it says nothing about whether a SINGLE CONTIGUOUS block big enough for the
+// whole file (readFile()'s String plus the rebuilt std::string, both roughly file-sized) is
+// actually available, which is exactly what a read-modify-write on every call needs and
+// exactly what fragmentation starves first. Appending is now a plain O_APPEND write (no
+// read, no file-sized allocation); trim() below still does the expensive rewrite, but only
+// once the file has grown TRIM_SLACK_LINES past target, and skips itself on a still-tight
+// contiguous block rather than risking the abort -- the file is simply left to trim on a
+// later, healthier call.
+constexpr size_t TRIM_SLACK_LINES = 64;
+// Conservative estimate of a tagged log line ("[SUBSYSTEM] ..." + newline), used only to
+// decide WHEN trim() should run from a cheap fileSize() check -- not exact byte accounting.
+constexpr size_t ASSUMED_BYTES_PER_LINE = 96;
+
+// Re-reads the file, keeps only its last `maxLines` lines, and rewrites it. `knownSize` is
+// the file size the caller already measured via fileSize() moments ago (append()'s own
+// write) -- checked BEFORE calling readFile() below, since readFile() is itself the first
+// of the two large allocations this guard exists to avoid making blind. Trimming only ever
+// drops TRIM_SLACK_LINES worth of bytes off a file of roughly knownSize, so `existing` and
+// the rebuilt `out` are both roughly knownSize -- two separate allocations that need to
+// coexist, hence the 2x (getMaxAllocHeap() only reports the single largest free block, not
+// whether a second, similarly-sized block also exists, so this is a heuristic, not a
+// guarantee). See TRIM_SLACK_LINES above for why this runs rarely instead of on every
+// append(), and why it bails out (leaving the file to trim on a later call) rather than
+// force the read-modify-write through a contiguous block too small for it.
+inline void trim(const char* path, size_t maxLines, size_t knownSize) {
+  if (ESP.getMaxAllocHeap() < knownSize * 2 + 256) return;
 
   const String existing = Storage.readFile(path);
   const char* data = existing.c_str();
   const size_t len = existing.length();
+  if (len == 0) return;
 
   // Pass 1: count existing lines (a trailing line with no final '\n' still counts).
   size_t totalLines = 0;
@@ -48,13 +70,12 @@ inline void append(const char* path, const std::string& line, size_t maxLines, b
       pos = static_cast<size_t>(nl - data) + 1;
     }
   }
+  if (totalLines <= maxLines) return;  // grew past the trim trigger but not past maxLines itself
 
-  // Pass 2: find the byte offset of the first line to keep, so the new line
-  // still fits within maxLines total without ever materializing per-line copies.
-  const size_t keepExisting = totalLines > maxLines - 1 ? maxLines - 1 : totalLines;
-  const size_t skipLines = totalLines - keepExisting;
+  // Pass 2: find the byte offset of the first line to keep.
+  const size_t skipLines = totalLines - maxLines;
   size_t keepFrom = 0;
-  if (skipLines > 0) {
+  {
     size_t pos = 0, skipped = 0;
     while (pos < len && skipped < skipLines) {
       const char* nl = static_cast<const char*>(memchr(data + pos, '\n', len - pos));
@@ -68,15 +89,35 @@ inline void append(const char* path, const std::string& line, size_t maxLines, b
     keepFrom = pos;
   }
 
-  const size_t keptLen = len - keepFrom;
   std::string out;
-  out.reserve(keptLen + line.size() + 1);
-  out.append(data + keepFrom, keptLen);
-  if (!out.empty() && out.back() != '\n') out += '\n';
-  out += line;
-  out += '\n';
-
+  out.reserve(len - keepFrom);
+  out.append(data + keepFrom, len - keepFrom);
   Storage.writeFile(path, out.c_str());
+}
+
+// force=true bypasses the debugLoggingEnabled gate (still subject to maxLines and the
+// heap-safety floor above). Mirrors CrossPointSettings::debugLoggingEnabled's own
+// carve-out for crash_report.txt: routine per-subsystem chatter stays opt-in so ordinary
+// users don't get SD clutter, but a one-shot event that heads off or explains an actual
+// crash must survive regardless -- those are exactly the sessions where nobody thought to
+// turn debug logging on ahead of time. Use sparingly: reserved for panic-adjacent
+// diagnostics (heap-guard trip points, crash summaries), not routine subsystem logging.
+inline void append(const char* path, const std::string& line, size_t maxLines, bool force = false) {
+  if ((!force && !DebugLogging::enabled()) || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
+
+  HalFile file = Storage.open(path, O_WRITE | O_CREAT | O_APPEND);
+  if (!file) return;
+  file.write(line.data(), line.size());
+  file.write(static_cast<uint8_t>('\n'));
+  const size_t sizeAfter = file.fileSize();
+  // Close before trim() below reopens the same path for read then write (DESTRUCTOR_CLOSES_FILE
+  // handles this file's own eventual scope exit, but that's too late for trim()'s reopen).
+  file.close();
+
+  const size_t trimTriggerBytes = (maxLines + TRIM_SLACK_LINES) * ASSUMED_BYTES_PER_LINE;
+  if (sizeAfter > trimTriggerBytes) {
+    trim(path, maxLines, sizeAfter);
+  }
 }
 
 }  // namespace RollingSdLog


### PR DESCRIPTION
## Summary

Root-cause fix for a real-device crash on the RC that shipped #128 (`v1.8.77-rc+df0550c`).

- `crash_report_4.txt`: blank `Panic reason:` (the throwing-`operator new`-under-`-fno-exceptions` signature we've chased before), `Heap before panic: free 54428 bytes, largest block 22516 bytes`. Free heap looked healthy; the largest *contiguous* block did not.
- The panic's raw stack dump decodes (verified byte-for-byte) to `"75634 pressed=1 rele..."` — an exact fragment of the `[SLEEP]` diag log line written immediately before the crash, matching `debug_log_6.txt`'s timestamp exactly. That implicates `RollingSdLog::append()` itself, not the OPDS heap guards from #127/earlier.
- `RollingSdLog::append()` read the *entire* shared `/debug_log.txt` (up to 500 rolling lines across every subsystem — SLEEP/OPDS/BATTERY/GYM/READERPERF/COVER/FDT/etc.) into a `String`, then rebuilt it as a second full-size `std::string`, **on every single log line, from every subsystem**. That's one contiguous allocation roughly the size of the whole file, twice, per call. The only guard was total free heap (`MIN_SAFE_HEAP_BYTES`) — nothing checked the largest contiguous block, which is exactly what fragmentation starves first. The function's own comment already documented an earlier real-device abort of this same shape (heap ~21KB, page-turn font buffers) — this is a **second, independent confirmation** of the same structural weakness, not a new theory.

## Fix

- The common case (one line) is now a plain `O_APPEND` write — no read, no file-sized allocation.
- The expensive read-modify-write moved into a new `trim()`, which only runs once the file has grown `TRIM_SLACK_LINES` (64 lines) past target — not on every append.
- `trim()` checks `ESP.getMaxAllocHeap()` against the **already-known** file size (measured via `fileSize()` right after the append, so we never blindly call `readFile()` first) before doing anything, and bails out — leaving the file to trim on a later, healthier call — rather than risk the abort.
- Confirmed `O_WRITE | O_CREAT | O_APPEND` resolves correctly on both targets: real device via SdFat's own flag values, simulator via `<fcntl.h>`'s native POSIX values (checked both headers directly).

## Test plan
- [x] `pio run -e default` — clean build
- [x] `pio check` (cppcheck) — no defects
- [x] `clang-format` — applied
- [x] Host-side validation of `trim()`'s line-accounting logic against synthetic multi-line input: exact trim boundary (564→500 lines, correct first/last surviving line), no-op when already ≤ maxLines, no-trailing-newline edge case — all pass
- [ ] On-device: heavy OPDS browsing session with Debug Logging on, confirm `debug_log.txt` keeps growing/trimming correctly and no crash recurs at the same heap shape (~54KB free / ~22KB largest block)