### PR TITLE
feat: expand diagnostic logging to WiFi, web server, OTA, and stack margin

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -25,6 +25,7 @@
 #include "settings/OpdsServerListActivity.h"
 #include "settings/SettingsActivity.h"
 #include "util/FullScreenMessageActivity.h"
+#include "util/StackDiagLog.h"
 
 static portMUX_TYPE activityManagerSpinlock = portMUX_INITIALIZER_UNLOCKED;
 
@@ -54,6 +55,17 @@ void ActivityManager::renderTaskLoop() {
       HalPowerManager::Lock powerLock;  // Ensure we don't go into low-power mode while rendering
       currentActivity->render(std::move(lock));
     }
+
+    // Same cadence/rationale as main.cpp's own main-task sample -- see StackDiagLog.h.
+    {
+      static unsigned long lastStackDiagLogMs = 0;
+      const unsigned long nowMs = millis();
+      if (nowMs - lastStackDiagLogMs >= 300000) {
+        lastStackDiagLogMs = nowMs;
+        StackDiagLog::append("render", uxTaskGetStackHighWaterMark(nullptr));
+      }
+    }
+
     // Notify any task blocked in requestUpdateAndWait() that the render is done.
     TaskHandle_t waiter = nullptr;
     taskENTER_CRITICAL(&activityManagerSpinlock);

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -14,6 +14,7 @@
 #include "activities/util/KeyboardEntryActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/WifiDiagLog.h"
 
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
@@ -323,6 +324,7 @@ void WifiSelectionActivity::handleAutoConnectFailure() {
     if (tryNextSavedNetworkFromScan()) {
       return;
     }
+    WifiDiagLog::append("auto-connect exhausted all saved networks in scan, falling back to manual list");
     autoConnecting = false;
     state = WifiSelectionState::NETWORK_LIST;
     selectedNetworkIndex = 0;
@@ -354,6 +356,8 @@ void WifiSelectionActivity::attemptConnection() {
   connectionStartTime = millis();
   connectedIP.clear();
   connectionError.clear();
+  WifiDiagLog::append("connecting: ssid=" + selectedSSID + " auto=" + (autoConnecting ? "1" : "0") +
+                      " savedPassword=" + (usedSavedPassword ? "1" : "0"));
   // Paint "Connecting to <ssid>" before the radio work below, not after. requestUpdate()
   // only sets a flag consumed once ActivityManager::loop() regains control, so with
   // WiFi.mode() + disconnect + delay(100) + WiFi.begin() in between, the panel kept
@@ -403,6 +407,8 @@ void WifiSelectionActivity::checkConnectionStatus() {
     snprintf(ipStr, sizeof(ipStr), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
     connectedIP = ipStr;
     autoConnecting = false;
+    WifiDiagLog::append("connected: ssid=" + selectedSSID + " ip=" + std::string(ipStr) +
+                        " elapsedMs=" + std::to_string(millis() - connectionStartTime));
 
 // Guarded out of the simulator build: crosspoint-simulator's WiFiClass stub
 // doesn't implement BSSID()/channel() either.
@@ -473,6 +479,9 @@ void WifiSelectionActivity::checkConnectionStatus() {
     if (status == WL_NO_SSID_AVAIL) {
       connectionError = tr(STR_ERROR_NETWORK_NOT_FOUND);
     }
+    WifiDiagLog::append("failed: ssid=" + selectedSSID +
+                        " status=" + (status == WL_NO_SSID_AVAIL ? "NO_SSID_AVAIL" : "CONNECT_FAILED") +
+                        " auto=" + (autoConnecting ? "1" : "0"));
     if (autoConnecting) {
       handleAutoConnectFailure();
       return;
@@ -489,6 +498,8 @@ void WifiSelectionActivity::checkConnectionStatus() {
   if (millis() - connectionStartTime > timeoutMs) {
     WiFi.disconnect();
     connectionError = tr(STR_ERROR_CONNECTION_TIMEOUT);
+    WifiDiagLog::append("timeout: ssid=" + selectedSSID + " afterMs=" + std::to_string(timeoutMs) + " auto=" +
+                        (autoConnecting ? "1" : "0") + " lastStatus=" + std::to_string(static_cast<int>(status)));
     if (autoConnecting) {
       handleAutoConnectFailure();
       return;

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -15,10 +15,12 @@
 #include "network/HttpDownloader.h"
 #include "network/OtaUpdater.h"
 #include "reading/ReadingStatsStore.h"
+#include "util/FirmwareDiagLog.h"
 
 void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
     LOG_ERR("OTA", "WiFi connection failed, exiting");
+    FirmwareDiagLog::append("OTA", "aborted: WiFi connection failed");
     finish();
     return;
   }
@@ -36,6 +38,11 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
     const auto httpFailure = HttpDownloader::getLastFailure();
     LOG_DBG("OTA", "Update check failed: %d (free heap %u, largest block %u, http stage %u detail %d)", res,
             ESP.getFreeHeap(), ESP.getMaxAllocHeap(), static_cast<unsigned>(httpFailure.stage), httpFailure.detail);
+    FirmwareDiagLog::append("OTA", "check failed: res=" + std::to_string(res) +
+                                       " free=" + std::to_string(ESP.getFreeHeap()) +
+                                       " largest=" + std::to_string(ESP.getMaxAllocHeap()) +
+                                       " httpStage=" + std::to_string(static_cast<unsigned>(httpFailure.stage)) +
+                                       " httpDetail=" + std::to_string(httpFailure.detail));
     {
       RenderLock lock(*this);
       lastErrorCode = res;
@@ -255,6 +262,9 @@ void OtaUpdateActivity::beginInstall() {
 
   if (res != OtaUpdater::OK) {
     LOG_DBG("OTA", "Update failed: %d (free heap %u, largest block %u)", res, ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+    FirmwareDiagLog::append("OTA", "install failed: res=" + std::to_string(res) +
+                                       " free=" + std::to_string(ESP.getFreeHeap()) +
+                                       " largest=" + std::to_string(ESP.getMaxAllocHeap()));
     {
       RenderLock lock(*this);
       lastErrorCode = res;
@@ -266,6 +276,7 @@ void OtaUpdateActivity::beginInstall() {
     return;
   }
 
+  FirmwareDiagLog::append("OTA", "install succeeded, rebooting");
   {
     RenderLock lock(*this);
     state = FINISHED;

--- a/src/activities/settings/SdFirmwareUpdateActivity.cpp
+++ b/src/activities/settings/SdFirmwareUpdateActivity.cpp
@@ -13,6 +13,7 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/FirmwareFlasher.h"
+#include "util/FirmwareDiagLog.h"
 
 void SdFirmwareUpdateActivity::onEnter() {
   Activity::onEnter();
@@ -99,6 +100,8 @@ bool SdFirmwareUpdateActivity::validateFirmware() {
   const auto vr = firmware_flash::validateImageFile(firmwarePath.c_str(), partitionLimit);
   if (vr != firmware_flash::Result::OK) {
     LOG_ERR("FW", "image validation failed: %s", firmware_flash::resultName(vr));
+    FirmwareDiagLog::append(
+        "FW", "SD update rejected: " + std::string(firmware_flash::resultName(vr)) + " path=" + firmwarePath);
     if (vr == firmware_flash::Result::TOO_LARGE) {
       errorMessage = tr(STR_FIRMWARE_TOO_LARGE);
     } else if (vr == firmware_flash::Result::TOO_SMALL) {
@@ -167,6 +170,8 @@ void SdFirmwareUpdateActivity::performUpdate() {
   const auto result = firmware_flash::flashFromSdPath(firmwarePath.c_str(), progressCb, this);
   if (result != firmware_flash::Result::OK) {
     LOG_ERR("FW", "flash failed: %s", firmware_flash::resultName(result));
+    FirmwareDiagLog::append(
+        "FW", "SD update failed: " + std::string(firmware_flash::resultName(result)) + " path=" + firmwarePath);
     errorMessage = tr(STR_FIRMWARE_WRITE_FAILED);
     RenderLock lock(*this);
     state = State::FAILED;
@@ -175,6 +180,7 @@ void SdFirmwareUpdateActivity::performUpdate() {
   }
 
   LOG_INF("FW", "SD firmware update complete, restarting");
+  FirmwareDiagLog::append("FW", "SD update complete, restarting: path=" + firmwarePath);
   {
     RenderLock lock(*this);
     state = State::SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@
 #include "util/ButtonNavigator.h"
 #include "util/ScreenshotUtil.h"
 #include "util/SleepDiagLog.h"
+#include "util/StackDiagLog.h"
 
 GfxRenderer renderer(display);
 MappedInputManager mappedInputManager(gpio, renderer);
@@ -860,6 +861,17 @@ void loop() {
                millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS,
                activityManager.currentActivityDebugName());
       BatteryDiagLog::append(buf);
+    }
+  }
+
+  // Same cadence/rationale as the battery breadcrumb above, for the main loop task's own
+  // stack margin -- see StackDiagLog.h.
+  {
+    static unsigned long lastStackDiagLogMs = 0;
+    const unsigned long nowMs = millis();
+    if (nowMs - lastStackDiagLogMs >= 300000) {
+      lastStackDiagLogMs = nowMs;
+      StackDiagLog::append("main", uxTaskGetStackHighWaterMark(nullptr));
     }
   }
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -5,6 +5,7 @@
 #include <HalGPIO.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_efuse.h>
 #include <esp_efuse_table.h>
@@ -30,6 +31,7 @@
 #include "html/SettingsPageHtml.generated.h"
 #include "html/js/jszip_minJs.generated.h"
 #include "util/BookCacheUtils.h"
+#include "util/WebDiagLog.h"
 
 namespace {
 // Folders/files to hide from the web interface file browser
@@ -188,9 +190,13 @@ void CrossPointWebServer::begin() {
 
   LOG_DBG("WEB", "[MEM] Free heap before begin: %d bytes", ESP.getFreeHeap());
   LOG_DBG("WEB", "Network mode: %s", apMode ? "AP" : "STA");
+  WebDiagLog::append("begin: free heap=" + std::to_string(ESP.getFreeHeap()) + " mode=" + (apMode ? "AP" : "STA"));
 
   LOG_DBG("WEB", "Creating web server on port %d...", port);
-  server.reset(new WebServer(port));
+  // Bare `new` under -fno-exceptions calls abort() on OOM instead of returning nullptr (see
+  // CLAUDE.md); the null check right below already existed, so this only needed the nothrow
+  // allocation to make that check reachable instead of the abort happening first.
+  server = makeUniqueNoThrow<WebServer>(port);
 
   // Disable WiFi sleep to improve responsiveness and prevent 'unreachable' errors.
   // This is critical for reliable web server operation on ESP32.
@@ -206,6 +212,8 @@ void CrossPointWebServer::begin() {
 
   if (!server) {
     LOG_ERR("WEB", "Failed to create WebServer!");
+    WebDiagLog::appendCritical("OOM creating WebServer: free=" + std::to_string(ESP.getFreeHeap()) +
+                               " largest=" + std::to_string(ESP.getMaxAllocHeap()));
     return;
   }
 
@@ -272,22 +280,43 @@ void CrossPointWebServer::begin() {
 
   server->onNotFound([this] { handleNotFound(); });
   LOG_DBG("WEB", "[MEM] Free heap after route setup: %d bytes", ESP.getFreeHeap());
+  WebDiagLog::append("free heap after route setup=" + std::to_string(ESP.getFreeHeap()));
 
   // Collect WebDAV headers and register handler
   const char* davHeaders[] = {"Depth", "Destination", "Overwrite", "If", "Lock-Token", "Timeout"};
   server->collectHeaders(davHeaders, 6);
-  server->addHandler(new WebDAVHandler());  // Note: WebDAVHandler will be deleted by WebServer when server is stopped
-  LOG_DBG("WEB", "WebDAV handler initialized");
+  // `new (std::nothrow)`, not makeUniqueNoThrow: addHandler() takes ownership and deletes
+  // this itself when the server stops (see the comment it used to carry), so a unique_ptr
+  // here would double-free. On OOM, skip registering WebDAV rather than crash -- the rest
+  // of the web server (file browser, settings, uploads) still works without it.
+  auto* davHandler = new (std::nothrow) WebDAVHandler();
+  if (davHandler) {
+    server->addHandler(davHandler);  // WebDAVHandler is deleted by WebServer when server is stopped
+    LOG_DBG("WEB", "WebDAV handler initialized");
+  } else {
+    LOG_ERR("WEB", "OOM creating WebDAVHandler, WebDAV routes unavailable this session");
+    WebDiagLog::appendCritical("OOM creating WebDAVHandler: free=" + std::to_string(ESP.getFreeHeap()) +
+                               " largest=" + std::to_string(ESP.getMaxAllocHeap()));
+  }
 
   server->begin();
 
   // Start WebSocket server for fast binary uploads
   LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
-  wsServer.reset(new WebSocketsServer(wsPort));
-  wsInstance = const_cast<CrossPointWebServer*>(this);
-  wsServer->begin();
-  wsServer->onEvent(wsEventCallback);
-  LOG_DBG("WEB", "WebSocket server started");
+  // Same nothrow treatment as `server` above. On OOM, skip WebSocket setup rather than
+  // crash -- the REST/file-browser routes already registered above still work without the
+  // fast-binary-upload path.
+  wsServer = makeUniqueNoThrow<WebSocketsServer>(wsPort);
+  if (wsServer) {
+    wsInstance = const_cast<CrossPointWebServer*>(this);
+    wsServer->begin();
+    wsServer->onEvent(wsEventCallback);
+    LOG_DBG("WEB", "WebSocket server started");
+  } else {
+    LOG_ERR("WEB", "OOM creating WebSocketsServer, fast-upload path unavailable this session");
+    WebDiagLog::appendCritical("OOM creating WebSocketsServer: free=" + std::to_string(ESP.getFreeHeap()) +
+                               " largest=" + std::to_string(ESP.getMaxAllocHeap()));
+  }
 
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
@@ -300,6 +329,7 @@ void CrossPointWebServer::begin() {
   LOG_DBG("WEB", "Access at http://%s/", ipAddr.c_str());
   LOG_DBG("WEB", "WebSocket at ws://%s:%d/", ipAddr.c_str(), wsPort);
   LOG_DBG("WEB", "[MEM] Free heap after server.begin(): %d bytes", ESP.getFreeHeap());
+  WebDiagLog::append("started on port " + std::to_string(port) + ", free heap=" + std::to_string(ESP.getFreeHeap()));
 }
 
 void CrossPointWebServer::abortWsUpload(const char* tag) {
@@ -360,6 +390,7 @@ void CrossPointWebServer::stop() {
   server.reset();
   LOG_DBG("WEB", "Web server stopped and deleted");
   LOG_DBG("WEB", "[MEM] Free heap after delete server: %d bytes", ESP.getFreeHeap());
+  WebDiagLog::append("stopped, free heap=" + std::to_string(ESP.getFreeHeap()));
 
   // Note: Static upload variables (uploadFileName, uploadPath, uploadError) are declared
   // later in the file and will be cleared when they go out of scope or on next upload
@@ -714,6 +745,8 @@ static bool flushUploadBuffer(CrossPointWebServer::UploadState& state) {
 
     if (written != state.bufferPos) {
       LOG_DBG("WEB", "[UPLOAD] Buffer flush failed: expected %d, wrote %d", state.bufferPos, written);
+      WebDiagLog::appendCritical("upload buffer flush failed: expected=" + std::to_string(state.bufferPos) +
+                                 " wrote=" + std::to_string(written) + " file=" + std::string(state.fileName.c_str()));
       state.bufferPos = 0;
       return false;
     }
@@ -769,6 +802,8 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
 
     LOG_DBG("WEB", "[UPLOAD] START: %s to path: %s", state.fileName.c_str(), state.path.c_str());
     LOG_DBG("WEB", "[UPLOAD] Free heap: %d bytes", ESP.getFreeHeap());
+    WebDiagLog::append("upload start: " + std::string(state.fileName.c_str()) + " -> " +
+                       std::string(state.path.c_str()) + " free heap=" + std::to_string(ESP.getFreeHeap()));
 
     // Create file path
     String filePath = state.path;
@@ -788,6 +823,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
     if (!Storage.openFileForWrite("WEB", filePath, state.file)) {
       state.error = "Failed to create file on SD card";
       LOG_DBG("WEB", "[UPLOAD] FAILED to create file: %s", filePath.c_str());
+      WebDiagLog::appendCritical("upload failed to create file: " + std::string(filePath.c_str()));
       return;
     }
     esp_task_wdt_reset();
@@ -847,6 +883,8 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
                 elapsed, avgKbps);
         LOG_DBG("WEB", "[UPLOAD] Diagnostics: %d writes, total write time: %lu ms (%.1f%%)", writeCount, totalWriteTime,
                 writePercent);
+        WebDiagLog::append("upload complete: " + std::string(state.fileName.c_str()) + " " +
+                           std::to_string(state.size) + " bytes in " + std::to_string(elapsed) + "ms");
 
         // Clear epub cache to prevent stale metadata issues when overwriting files
         String filePath = state.path;

--- a/src/network/FirmwareFlasher.cpp
+++ b/src/network/FirmwareFlasher.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 
 #include "OtaBootSwitch.h"
+#include "util/FirmwareDiagLog.h"
 
 namespace firmware_flash {
 
@@ -233,6 +234,7 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
   const esp_partition_t* dest = esp_ota_get_next_update_partition(nullptr);
   if (!dest) {
     LOG_ERR("FLASH", "no next-update partition");
+    FirmwareDiagLog::append("FLASH", "no next-update partition, src=" + std::string(sdPath));
     return Result::NO_PARTITION;
   }
 
@@ -244,6 +246,8 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
     const Result validateRes = validateImageFile(sdPath, dest->size);
     if (validateRes != Result::OK) {
       LOG_ERR("FLASH", "image validation failed: %s", resultName(validateRes));
+      FirmwareDiagLog::append(
+          "FLASH", "validation failed: " + std::string(resultName(validateRes)) + " src=" + std::string(sdPath));
       return validateRes;
     }
   }
@@ -251,6 +255,7 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
   HalFile file;
   if (!Storage.openFileForRead("FLASH", sdPath, file) || !file) {
     LOG_ERR("FLASH", "open failed: %s", sdPath);
+    FirmwareDiagLog::append("FLASH", "open failed: src=" + std::string(sdPath));
     return Result::OPEN_FAIL;
   }
 
@@ -261,6 +266,8 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
   auto buffer = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[CHUNK]);
   if (!buffer) {
     LOG_ERR("FLASH", "OOM");
+    FirmwareDiagLog::append("FLASH", "OOM allocating chunk buffer: free=" + std::to_string(ESP.getFreeHeap()) +
+                                         " largest=" + std::to_string(ESP.getMaxAllocHeap()));
     file.close();
     return Result::OOM;
   }
@@ -277,6 +284,8 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
       if (esp_partition_erase_range(dest, streamPos, eraseLen) != ESP_OK) {
         LOG_ERR("FLASH", "erase @%u (len=%u) failed", static_cast<unsigned>(streamPos),
                 static_cast<unsigned>(eraseLen));
+        FirmwareDiagLog::append("FLASH", "erase failed @" + std::to_string(streamPos) + " len=" +
+                                             std::to_string(eraseLen) + " of " + std::to_string(firmwareSize));
         file.close();
         return Result::ERASE_FAIL;
       }
@@ -287,11 +296,15 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
     const int read = file.read(buffer.get(), want);
     if (read <= 0 || static_cast<size_t>(read) != want) {
       LOG_ERR("FLASH", "read @%u: got=%d want=%u", static_cast<unsigned>(streamPos), read, static_cast<unsigned>(want));
+      FirmwareDiagLog::append("FLASH", "read failed @" + std::to_string(streamPos) + " got=" + std::to_string(read) +
+                                           " want=" + std::to_string(want) + " of " + std::to_string(firmwareSize));
       file.close();
       return Result::READ_FAIL;
     }
     if (esp_partition_write(dest, streamPos, buffer.get(), want) != ESP_OK) {
       LOG_ERR("FLASH", "write @%u failed", static_cast<unsigned>(streamPos));
+      FirmwareDiagLog::append("FLASH",
+                              "write failed @" + std::to_string(streamPos) + " of " + std::to_string(firmwareSize));
       file.close();
       return Result::WRITE_FAIL;
     }
@@ -303,8 +316,12 @@ Result flashFromSdPath(const char* sdPath, ProgressCb onProgress, void* ctx, boo
 
   if (!ota_boot::switchTo(dest)) {
     LOG_ERR("FLASH", "otadata switch failed");
+    FirmwareDiagLog::append("FLASH", "otadata switch failed, dest=" + std::string(dest->label) +
+                                         " -- new image flashed but NOT selected to boot");
     return Result::OTADATA_FAIL;
   }
+  FirmwareDiagLog::append(
+      "FLASH", "flashed and switched: dest=" + std::string(dest->label) + " size=" + std::to_string(firmwareSize));
   return Result::OK;
 }
 

--- a/src/util/FirmwareDiagLog.h
+++ b/src/util/FirmwareDiagLog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+#include "DebugLog.h"
+#include "RollingSdLog.h"
+
+// One-shot diagnostic log for firmware update outcomes -- OTA-over-WiFi (OtaUpdater.cpp,
+// OtaUpdateActivity.cpp) and manual SD-card update (SdFirmwareUpdateActivity.cpp), both
+// funneling through the same low-level writer (FirmwareFlasher.cpp) -- tagged into the
+// shared /debug_log.txt (see DebugLog.h). The existing LOG_ERR/LOG_DBG calls across these
+// files are compiled OUT entirely in release builds (LOG_LEVEL=1 in gh_release/gh_release_rc,
+// platformio.ini) and even in a debug build only survive a 16-line RTC ring buffer -- a
+// failed update (bricking risk, the highest-consequence failure class in this firmware)
+// has had no durable trace at all.
+//
+// force=true unconditionally (see RollingSdLog::append): every call site here is a one-shot
+// terminal outcome (validation/flash success or failure, not routine per-chunk progress),
+// so it survives regardless of the debug-logging toggle -- mirrors the crash-report/
+// heap-guard carve-out, for the same reason: this is exactly the kind of event a user
+// hasn't turned debug logging on ahead of expecting.
+namespace FirmwareDiagLog {
+
+inline void append(const char* tag, const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[" + std::string(tag) + "] " + line, DebugLog::MAX_LINES, /*force=*/true);
+}
+
+}  // namespace FirmwareDiagLog

--- a/src/util/StackDiagLog.h
+++ b/src/util/StackDiagLog.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include "DebugLog.h"
+#include "RollingSdLog.h"
+
+// Periodic stack high-water-mark breadcrumb for the app's two FreeRTOS tasks (the main
+// Arduino loop task and ActivityManager's render task), tagged into the shared
+// /debug_log.txt. Zero stack-margin visibility existed anywhere in this firmware before
+// this -- a classic silent-crash cause (stack overflow corrupting adjacent heap, see
+// CLAUDE.md's Stack Safety section) with no instrumentation at all.
+// uxTaskGetStackHighWaterMark() returns the LOWEST-EVER free stack margin for the calling
+// task, not the current value -- exactly what's needed to catch a rare deep-recursion
+// spike that a point-in-time sample would miss. On ESP-IDF's FreeRTOS port StackType_t is
+// uint8_t, so the returned count is already bytes (see CLAUDE.md's own debugging section:
+// "uxTaskGetStackHighWaterMark(nullptr) (< 512 bytes -> increase stack)") -- no word-to-
+// byte conversion needed here, unlike the vanilla FreeRTOS API contract on other ports.
+namespace StackDiagLog {
+
+inline void append(const char* taskName, uint32_t freeBytes) {
+  RollingSdLog::append(DebugLog::PATH,
+                       "[STACK] " + std::string(taskName) + " min free=" + std::to_string(freeBytes) + " bytes",
+                       DebugLog::MAX_LINES);
+}
+
+}  // namespace StackDiagLog

--- a/src/util/WebDiagLog.h
+++ b/src/util/WebDiagLog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+#include "DebugLog.h"
+#include "RollingSdLog.h"
+
+// Rolling diagnostic log for the on-device web server (file browser, WebDAV, settings
+// API) and its file-upload path, tagged into the shared /debug_log.txt (see DebugLog.h).
+// The existing LOG_DBG("WEB", ...)/LOG_ERR("WEB", ...) call sites in CrossPointWebServer.cpp
+// are compiled OUT entirely in release builds (LOG_LEVEL=1 in gh_release/gh_release_rc,
+// platformio.ini) and even in a debug build only survive in a 16-line RTC ring buffer --
+// neither reaches a user's SD card, so "the upload froze"/"WebDAV won't start" reports have
+// had no durable trace at all. This mirrors SleepDiagLog/BatteryDiagLog's rationale.
+namespace WebDiagLog {
+
+inline void append(const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[WEB] " + line, DebugLog::MAX_LINES);
+}
+
+// force=true bypasses the debugLoggingEnabled gate (see RollingSdLog::append). Reserved for
+// server-start/upload allocation failures -- the same OOM class already guarded elsewhere
+// (hasHeapForNavigation() etc.) -- not routine request/response chatter.
+inline void appendCritical(const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[WEB] " + line, DebugLog::MAX_LINES, /*force=*/true);
+}
+
+}  // namespace WebDiagLog

--- a/src/util/WifiDiagLog.h
+++ b/src/util/WifiDiagLog.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "DebugLog.h"
+#include "RollingSdLog.h"
+
+// Rolling diagnostic log for WiFi connection attempts (manual and saved-network
+// auto-connect), tagged into the shared /debug_log.txt (see DebugLog.h). WiFi connect
+// failures are the single most common "it doesn't work" field report this project sees,
+// and until now they left no durable trace at all -- WifiSelectionActivity.cpp's
+// LOG_DBG("WIFI", ...) calls are compiled OUT entirely in release builds (LOG_LEVEL=1 in
+// gh_release/gh_release_rc, platformio.ini) and even in a debug build only survive in a
+// 16-line RTC ring buffer. Mirrors SleepDiagLog/BatteryDiagLog's rationale.
+namespace WifiDiagLog {
+
+inline void append(const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[WIFI] " + line, DebugLog::MAX_LINES);
+}
+
+}  // namespace WifiDiagLog


### PR DESCRIPTION
## Summary

Follow-up to the diagnostic-logging coverage survey run after `crash_report_4.txt`'s diagnosis (#129 fixed `RollingSdLog::append()` itself; #130 fixed two matching bare-throwing-`new` sites). This addresses the survey's remaining prioritized findings:

**WebDiagLog.h + CrossPointWebServer.cpp** — server start/stop heap breadcrumbs and the full upload lifecycle (start / buffer-flush-failed / file-create-failed / complete), all previously `LOG_DBG`-only (compiled OUT in release builds, and RTC-ring-buffer-only even in debug builds). Also fixed **three more bare `new` allocations** discovered while reading this code (same bug class as `crash_report_4.txt`):
- `server`/`wsServer` now use `makeUniqueNoThrow`, with the existing (`server`) or new (`wsServer`) null guard degrading gracefully — skip WebDAV or the WebSocket fast-upload path on OOM rather than crash; the main file-browser/settings routes still work either way.
- `WebDAVHandler` uses `new (std::nothrow)` directly since `addHandler()` takes ownership and deletes it itself (the CLAUDE.md "C API takes ownership" pattern).

**WifiDiagLog.h + WifiSelectionActivity.cpp** — connect attempt/success/failure/timeout and the saved-network auto-connect cascade. WiFi connect failures are reportedly the single most common field complaint and had zero durable trace before this.

**FirmwareDiagLog.h + OtaUpdater/OtaUpdateActivity/FirmwareFlasher/SdFirmwareUpdateActivity** — every terminal outcome (validation/erase/read/write/otadata-switch failure, or success) on both the OTA and SD-manual update paths, which both funnel through `FirmwareFlasher::flashFromSdPath()`. `force=true` throughout — a failed update is the highest-consequence failure class in this firmware (bricking risk), and every line here is a one-shot terminal outcome, not routine progress chatter.

**StackDiagLog.h + main.cpp/ActivityManager.cpp** — periodic (5 min, matching `BatteryDiagLog`'s cadence) `uxTaskGetStackHighWaterMark()` sampling for both FreeRTOS tasks in the app (main loop task, render task). Zero stack-margin visibility existed anywhere before this — a classic silent-crash cause with no instrumentation at all.

## Test plan
- [x] `pio run -e default` — clean build
- [x] `pio check` (cppcheck) — no defects
- [x] `clang-format` — applied, no logic changes
- [ ] On-device: exercise WiFi connect (including a deliberate wrong-password failure), a file upload, and confirm the corresponding lines land in `debug_log.txt`