### PR TITLE
fix: adopt upstream XTEINK display-controller detection

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -3,35 +3,13 @@
 #include <Preferences.h>
 #include <SPI.h>
 #include <Wire.h>
+#include <XteinkDetect.h>
 #include <esp_sleep.h>
 
 // Global HalGPIO instance
 HalGPIO gpio;
 
 namespace X3GPIO {
-
-struct X3ProbeResult {
-  bool bq27220 = false;
-  bool ds3231 = false;
-  bool qmi8658 = false;
-
-  uint8_t score() const {
-    return static_cast<uint8_t>(bq27220) + static_cast<uint8_t>(ds3231) + static_cast<uint8_t>(qmi8658);
-  }
-};
-
-bool readI2CReg8(uint8_t addr, uint8_t reg, uint8_t* outValue) {
-  Wire.beginTransmission(addr);
-  Wire.write(reg);
-  if (Wire.endTransmission(false) != 0) {
-    return false;
-  }
-  if (Wire.requestFrom(addr, static_cast<uint8_t>(1), static_cast<uint8_t>(true)) < 1) {
-    return false;
-  }
-  *outValue = Wire.read();
-  return true;
-}
 
 bool readI2CReg16LE(uint8_t addr, uint8_t reg, uint16_t* outValue) {
   Wire.beginTransmission(addr);
@@ -58,58 +36,6 @@ bool readBQ27220CurrentMA(int16_t* outCurrent) {
   }
   *outCurrent = static_cast<int16_t>(raw);
   return true;
-}
-
-bool probeBQ27220Signature() {
-  uint16_t soc = 0;
-  uint16_t voltageMv = 0;
-  if (!readI2CReg16LE(I2C_ADDR_BQ27220, BQ27220_SOC_REG, &soc)) {
-    return false;
-  }
-  if (soc > 100) {
-    return false;
-  }
-  if (!readI2CReg16LE(I2C_ADDR_BQ27220, BQ27220_VOLT_REG, &voltageMv)) {
-    return false;
-  }
-  return voltageMv >= 2500 && voltageMv <= 5000;
-}
-
-bool probeDS3231Signature() {
-  uint8_t sec = 0;
-  if (!readI2CReg8(I2C_ADDR_DS3231, DS3231_SEC_REG, &sec)) {
-    return false;
-  }
-  const uint8_t tensDigit = (sec >> 4) & 0x07;
-  const uint8_t onesDigit = sec & 0x0F;
-
-  return tensDigit <= 5 && onesDigit <= 9;
-}
-
-bool probeQMI8658Signature() {
-  uint8_t whoami = 0;
-  if (readI2CReg8(I2C_ADDR_QMI8658, QMI8658_WHO_AM_I_REG, &whoami) && whoami == QMI8658_WHO_AM_I_VALUE) {
-    return true;
-  }
-  if (readI2CReg8(I2C_ADDR_QMI8658_ALT, QMI8658_WHO_AM_I_REG, &whoami) && whoami == QMI8658_WHO_AM_I_VALUE) {
-    return true;
-  }
-  return false;
-}
-
-X3ProbeResult runX3ProbePass() {
-  X3ProbeResult result;
-  Wire.begin(X3_I2C_SDA, X3_I2C_SCL, X3_I2C_FREQ);
-  Wire.setTimeOut(6);
-
-  result.bq27220 = probeBQ27220Signature();
-  result.ds3231 = probeDS3231Signature();
-  result.qmi8658 = probeQMI8658Signature();
-
-  Wire.end();
-  pinMode(20, INPUT);
-  pinMode(0, INPUT);
-  return result;
 }
 
 }  // namespace X3GPIO
@@ -162,24 +88,20 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
     return nvsToDeviceType(cachedValue);
   }
 
