### PR TITLE
fix: replace two bare-throwing-new allocations with makeUniqueNoThrow

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -52,7 +52,9 @@
 #include "fontIds.h"
 #include "util/BookReaderSettings.h"
 #include "util/BookmarkUtil.h"
+#include "util/DebugLog.h"
 #include "util/ReaderPerfLog.h"
+#include "util/RollingSdLog.h"
 #include "util/ScreenshotUtil.h"
 
 namespace {
@@ -1662,7 +1664,22 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // line below reports THIS chapter's SD I/O, not whatever leaked over from
     // the previous page turn's render-time prewarm.
     if (auto* fcmForBuildStats = renderer.getFontCacheManager()) fcmForBuildStats->resetStats();
-    section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+    section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
+    if (!section) {
+      // Bare `new` under -fno-exceptions calls abort() on OOM instead of returning nullptr
+      // (see CLAUDE.md) -- this is the primary chapter-load path, crossed on every chapter
+      // transition, so it gets the same makeUniqueNoThrow treatment as every other fallible
+      // allocation. Leaving `section` null and returning lets the next render() tick retry
+      // once whatever fragmented the heap has cleared, the same trade already made by
+      // hasHeapForNavigation()/hasHeapForCoverWork() in the OPDS browser.
+      LOG_ERR("ERS", "OOM building Section for spine index %d: free=%u largest=%u", currentSpineIndex,
+              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+      RollingSdLog::append(DebugLog::PATH,
+                           "[ERS] OOM building Section spine=" + std::to_string(currentSpineIndex) + " free=" +
+                               std::to_string(ESP.getFreeHeap()) + " largest=" + std::to_string(ESP.getMaxAllocHeap()),
+                           DebugLog::MAX_LINES, /*force=*/true);
+      return;
+    }
 
     // A finalized cache serves every page as-is. A partial cache (suspended build from a
     // previous session) serves its pages instantly too, but a build must still run to lay

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_sntp.h>
 #include <esp_wifi.h>
@@ -24,6 +25,8 @@
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/DebugLog.h"
+#include "util/RollingSdLog.h"
 
 namespace {
 DocumentMatchMethod alternateMatchMethod(const DocumentMatchMethod method) {
@@ -64,7 +67,21 @@ void syncTimeWithNTP() {
 void KOReaderSyncActivity::ensureEpubLoaded() {
   if (!epub) {
     LOG_DBG("KOSync", "Loading epub for progress mapping (heap: %u)", (unsigned)ESP.getFreeHeap());
-    epub = std::make_shared<Epub>(epubPath, "/.crosspoint");
+    // Bare `new` under -fno-exceptions calls abort() on OOM instead of returning nullptr (see
+    // CLAUDE.md) -- std::make_shared<Epub>(...) is exactly that. ReaderActivity::loadEpub()
+    // already uses makeUniqueNoThrow<Epub>() for this same constructor; this member happens to
+    // be a shared_ptr (converts implicitly from the unique_ptr makeUniqueNoThrow returns) but
+    // needs the identical OOM guard.
+    epub = makeUniqueNoThrow<Epub>(epubPath, "/.crosspoint");
+    if (!epub) {
+      LOG_ERR("KOSync", "OOM allocating Epub for progress mapping: free=%u largest=%u",
+              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+      RollingSdLog::append(DebugLog::PATH,
+                           "[KOSync] OOM allocating Epub: free=" + std::to_string(ESP.getFreeHeap()) +
+                               " largest=" + std::to_string(ESP.getMaxAllocHeap()),
+                           DebugLog::MAX_LINES, /*force=*/true);
+      return;
+    }
     epub->setupCacheDir();
     // Load metadata only (no CSS needed for progress mapping, don't rebuild if cache is missing).
     if (!epub->load(false, true)) {

--- a/src/util/RollingSdLog.h
+++ b/src/util/RollingSdLog.h
@@ -8,9 +8,10 @@
 
 #include "util/DebugLogging.h"
 
-// Shared read-modify-write implementation behind ReaderPerfLog, SleepDiagLog,
-// and GameInputDiagLog. Read-modify-write since HalStorage has no append mode;
-// bounded by maxLines so the cost stays small even after a long session.
+// Shared logger behind ReaderPerfLog, SleepDiagLog, GameInputDiagLog, and the rest of
+// DebugLog.h's subsystems. The common case is a cheap O_APPEND write of one line; trimming
+// back to maxLines needs a read-modify-write of the whole file and only runs occasionally
+// (see trim() below), not on every call.
 namespace RollingSdLog {
 
 // Skip the write (rather than crash) when free heap is too tight. Under
@@ -23,19 +24,40 @@ namespace RollingSdLog {
 // single call, fragmenting the heap further before the growth that aborted.
 constexpr uint32_t MIN_SAFE_HEAP_BYTES = 32768;
 
-// force=true bypasses the debugLoggingEnabled gate (still subject to maxLines and the
-// heap-safety floor above). Mirrors CrossPointSettings::debugLoggingEnabled's own
-// carve-out for crash_report.txt: routine per-subsystem chatter stays opt-in so ordinary
-// users don't get SD clutter, but a one-shot event that heads off or explains an actual
-// crash must survive regardless -- those are exactly the sessions where nobody thought to
-// turn debug logging on ahead of time. Use sparingly: reserved for panic-adjacent
-// diagnostics (heap-guard trip points, crash summaries), not routine subsystem logging.
-inline void append(const char* path, const std::string& line, size_t maxLines, bool force = false) {
-  if ((!force && !DebugLogging::enabled()) || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
+// A second, later real-device crash report (blank panic reason, free heap a healthy-looking
+// 54428 bytes but largest contiguous block only 22516) had this exact function's rebuilt
+// std::string sitting in the panic stack dump. MIN_SAFE_HEAP_BYTES above only checks total
+// free heap; it says nothing about whether a SINGLE CONTIGUOUS block big enough for the
+// whole file (readFile()'s String plus the rebuilt std::string, both roughly file-sized) is
+// actually available, which is exactly what a read-modify-write on every call needs and
+// exactly what fragmentation starves first. Appending is now a plain O_APPEND write (no
+// read, no file-sized allocation); trim() below still does the expensive rewrite, but only
+// once the file has grown TRIM_SLACK_LINES past target, and skips itself on a still-tight
+// contiguous block rather than risking the abort -- the file is simply left to trim on a
+// later, healthier call.
+constexpr size_t TRIM_SLACK_LINES = 64;
+// Conservative estimate of a tagged log line ("[SUBSYSTEM] ..." + newline), used only to
+// decide WHEN trim() should run from a cheap fileSize() check -- not exact byte accounting.
+constexpr size_t ASSUMED_BYTES_PER_LINE = 96;
+
+// Re-reads the file, keeps only its last `maxLines` lines, and rewrites it. `knownSize` is
+// the file size the caller already measured via fileSize() moments ago (append()'s own
+// write) -- checked BEFORE calling readFile() below, since readFile() is itself the first
+// of the two large allocations this guard exists to avoid making blind. Trimming only ever
+// drops TRIM_SLACK_LINES worth of bytes off a file of roughly knownSize, so `existing` and
+// the rebuilt `out` are both roughly knownSize -- two separate allocations that need to
+// coexist, hence the 2x (getMaxAllocHeap() only reports the single largest free block, not
+// whether a second, similarly-sized block also exists, so this is a heuristic, not a
+// guarantee). See TRIM_SLACK_LINES above for why this runs rarely instead of on every
+// append(), and why it bails out (leaving the file to trim on a later call) rather than
+// force the read-modify-write through a contiguous block too small for it.
+inline void trim(const char* path, size_t maxLines, size_t knownSize) {
+  if (ESP.getMaxAllocHeap() < knownSize * 2 + 256) return;
 
   const String existing = Storage.readFile(path);
   const char* data = existing.c_str();
   const size_t len = existing.length();
+  if (len == 0) return;
 
   // Pass 1: count existing lines (a trailing line with no final '\n' still counts).
   size_t totalLines = 0;
@@ -48,13 +70,12 @@ inline void append(const char* path, const std::string& line, size_t maxLines, b
       pos = static_cast<size_t>(nl - data) + 1;
     }
   }
+  if (totalLines <= maxLines) return;  // grew past the trim trigger but not past maxLines itself
 
-  // Pass 2: find the byte offset of the first line to keep, so the new line
-  // still fits within maxLines total without ever materializing per-line copies.
-  const size_t keepExisting = totalLines > maxLines - 1 ? maxLines - 1 : totalLines;
-  const size_t skipLines = totalLines - keepExisting;
+  // Pass 2: find the byte offset of the first line to keep.
+  const size_t skipLines = totalLines - maxLines;
   size_t keepFrom = 0;
-  if (skipLines > 0) {
+  {
     size_t pos = 0, skipped = 0;
     while (pos < len && skipped < skipLines) {
       const char* nl = static_cast<const char*>(memchr(data + pos, '\n', len - pos));
@@ -68,15 +89,35 @@ inline void append(const char* path, const std::string& line, size_t maxLines, b
     keepFrom = pos;
   }
 
-  const size_t keptLen = len - keepFrom;
   std::string out;
-  out.reserve(keptLen + line.size() + 1);
-  out.append(data + keepFrom, keptLen);
-  if (!out.empty() && out.back() != '\n') out += '\n';
-  out += line;
-  out += '\n';
-
+  out.reserve(len - keepFrom);
+  out.append(data + keepFrom, len - keepFrom);
   Storage.writeFile(path, out.c_str());
+}
+
+// force=true bypasses the debugLoggingEnabled gate (still subject to maxLines and the
+// heap-safety floor above). Mirrors CrossPointSettings::debugLoggingEnabled's own
+// carve-out for crash_report.txt: routine per-subsystem chatter stays opt-in so ordinary
+// users don't get SD clutter, but a one-shot event that heads off or explains an actual
+// crash must survive regardless -- those are exactly the sessions where nobody thought to
+// turn debug logging on ahead of time. Use sparingly: reserved for panic-adjacent
+// diagnostics (heap-guard trip points, crash summaries), not routine subsystem logging.
+inline void append(const char* path, const std::string& line, size_t maxLines, bool force = false) {
+  if ((!force && !DebugLogging::enabled()) || maxLines == 0 || ESP.getFreeHeap() < MIN_SAFE_HEAP_BYTES) return;
+
+  HalFile file = Storage.open(path, O_WRITE | O_CREAT | O_APPEND);
+  if (!file) return;
+  file.write(line.data(), line.size());
+  file.write(static_cast<uint8_t>('\n'));
+  const size_t sizeAfter = file.fileSize();
+  // Close before trim() below reopens the same path for read then write (DESTRUCTOR_CLOSES_FILE
+  // handles this file's own eventual scope exit, but that's too late for trim()'s reopen).
+  file.close();
+
+  const size_t trimTriggerBytes = (maxLines + TRIM_SLACK_LINES) * ASSUMED_BYTES_PER_LINE;
+  if (sizeAfter > trimTriggerBytes) {
+    trim(path, maxLines, sizeAfter);
+  }
 }
 
 }  // namespace RollingSdLog


### PR DESCRIPTION
## Summary

Stacked on #129 (needs its `RollingSdLog::append()` `force` parameter for the forced SD log lines below) -- found by the diagnostic-logging coverage survey run right after #129's diagnosis, same bug class as the two already-fixed OPDS crash sites:

- **`EpubReaderActivity.cpp`**: `section = std::unique_ptr<Section>(new Section(...))` on the primary chapter-load path -- crossed on every chapter transition, the single largest allocation surface in the app. Bare `new` under `-fno-exceptions` calls `abort()` on OOM instead of returning `nullptr` (CLAUDE.md). Now `makeUniqueNoThrow<Section>()`; on OOM, logs (`LOG_ERR` + forced SD line) and returns, leaving `section` null so the next `render()` tick retries once the heap recovers -- same trade already made by `hasHeapForNavigation()`/`hasHeapForCoverWork()` in the OPDS browser.
- **`KOReaderSyncActivity.cpp`**: `epub = std::make_shared<Epub>(...)` in `ensureEpubLoaded()`, inconsistent with `ReaderActivity::loadEpub()`'s own `makeUniqueNoThrow<Epub>()` for the identical constructor call. The caller (`performSync()`) already null-checks `epub` right after calling `ensureEpubLoaded()` -- the existing `epub->load()` failure path already leaves `epub` null the same way, so **no caller changes needed**.

## Test plan
- [x] `pio run -e default` — clean build
- [x] `pio check` (cppcheck) — no defects
- [x] `clang-format` — applied, no logic changes
- [ ] On-device: can't force an OOM deliberately; relying on the pattern match to `makeUniqueNoThrow` already used successfully elsewhere (`ReaderActivity::loadEpub`, `OpdsCoverCache`, etc.)