-  // No cache yet: run active X3 fingerprint probe and persist result.
-  const X3GPIO::X3ProbeResult pass1 = X3GPIO::runX3ProbePass();
-  delay(2);
-  const X3GPIO::X3ProbeResult pass2 = X3GPIO::runX3ProbePass();
+  // No cache yet: use FreeInk's canonical two-pass X3 fingerprint and persist
+  // only confirmed results. Inconclusive probes deliberately remain uncached
+  // so a flaky first boot gets re-probed next time.
+  uint8_t score1 = 0;
+  uint8_t score2 = 0;
+  const freeink::XteinkVerdict verdict = freeink::detectXteinkVerdict(&score1, &score2);
+  LOG_INF("HW", "Xteink probe scores: pass1=%u pass2=%u verdict=%u", score1, score2, static_cast<unsigned>(verdict));
 
-  const uint8_t score1 = pass1.score();
-  const uint8_t score2 = pass2.score();
-  LOG_INF("HW", "X3 probe scores: pass1=%u(bq=%d rtc=%d imu=%d) pass2=%u(bq=%d rtc=%d imu=%d)", score1, pass1.bq27220,
-          pass1.ds3231, pass1.qmi8658, score2, pass2.bq27220, pass2.ds3231, pass2.qmi8658);
-  const bool x3Confirmed = (score1 >= 2) && (score2 >= 2);
-  const bool x4Confirmed = (score1 == 0) && (score2 == 0);
-
-  if (x3Confirmed) {
+  if (verdict == freeink::XteinkVerdict::X3Confirmed) {
     writeNvsDeviceValue(NVS_KEY_DEV_CACHED, NvsDeviceValue::X3);
     return HalGPIO::DeviceType::X3;
   }
 
-  if (x4Confirmed) {
+  if (verdict == freeink::XteinkVerdict::X4Confirmed) {
     writeNvsDeviceValue(NVS_KEY_DEV_CACHED, NvsDeviceValue::X4);
     return HalGPIO::DeviceType::X4;
   }
@@ -192,9 +114,27 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 
 void HalGPIO::begin() {
   inputMgr.begin();
-  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
   _deviceType = detectDeviceTypeWithFingerprint();
+  BoardConfig::selectDevice(deviceIsX3() ? BoardConfig::Board::XteinkX3 : BoardConfig::Board::XteinkX4);
+
+  // Resolve the per-batch panel controller before SPI owns the EPD pins: the
+  // probe bit-bangs a half-duplex protocol directly on those pins, which is
+  // undefined once SPI.begin() has attached them to the SPI peripheral. FreeInk
+  // uses the live display-bus probe as ground truth here, not the OEM
+  // hw_calib/screenType NVS value -- that value is field-unreliable (a
+  // full-flash from another unit can overwrite it with the wrong panel's
+  // record), so applyXteinkDisplayController() only logs it for diagnostics
+  // and decides from the probe. X3's facade keys panel selection off the
+  // sibling board profile, so preserve a detected UC8279 through
+  // selectDevice() here -- HalDisplay::begin()'s later setDisplayX3() call
+  // checks for this and won't reset it back to the base X3/UC8253 profile.
+  freeink::applyXteinkDisplayController();
+  if (deviceIsX3() && BoardConfig::ACTIVE.displayController == BoardConfig::DisplayController::UC8279) {
+    BoardConfig::selectDevice(BoardConfig::Board::XteinkX3Uc8279);
+  }
+
+  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
   if (deviceIsX4()) {
     pinMode(BAT_GPIO0, INPUT);

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,6 +72,7 @@ lib_deps =
   EInkDisplay=symlink://freeink-sdk/libs/display/FreeInkDisplay
   SDCardManager=symlink://freeink-sdk/libs/hardware/SDCardManager
   BoardConfig=symlink://freeink-sdk/libs/hardware/BoardConfig
+  XteinkDetect=symlink://freeink-sdk/libs/hardware/XteinkDetect
   PowerManager=symlink://freeink-sdk/libs/hardware/PowerManager
   FreeInkUI=symlink://freeink-sdk/libs/ui/FreeInkUI
   Icons=symlink://freeink-sdk/libs/assets/Icons


### PR DESCRIPTION
## Summary

Safety-P0 (urgent upstream-convergence exception, ahead of BLE-R1) per the read-only audit in `docs/upstream-sync-architecture.md`. Fixes a real, currently-unpatched hardware-correctness gap: Midad has no panel-controller detection at all today, so a newer-production Xteink unit is driven with the wrong controller's command set.

**Two distinct kinds of detection, not to be confused with each other:**
- **X3/X4 DEVICE-MODEL detection** (which board this is) — already exists on `develop` today (`detectDeviceTypeWithFingerprint()`), untouched in spirit by this PR beyond swapping its I2C-probe internals for the SDK's canonical version (see below). Still gated by the existing `cphw` NVS override (`dev_ovr`) and cache (`dev_det`), both preserved exactly.
- **Per-batch PANEL-CONTROLLER detection** (which silicon this X3/X4 actually carries — UC8253 vs its UC8279d sibling on X3, SSD1677 vs UC8179/UC8279 on X4) — **did not exist in Midad's `HalGPIO.cpp` at all before this PR.** This is the actual gap being closed.

**Failure mechanism**: `freeink::applyXteinkDisplayController()`'s panel-controller probe bit-bangs a half-duplex protocol directly on the EPD pins. Once `SPI.begin()` has attached those same pins to the SPI peripheral, a raw bit-bang probe on them is undefined. Midad's `HalGPIO::begin()` calls `SPI.begin()` unconditionally with zero controller detection beforehand, so a newer-batch unit is always driven with each profile's hardcoded original controller — producing corrupted/garbled display output, or in the worst observed case a hang during display bring-up before any serial log line. Not permanent hardware damage — MCU/flash/SD are untouched, and USB/esptool recovery is unaffected either way.

## SDK pin: `a485dc46`, not the smaller `e514a868`

`e514a868` looked like a plausible minimal pin (it has the board-agnostic `applyXteinkDisplayController()` function wired in already), but direct inspection of the `freeink-sdk` repo shows it isn't actually a complete fix:

- **Live probe is now authoritative rather than OEM NVS.** At `e514a868`, `applyXteinkDisplayController()` trusts the OEM `hw_calib/screenType` NVS value first and only falls back to the live bus probe. `a485dc46` fixed this — that NVS value is field-unreliable (a full-flash from another unit can overwrite it with the wrong panel's record) — so the live probe is now sole ground truth, with the OEM value logged for diagnostics only.
- **Mature UC8279 handling.** X3's `Uc8279Driver.cpp` is 195 lines at `e514a868` vs. 419 at `a485dc46` — missing 4-level grayscale, partial-window/DU-mode timing, half-refresh GC-waveform, and external-LUT fixes that landed afterward.
- **X4-family UC8279 driver/support.** `Uc8279X4Driver.cpp/.h` (distinct geometry from X3's own UC8279 driver) doesn't exist at all until `a485dc46`. Pinning `e514a868` would leave X4 units carrying that sibling silicon with no matching driver.
- **Exact alignment with current CrossPoint SDK pin.** `a485dc46` is upstream's own pin already (confirmed identical at both the fixed conflict-baseline SHA `2cac5971` and upstream's current tip) — this isn't jumping ahead of upstream, it's catching up to where upstream has already been.

No measurable Midad-side regression risk from the extra scope in `a485dc46`: the unrelated additions in that range (`ContentProtection`, `MemoryManager`, `SecureNet`) are new libraries Midad's `platformio.ini` does not symlink, so they add zero binary size and zero build risk. `FreeInkUI` (which Midad does link) gained one backward-compatible additive parameter in `keyboard.h`; Midad's own code never references that header directly (goes through the `UITheme`/`GUI` macro per CLAUDE.md).

## Changes (exactly three files)

- **`freeink-sdk`**: `e62f6c16` → `a485dc46`.
- **`platformio.ini`**: adds `XteinkDetect=symlink://freeink-sdk/libs/hardware/XteinkDetect`, in the same position upstream's own PR added it. Nothing else — `ContentProtection`/`MemoryManager`/`SecureNet` are not linked.
- **`lib/hal/HalGPIO.cpp`**:
  - Adds `#include <XteinkDetect.h>`.
  - Removes the hand-rolled X3-only I2C fingerprint superseded by FreeInk's canonical detector (`X3ProbeResult`, `readI2CReg8`, `probeBQ27220Signature`, `probeDS3231Signature`, `probeQMI8658Signature`, `runX3ProbePass`) in favor of `freeink::detectXteinkVerdict()` — the same swap upstream's own `#2774` made.
  - **Preserves** `readI2CReg16LE()`/`readBQ27220CurrentMA()` untouched — still used by `isUsbConnected()`, unrelated to the fingerprint being replaced.
  - **Preserves** the existing `cphw` namespace `dev_ovr`/`dev_det` override+cache scheme exactly.
  - `begin()`: selects the X3/X4 `BoardConfig` profile right after device-type detection, then calls `freeink::applyXteinkDisplayController()`, then preserves/selects the `XteinkX3Uc8279` profile if that sibling was detected — all **before** `SPI.begin()`.
  - `inputMgr.begin()` stays in its existing position (first line) — compilation didn't require moving it.

## What this PR deliberately does NOT do

Per explicit scope: this is convergence of the detection/controller-probe logic, **not** a whole-file byte-identity exercise with current CrossPoint. Unrelated Midad/current-branch differences remain intentionally untouched:

- No `#if FREEINK_MCU_C3` / non-C3 fallback restructuring (upstream's own ESP32-S3 groundwork — Phase 5 territory, still in progress on this fork, not this fix's concern).
- No `inputMgr.begin()` relocation.
- Current CrossPoint's own `HalGPIO.cpp` still carries a comment claiming `applyXteinkDisplayController()` "checks the OEM hw_calib/screenType first" — **that's stale relative to the SDK version it's actually paired with** (the OEM-first behavior was replaced by the live-probe-as-ground-truth behavior described above). This PR does not copy that stale comment; it documents the actual, current SDK behavior instead.
- No `ContentProtection`/`MemoryManager`/`SecureNet`, no BLE-R1 work, no Phase D, no `FOOTNOTE_HREF_LEN`/`WifiCredentialStore`/`HomeActivity` cover-cache changes (all separately flagged, independent fixes per the audit — not bundled here), no S3 work, no opportunistic upstream cleanup.
- **Not claimed**: whole-file byte identity with current CrossPoint's `HalGPIO.cpp`. Only the detection/controller-probe region converges.

`e02fb457` (the stale branch's prior attempt at this same fix) was treated as provenance/evidence only, not replayed as a patch — this PR's `HalGPIO.cpp` was written fresh against current `develop`, with the unrelated MCU/S3/input-manager restructuring that commit didn't actually carry anyway (confirmed by direct diff during the audit) correctly excluded regardless.

## Verification

- `pio run -e default`: **success.**
- `pio run -e simulator`: **success** — compile/regression evidence only, mostly cache hits since `lib/hal/` (including this file) is excluded from simulator builds entirely (`lib_ignore = hal` in both `[env:simulator]`/`[env:simulator_x3]`; the simulator vendors its own host-native `HalGPIO.cpp`). **Does not and cannot validate the actual controller probe or SPI-pin ordering.**
- `pio check` (cppcheck): **no defects.**
- `clang-format`: **clean**, no changes needed.
- Full existing gtest suite: **134/134 passed** (no new host-testable logic here — this is hardware-only HAL code).

### Real hardware — original Xteink X3

Built, flashed, and serial-monitored on a physical Xteink X3 (ESP32-C3, confirmed via `esptool chip-id`; device self-identifies `Hardware detect: X3`, QMI8658 IMU and DS3231 RTC both found — genuine X3 hardware, not simulator/spoofed). Boot log:

```
[271] [INF] [HW] Using cached device type: X3
[271] [XTDET] NVS hw_calib/screenType: not set [info only]
[426] [XTDET] bus probe VER=FF FF FF FF FF FLG=13 -> default controller
[430] [INF] [MAIN] Hardware detect: X3
...
[644] [DBG] [MAIN] Starting CrossPoint version 1.8.57-dev-...
```

Confirms, live: the panel-controller probe runs and completes (`XTDET` lines) **before** any SPI/display activity, correctly logs the OEM NVS value as diagnostics-only ("not set... [info only]"), correctly declines to promote (`VER=FF FF FF FF FF` — no UC81xx response, this unit is the original UC8253) and stays on the default controller, and the device boots cleanly through to normal operation with the real device's own settings/library data (Settings, 9 recent books, KOReader credentials, 1 OPDS server, Foulad theme) — no hang, no crash. The display itself refreshed multiple times afterward (`Time = 32/689/33/764 ms from clearScreen to displayBuffer`), confirming normal E-ink operation post-fix. (The interspersed `[ERR] [GFX] !! Outside range` lines during the boot spinner are a pre-existing bounds-check log in `lib/GfxRenderer/GfxRenderer.cpp:431`, unrelated to this change — this PR never touches that file.)

**Original X3 (UC8253): confirmed — detects X3, stays on UC8253, boots/displays normally.**

### Explicit hardware-coverage gap

No X4 unit, and no new-production UC8279/UC8179 X3 or X4 unit, was available to test against. Per the audit's hardware-validation matrix, this leaves untested: original X4 (SSD1677), new-silicon X3 (UC8279d promotion path), and new-silicon X4 (UC8179/UC8279 promotion path) — including the actual controller-promotion branch of `applyXteinkDisplayController()` itself, since the only unit available happened to be original-silicon. Recording this gap explicitly rather than blocking the PR on it, per instruction. Flagging for whoever has access to a newer-batch unit to verify the promotion path fires correctly.

## Final diff audit

- Exactly three files changed: `freeink-sdk`, `lib/hal/HalGPIO.cpp`, `platformio.ini`. Confirmed via `git diff --stat`.
- `freeink-sdk` submodule's own working tree is clean (no local modifications inside it) — only its pinned commit moved.
- No unrelated SDK content vendored: `ContentProtection`/`MemoryManager`/`SecureNet` do not appear anywhere in `platformio.ini`.
- `readI2CReg16LE`/`readBQ27220CurrentMA` remain, unchanged.
- `dev_ovr`/`dev_det` remain, unchanged.
- Live controller probe happens before `SPI.begin()` — confirmed both by code inspection and by the live hardware log above (`XTDET` lines precede all display/SPI activity).
- No controller-result NVS cache was introduced — confirmed by direct read of `applyXteinkDisplayController()`'s implementation (decides fresh from a live probe every boot, writes nothing) and by the live log (`hw_calib/screenType: not set` — no controller-specific key ever touched).
- No BLE code changed.
- No S3/input-manager restructuring slipped in.

## Conflict-baseline re-measurement

Real `git merge` dry-run against the fixed baseline (`2cac5971`), same methodology as every prior phase: **159 files, not the ~158 predicted going in** — `lib/hal/HalGPIO.cpp` is now newly on the list (previously clean). Reporting this precisely rather than the original estimate, since the actual conflict source is worth understanding: inspecting the real conflict markers shows both hunks are trivial — one is a one-line comment-wording difference, the other is exactly the region covered by "what this PR deliberately does not do" above (the stale-comment / `#if FREEINK_MCU_C3` divergence, both intentional per this PR's own scope decisions). The underlying detection/controller-probe *logic* is now identical in structure to upstream's; only comment text and the deliberately-deferred S3 restructuring differ. `platformio.ini` was already conflicting (one additional line, identical to upstream's own). `freeink-sdk` (the gitlink) stays off the list either way — it's converging toward upstream's pin, not diverging from it.

Net effect: one file's *conflict status* flips from clean to conflicting, but its *content* becomes substantially closer to upstream than before — a future real merge in this exact region should be close to mechanical (the safety-critical logic already matches; only wording/scope choices remain to reconcile), a meaningfully better position than the pre-PR state where this region was pure legacy Midad-specific code with no relationship to upstream's rewrite at all.

## Not in this PR

- BLE-R1, BLE-R2..R7, Phase D — not started.
- The other three independent fixes flagged by the same audit (`FOOTNOTE_HREF_LEN`, `WifiCredentialStore` lazy-load, `HomeActivity` cover-cache) — each is its own separate PR candidate, not bundled here.
- Any S3/touch/PowerManager evolution from current upstream unrelated to this specific fix.
