### PR TITLE
feat: BLE-R1 -- Phase 1 lifecycle stabilization

### DIFF
--- a/lib/hal/BlePeripheralManager.cpp
+++ b/lib/hal/BlePeripheralManager.cpp
@@ -4,6 +4,7 @@
 #include <HalPowerManager.h>
 #include <Logging.h>
 #include <NimBLEDevice.h>
+#include <esp_mac.h>
 
 #include <cstring>
 
@@ -107,8 +108,20 @@ BlePeripheralManager& BlePeripheralManager::getInstance() {
   return instance;
 }
 
+void BlePeripheralManager::getAdvertisedName(char* outBuf, size_t outBufLen) {
+  uint8_t mac[6] = {};
+  esp_efuse_mac_get_default(mac);
+  snprintf(outBuf, outBufLen, "Midad-%02X%02X%02X", mac[3], mac[4], mac[5]);
+}
+
 bool BlePeripheralManager::begin() {
-  if (state_ != State::Off) return true;  // already running
+  // Only Advertising/Connected are genuinely "already running, no-op". PausedLowMemory
+  // used to be folded into this same early return (state_ != State::Off), which meant
+  // once poll() paused for low memory, begin() could never retry again -- no matter how
+  // long the cool-down ran or how much heap recovered. Off and PausedLowMemory both
+  // fall through to the cool-down + heap-gate checks below instead, so a genuine retry
+  // can actually happen once both clear.
+  if (state_ == State::Advertising || state_ == State::Connected) return true;
 
   if (coolingDown_) {
     if (millis() - lastLowMemoryTeardownMs_ < kCooldownMs) {
@@ -138,11 +151,21 @@ bool BlePeripheralManager::begin() {
     NimBLEDevice::deinit(true);
   }
 
-  if (!NimBLEDevice::init("Midad")) {
+  char advertisedName[24];
+  getAdvertisedName(advertisedName, sizeof(advertisedName));
+
+  if (!NimBLEDevice::init(advertisedName)) {
     LOG_ERR(TAG, "begin(): NimBLEDevice::init() failed");
     return false;
   }
   NimBLEDevice::setMTU(kTargetMtu);
+  // Explicit TX power (+9 dBm), not left at whatever default the controller happens to
+  // pick: an earlier hardware session found the controller reporting advertising-active
+  // while two independent scanners at desk range saw nothing over the air with no
+  // explicit setPower() call. NimBLE-Arduino's setPower(int8_t dbm, ...) is the current
+  // API surface (h2zero/NimBLE-Arduino ^2.3.8) -- not the esp_power_level_t-enum-based
+  // setPower(ESP_PWR_LVL_P9) shape an earlier, now-superseded version of this fix used.
+  NimBLEDevice::setPower(9);
 
   g_server = NimBLEDevice::createServer();
   if (!g_server) {
@@ -163,10 +186,15 @@ bool BlePeripheralManager::begin() {
     return false;
   }
 
-  // WRITE_ENC: requires an encrypted link before a write is accepted -- see
-  // docs/ble-module-tasks.md's Security section (LE Secure Connections, not Just
-  // Works, since this exchange needs to resist a passive eavesdropper).
-  NimBLECharacteristic* authChar = service->createCharacteristic(kAuthCharUuid, NIMBLE_PROPERTY::WRITE_ENC);
+  // WRITE | WRITE_ENC: WRITE_ENC alone is only the requires-encryption flag -- without
+  // the plain WRITE property bit the characteristic declaration advertises no write
+  // support at all, and a real phone BLE stack refuses to even attempt a write ("The
+  // WRITE property is not supported by this BLE characteristic", confirmed against a
+  // real client on an earlier hardware session). Encryption is still fully enforced:
+  // WRITE_ENC gates the write on an encrypted link per docs/ble-module-tasks.md's
+  // Security section -- this only adds the missing "writable at all" declaration.
+  NimBLECharacteristic* authChar =
+      service->createCharacteristic(kAuthCharUuid, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_ENC);
   authChar->setCallbacks(&g_authCallbacks);
 
   g_commandChar = service->createCharacteristic(kCommandCharUuid, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::NOTIFY);
@@ -181,9 +209,33 @@ bool BlePeripheralManager::begin() {
 
   NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();
   advertising->addServiceUUID(kServiceUuid);
+  // Scan response, NOT the primary advertising payload: the 128-bit service UUID
+  // above already consumes 18 of the primary payload's 31-byte legacy AD budget: the
+  // per-device name ("Midad-XXXXXX", up to 14 bytes with its AD header) doesn't fit
+  // alongside it. NimBLEAdvertisementData::addData() silently no-ops when a field
+  // doesn't fit rather than failing loudly, so without this the name was verified
+  // live to never reach the actual over-the-air advertisement at all (confirmed via
+  // a real scan: local_name absent from the raw AD payload) -- any name a scanner
+  // showed was a stale OS-level cache from an earlier static-name advertisement, not
+  // a live read. Scan response is a second, separate 31-byte payload sent in reply to
+  // an active scan request, with its own budget -- enabling it and letting setName()
+  // land there (its own fallback order, see NimBLEAdvertising::setName()) fits both.
+  advertising->enableScanResponse(true);
+  advertising->setName(advertisedName);
   advertising->setMinInterval(kAdvIntervalUnits);
   advertising->setMaxInterval(kAdvIntervalUnits);
-  advertising->start();
+  // start() has real failure paths (GATT server start, adv-data set, ble_gap_adv_start
+  // rc) -- ignoring its result is how this class could sit in Advertising state with a
+  // silent radio for a whole session. Fail begin() honestly instead, tearing everything
+  // back down rather than leaving state_ claiming a radio that isn't actually running.
+  if (!advertising->start() || !advertising->isAdvertising()) {
+    LOG_ERR(TAG, "begin(): advertising failed to start (free heap=%u)", static_cast<unsigned>(ESP.getFreeHeap()));
+    NimBLEDevice::deinit(true);
+    g_server = nullptr;
+    g_commandChar = nullptr;
+    g_statusChar = nullptr;
+    return false;
+  }
 
   state_ = State::Advertising;
   publishStatus();
@@ -215,8 +267,40 @@ void BlePeripheralManager::end() {
 void BlePeripheralManager::poll() {
   if (state_ != State::Advertising && state_ != State::Connected) return;
 
-  if (ESP.getFreeHeap() < kHeapGateBytes) {
-    LOG_ERR(TAG, "poll(): heap dropped below gate while running (free=%u), tearing down",
+  // Zombie guard: state says Advertising but the controller isn't actually
+  // transmitting. Tear down so the caller's normal begin() cadence brings it back for
+  // real; no cool-down, this isn't memory pressure.
+  //
+  // MUST be lazy about it: adv-inactive is also the perfectly normal signature of a
+  // central mid-connect (the controller stops advertising the instant it accepts
+  // CONNECT_IND, milliseconds before the host delivers the connect event that moves
+  // state_ to Connected). An eager, no-tolerance version of this check would kill a
+  // real inbound connection mid-handshake. So: never a zombie if a connection exists,
+  // and the radio-idle condition must persist kZombiePersistMs before teardown.
+  if (state_ == State::Advertising) {
+    NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();
+    const bool radioIdle = advertising && !advertising->isAdvertising();
+    const bool hasConnection = g_server && g_server->getConnectedCount() > 0;
+    if (radioIdle && !hasConnection) {
+      if (zombieSinceMs_ == 0) {
+        zombieSinceMs_ = millis();
+      } else if (millis() - zombieSinceMs_ >= kZombiePersistMs) {
+        LOG_ERR(TAG, "poll(): zombie state -- Advertising but radio idle for %lus, tearing down for retry",
+                static_cast<unsigned long>(kZombiePersistMs / 1000));
+        zombieSinceMs_ = 0;
+        end();
+        return;
+      }
+    } else {
+      zombieSinceMs_ = 0;
+    }
+  }
+
+  // kRunningFloorBytes, NOT kHeapGateBytes: init already spent kHeapGateBytes-and-then-
+  // some, so judging a running session against the pre-flight number tears down every
+  // successful start on its very next poll().
+  if (ESP.getFreeHeap() < kRunningFloorBytes) {
+    LOG_ERR(TAG, "poll(): heap dropped below running floor (free=%u), tearing down",
             static_cast<unsigned>(ESP.getFreeHeap()));
     end();
     state_ = State::PausedLowMemory;

--- a/lib/hal/BlePeripheralManager.h
+++ b/lib/hal/BlePeripheralManager.h
@@ -39,15 +39,35 @@ class BlePeripheralManager {
                       // drop -- see docs/ble-module-tasks.md's PAUSED state design.
   };
 
-  // ~70 KB Idle-state gate from docs/ble-module-tasks.md's Hardware reality section:
-  // NimBLE's ~57 KB resident cost plus a flat safety margin, no EPUB-headroom term --
-  // that term is specific to Phase 4's Reading-state (BLE-central-while-reading)
-  // scenario, not this Idle-state peripheral role. Unmeasured on this codebase's real
-  // feature set yet; see the doc for the reasoning and what would revise it.
+  // ~70 KB Idle-state PRE-FLIGHT gate: NimBLE init itself consumes a large chunk of
+  // heap (tens of KB), so this is what begin() needs to see BEFORE init for the
+  // device to still have a workable floor left afterward. Deliberately NOT the
+  // while-running floor below -- using one number for both jobs means every
+  // successful start judges itself against its own pre-init requirement on the very
+  // next poll() and tears itself down immediately, since post-init free heap is far
+  // below this by design. See kRunningFloorBytes for the number poll() actually uses.
   static constexpr uint32_t kHeapGateBytes = 70 * 1024;
+  // While-RUNNING floor for poll(): once NimBLE is resident, kHeapGateBytes has
+  // already been spent and the question changes from "can we afford to start?" to
+  // "is the rest of the system being starved?". 8 KB carried over from an earlier
+  // hardware session's measurement, re-confirmed live on this build (real X3, BLE-R1):
+  // ~81 KB free immediately before begin(), ~22.5 KB free while advertising and
+  // holding steady over several minutes including repeated real connect/disconnect
+  // cycles (NimBLE's actual resident cost on this build: ~58.6 KB) -- comfortably
+  // above this floor, with more margin than the original session's ~12.7 KB
+  // measurement had. Reading state never sees this floor -- the lifecycle caller
+  // tears BLE down before the reader opens.
+  static constexpr uint32_t kRunningFloorBytes = 8 * 1024;
   // Cool-down after a low-memory teardown, so a caller retrying begin() can't spin the
   // radio on/off (PR #2527's field-crash finding, see the doc).
   static constexpr uint32_t kCooldownMs = 30000;
+  // How long poll()'s zombie check (state Advertising, radio reporting inactive, no
+  // live connection) must persist before tearing down for a retry. Must comfortably
+  // exceed the window between the controller accepting a CONNECT_IND (which stops
+  // advertising) and the host delivering the resulting connect event -- advertising
+  // legitimately going idle for a moment during a real inbound connection is normal,
+  // not a zombie; too short a persistence window tears down a connection mid-handshake.
+  static constexpr uint32_t kZombiePersistMs = 3000;
   // JSON payload budget for the Auth/Command/Status characteristics -- see the doc's
   // GATT layout MTU note (185-byte target MTU, minus ATT header and JSON framing
   // overhead). A write larger than this is truncated at the GATT layer (NimBLE's own
@@ -57,6 +77,18 @@ class BlePeripheralManager {
   static constexpr size_t kMaxPayloadLen = 160;
 
   static BlePeripheralManager& getInstance();
+
+  // Writes "Midad-<last 3 MAC bytes as hex>" into outBuf (caller-owned, fixed-size, no
+  // heap churn) -- the same name begin() advertises, exposed publicly so debug/status
+  // tooling can report the exact name a phone's scan list would show. Reads the
+  // factory-programmed MAC directly from eFuse (esp_efuse_mac_get_default()), NOT
+  // WiFi.macAddress() -- that call needs the WiFi driver initialized at least once
+  // this boot to have a value to return (it reads through esp_wifi_get_mac()), which
+  // the Idle -> BLE-peripheral state by design never does; confirmed live to return
+  // all-zeros here. eFuse access has no such dependency and needs no WiFi/BLE state at
+  // all -- same call already used by lib/Serialization/ObfuscationUtils.cpp's
+  // getHwKey() for the identical reason.
+  static void getAdvertisedName(char* outBuf, size_t outBufLen);
 
   // Starts advertising if the heap gate and cool-down both allow it. Returns false
   // (and logs why) otherwise -- the caller must not retry in a tight loop; back off and
@@ -115,6 +147,10 @@ class BlePeripheralManager {
   volatile State state_ = State::Off;
   uint32_t lastLowMemoryTeardownMs_ = 0;
   bool coolingDown_ = false;
+  // millis() when poll()'s zombie check first saw the signature (Advertising, radio
+  // reporting inactive, no connection); 0 = not currently seen. Reset the moment the
+  // condition clears, so only a persistent zombie -- not a momentary one -- tears down.
+  unsigned long zombieSinceMs_ = 0;
 
   uint8_t pendingAuth_[kMaxPayloadLen] = {};
   size_t pendingAuthLen_ = 0;

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -114,7 +114,13 @@ void pump() {
   char replyBuf[BlePeripheralManager::kMaxPayloadLen];
   const size_t replyLen = dispatch(cmd, doc["payload"], replyBuf, sizeof(replyBuf));
   if (replyLen > 0) {
-    BlePeripheral.sendCommandReply(reinterpret_cast<const uint8_t*>(replyBuf), replyLen);
+    // Log delivery, not just intent: notify() returns false when no client has
+    // subscribed to the Command characteristic's CCCD -- diagnostics-only, this
+    // doesn't retry or change protocol behavior, just distinguishes "device never
+    // replied" from "client never listened" for whoever reads the serial/debug log.
+    const bool delivered = BlePeripheral.sendCommandReply(reinterpret_cast<const uint8_t*>(replyBuf), replyLen);
+    LOG_DBG(TAG, "reply %s: %.*s", delivered ? "notified" : "NOT delivered (no subscriber?)",
+            static_cast<int>(replyLen), replyBuf);
   }
 }
 

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -118,9 +118,12 @@ void pump() {
     // subscribed to the Command characteristic's CCCD -- diagnostics-only, this
     // doesn't retry or change protocol behavior, just distinguishes "device never
     // replied" from "client never listened" for whoever reads the serial/debug log.
+    // Logs the command name only, never the reply body: this dispatcher is the
+    // shared path for every future command (settings, firmware, book, sync), and a
+    // later reply may carry identifiers/tokens/account data that don't belong in a
+    // serial or debug log.
     const bool delivered = BlePeripheral.sendCommandReply(reinterpret_cast<const uint8_t*>(replyBuf), replyLen);
-    LOG_DBG(TAG, "reply %s: %.*s", delivered ? "notified" : "NOT delivered (no subscriber?)",
-            static_cast<int>(replyLen), replyBuf);
+    LOG_DBG(TAG, "reply for cmd=%s: %s", cmd, delivered ? "notified" : "NOT delivered (no subscriber?)");
   }
 }
 

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -156,20 +156,7 @@ void ActivityManager::loop() {
 
       lock.unlock();  // onEnter may acquire its own lock
 
-#ifndef SIMULATOR
-      // Free NimBLE's resident heap before the incoming activity allocates, but only
-      // if BLE is actually running -- end() is cheap but not free (HalPowerManager
-      // lock, NimBLE deinit sequence), so skip it entirely when there's nothing to
-      // tear down (Off/PausedLowMemory). With BLE resident, a heavy onEnter() (Home's
-      // cover art especially) could hit allocation failures before the main loop's
-      // poll() got a chance to react -- poll() only runs after onEnter() returns.
-      // main.cpp's bleAllowedNow logic restarts BLE on the new screen if its
-      // post-onEnter() heap clears the pre-flight gate.
-      if (BlePeripheral.isActive()) {
-        BlePeripheral.end();
-      }
-#endif
-
+      prepareForActivityEnter();
       currentActivity->onEnter();
 
       // onEnter may request another pending action, we will handle it in the next loop iteration
@@ -194,6 +181,22 @@ void ActivityManager::exitActivity(const RenderLock& lock) {
   }
 }
 
+void ActivityManager::prepareForActivityEnter() {
+#ifndef SIMULATOR
+  // Free NimBLE's resident heap before the incoming activity allocates, but only if
+  // BLE is actually running -- end() is cheap but not free (HalPowerManager lock,
+  // NimBLE deinit sequence), so skip it entirely when there's nothing to tear down
+  // (Off/PausedLowMemory). With BLE resident, a heavy onEnter() (Home's cover art
+  // especially) could hit allocation failures before the main loop's poll() got a
+  // chance to react -- poll() only runs after onEnter() returns. main.cpp's
+  // bleAllowedNow logic restarts BLE on the new screen if its post-onEnter() heap
+  // clears the pre-flight gate.
+  if (BlePeripheral.isActive()) {
+    BlePeripheral.end();
+  }
+#endif
+}
+
 void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
   // Note: no lock here, this is usually called by loop() and we may run into deadlock
   if (currentActivity) {
@@ -202,8 +205,11 @@ void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
     pendingActivity = std::move(newActivity);
     pendingAction = PendingAction::Replace;
   } else {
-    // No current activity, safe to launch immediately
+    // No current activity, safe to launch immediately. Reachable e.g. after Pop
+    // empties the activity stack and goHome() replaces straight into a fresh
+    // HomeActivity -- same onEnter()-about-to-allocate concern as the loop() path.
     currentActivity = std::move(newActivity);
+    prepareForActivityEnter();
     currentActivity->onEnter();
   }
 }

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -3,6 +3,9 @@
 #include <FontCacheManager.h>
 #include <HalGPIO.h>
 #include <HalPowerManager.h>
+#ifndef SIMULATOR
+#include <BlePeripheralManager.h>
+#endif
 
 #include <algorithm>
 
@@ -152,6 +155,21 @@ void ActivityManager::loop() {
       currentActivity = std::move(pendingActivity);
 
       lock.unlock();  // onEnter may acquire its own lock
+
+#ifndef SIMULATOR
+      // Free NimBLE's resident heap before the incoming activity allocates, but only
+      // if BLE is actually running -- end() is cheap but not free (HalPowerManager
+      // lock, NimBLE deinit sequence), so skip it entirely when there's nothing to
+      // tear down (Off/PausedLowMemory). With BLE resident, a heavy onEnter() (Home's
+      // cover art especially) could hit allocation failures before the main loop's
+      // poll() got a chance to react -- poll() only runs after onEnter() returns.
+      // main.cpp's bleAllowedNow logic restarts BLE on the new screen if its
+      // post-onEnter() heap clears the pre-flight gate.
+      if (BlePeripheral.isActive()) {
+        BlePeripheral.end();
+      }
+#endif
+
       currentActivity->onEnter();
 
       // onEnter may request another pending action, we will handle it in the next loop iteration

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -57,6 +57,14 @@ class ActivityManager {
 
   void exitActivity(const RenderLock& lock);
 
+  // Frees NimBLE's resident heap before a newly-constructed activity's onEnter()
+  // runs, but only when BLE is actually active -- called from both places a fresh
+  // activity's onEnter() is invoked (loop()'s pendingActivity path and
+  // replaceActivity()'s no-current-activity path), so neither can bypass it. Not
+  // needed when returning to an already-stacked activity (Pop), since that doesn't
+  // call onEnter().
+  void prepareForActivityEnter();
+
   // Pending activity to be launched on next loop iteration
   std::unique_ptr<Activity> pendingActivity;
   enum class PendingAction { None, Push, Pop, Replace };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@
 #include "fontIds.h"
 #include "images/LoadingIcon.h"
 #include "util/BatteryDiagLog.h"
+#include "util/BleDiagLog.h"
 #include "util/ButtonNavigator.h"
 #include "util/ScreenshotUtil.h"
 #include "util/SleepDiagLog.h"
@@ -839,6 +840,51 @@ void loop() {
   }
   BlePeripheral.poll();
   BleCommandDispatcher::pump();
+
+  // Diagnostics + repaint nudge. The "BT" indicator in BaseTheme::drawHeader() reads
+  // live BlePeripheral state, but e-ink screens don't repaint on a timer -- without an
+  // explicit nudge here, a header already on screen when the radio finishes starting
+  // (or stops) would sit stale until some unrelated repaint happened to occur.
+  //
+  // BleDiagLog is best-effort, not guaranteed: RollingSdLog::append() silently skips
+  // the write below RollingSdLog::MIN_SAFE_HEAP_BYTES (32 KB) free heap, and NimBLE's
+  // own resident cost can leave less than that free while BLE is up -- an Off ->
+  // Advertising transition right after a successful begin() may not actually reach
+  // /debug_log.txt. LOG_DBG alongside it is serial-only and stripped from RC builds
+  // (LOG_LEVEL=1), so it doesn't fill that gap either. Not solved here: a low-heap
+  // transition may simply go unlogged to SD. See BleDiagLog.h.
+  static bool lastBleAllowedNow = false;
+  if (bleAllowedNow != lastBleAllowedNow) {
+    LOG_DBG("BLEDIAG", "bleAllowedNow %d -> %d (bleEnabled=%d wifiMode=%d isReader=%d)", lastBleAllowedNow,
+            bleAllowedNow, MIDAD_APP_SETTINGS.bleEnabled, static_cast<int>(WiFi.getMode()),
+            activityManager.isReaderActivity());
+    lastBleAllowedNow = bleAllowedNow;
+  }
+  static BlePeripheralManager::State lastBleDiagState = BlePeripheralManager::State::Off;
+  static unsigned long lastBleRefusalLogMs = 0;
+  const auto bleStateNow = BlePeripheral.state();
+  if (bleStateNow != lastBleDiagState) {
+    static const char* const kBleStateNames[] = {"off", "advertising", "connected", "paused_low_memory"};
+    char bleBuf[96];
+    snprintf(bleBuf, sizeof(bleBuf), "state %s -> %s, free heap=%u (gate=%u, floor=%u)",
+             kBleStateNames[static_cast<int>(lastBleDiagState)], kBleStateNames[static_cast<int>(bleStateNow)],
+             static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(BlePeripheralManager::kHeapGateBytes),
+             static_cast<unsigned>(BlePeripheralManager::kRunningFloorBytes));
+    BleDiagLog::append(bleBuf);
+    LOG_DBG("BLEDIAG", "%s", bleBuf);
+    lastBleDiagState = bleStateNow;
+    activityManager.requestUpdate();
+  } else if (bleAllowedNow && bleStateNow == BlePeripheralManager::State::Off &&
+             millis() - lastBleRefusalLogMs >= 60000) {
+    // Wanted to run for at least 60s straight but hasn't -- one line per minute while
+    // stuck, not every tick, so this doesn't flood the shared log.
+    lastBleRefusalLogMs = millis();
+    char bleBuf[96];
+    snprintf(bleBuf, sizeof(bleBuf), "still off after wanting to start: free heap=%u (gate=%u)",
+             static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(BlePeripheralManager::kHeapGateBytes));
+    BleDiagLog::append(bleBuf);
+    LOG_DBG("BLEDIAG", "%s", bleBuf);
+  }
 #endif
 
   if (Serial && millis() - lastMemPrint >= 10000) {
@@ -860,6 +906,40 @@ void loop() {
         uint8_t* buf = display.getFrameBuffer();
         logSerial.write(buf, bufferSize);
         logSerial.printf("SCREENSHOT_END\n");
+        // BLE_ON/BLE_OFF/BLE_STATUS/RESTART: permanent debug tooling alongside
+        // SCREENSHOT above, added for driving/inspecting BLE lifecycle state without
+        // physical button presses/screen navigation -- same rationale (device-side
+        // testing that doesn't need eyes on the e-ink panel or a phone in hand).
+      } else if (cmd == "BLE_ON") {
+        MIDAD_APP_SETTINGS.bleEnabled = 1;
+        MIDAD_APP_SETTINGS.saveToFile();
+        logSerial.printf("BLE_ON: bleEnabled now %d\n", MIDAD_APP_SETTINGS.bleEnabled);
+      } else if (cmd == "BLE_OFF") {
+        MIDAD_APP_SETTINGS.bleEnabled = 0;
+        MIDAD_APP_SETTINGS.saveToFile();
+        logSerial.printf("BLE_OFF: bleEnabled now %d\n", MIDAD_APP_SETTINGS.bleEnabled);
+      } else if (cmd == "BLE_STATUS") {
+#ifndef SIMULATOR
+        char advName[24];
+        BlePeripheralManager::getAdvertisedName(advName, sizeof(advName));
+        logSerial.printf(
+            "BLE_STATUS: enabled=%d activity=%s wifiMode=%d isReader=%d freeHeap=%u maxAlloc=%u gate=%u floor=%u "
+            "bleState=%d name=%s\n",
+            MIDAD_APP_SETTINGS.bleEnabled, activityManager.currentActivityDebugName(), static_cast<int>(WiFi.getMode()),
+            activityManager.isReaderActivity(), static_cast<unsigned>(ESP.getFreeHeap()),
+            static_cast<unsigned>(ESP.getMaxAllocHeap()), static_cast<unsigned>(BlePeripheralManager::kHeapGateBytes),
+            static_cast<unsigned>(BlePeripheralManager::kRunningFloorBytes), static_cast<int>(BlePeripheral.state()),
+            advName);
+#endif
+      } else if (cmd == "RESTART") {
+        // Lets a scripted USB test harness reboot the device to exercise boot-path
+        // behavior (e.g. the boot-time BLE session) without physical access.
+        // ESP.restart() is normally reserved for recovery paths (see CLAUDE.md), but a
+        // serial debug command is an explicit operator request, same as the power
+        // button.
+        logSerial.printf("RESTART: rebooting now\n");
+        logSerial.flush();
+        ESP.restart();
       }
     }
   }
@@ -998,8 +1078,19 @@ void loop() {
     yield();                             // Give FreeRTOS a chance to run tasks, but return immediately
   } else {
     if (millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
-      // If we've been inactive for a while, increase the delay to save power
-      powerManager.setPowerSaving(true);  // Lower CPU frequency after extended inactivity
+      // If we've been inactive for a while, increase the delay to save power.
+      // NEVER while BLE is up: HalPowerManager's low-power CPU frequency is below
+      // what Espressif requires for BLE RF (the controller keeps reporting
+      // advertising-active while physically transmitting nothing at that frequency).
+      // A device would work fine while the user is actively pressing buttons and
+      // silently go dark to real scanners the moment it idles without this check.
+#ifndef SIMULATOR
+      const bool blePreventsLowPower = BlePeripheral.isActive();
+#else
+      const bool blePreventsLowPower = false;
+#endif
+      powerManager.setPowerSaving(
+          !blePreventsLowPower);  // Lower CPU frequency after extended inactivity, unless BLE needs it
       delay(50);
     } else {
       // Short delay to prevent tight loop while still being responsive

--- a/src/util/BleDiagLog.h
+++ b/src/util/BleDiagLog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+#include "DebugLog.h"
+#include "RollingSdLog.h"
+
+// Rolling diagnostic log for BlePeripheralManager's lifecycle (state transitions, and
+// why it stays off when it wanted to start), tagged into the shared /debug_log.txt (see
+// DebugLog.h). lib/hal/BlePeripheralManager.cpp itself can't write here directly --
+// lib/hal/ never includes src/ headers in this codebase (see BlePeripheralManager.h's
+// own comment) -- so main.cpp, which already calls begin()/poll() and has the heap
+// figures on hand, logs on its behalf. Mirrors SleepDiagLog/WifiDiagLog's rationale: a
+// user reporting "the BT indicator never showed up" has no serial cable to show us
+// whether the radio ever actually started, or why not.
+//
+// Best-effort, not guaranteed: RollingSdLog::append() silently skips the write below
+// RollingSdLog::MIN_SAFE_HEAP_BYTES (32 KB) free heap, and NimBLE's own resident cost
+// can leave meaningfully less than that free while BLE is up -- a transition logged
+// right after a successful begin() may not actually reach the SD card. That's accepted
+// here rather than worked around: lowering the heap floor, forcing the write, or
+// building a small pending-record-flushed-later mechanism would all trade a diagnostic
+// nicety for real stability risk, which this log exists to help debug, not to add to.
+namespace BleDiagLog {
+
+inline void append(const std::string& line) {
+  RollingSdLog::append(DebugLog::PATH, "[BLE] " + line, DebugLog::MAX_LINES);
+}
+
+}  // namespace BleDiagLog

--- a/src/util/BleDiagLog.h
+++ b/src/util/BleDiagLog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Arduino.h>
+
 #include <string>
 
 #include "DebugLog.h"
@@ -23,8 +25,19 @@
 // nicety for real stability risk, which this log exists to help debug, not to add to.
 namespace BleDiagLog {
 
-inline void append(const std::string& line) {
-  RollingSdLog::append(DebugLog::PATH, "[BLE] " + line, DebugLog::MAX_LINES);
+// Takes a raw C string, not std::string: a std::string parameter would construct a
+// temporary from the caller's fixed char buffer BEFORE this function's body -- and
+// therefore before RollingSdLog's own MIN_SAFE_HEAP_BYTES check -- ever runs, exactly
+// the kind of allocation-ahead-of-the-safety-gate this log must not introduce given
+// BLE-R1 explicitly lets a running session's free heap sit as low as
+// BlePeripheralManager::kRunningFloorBytes (8 KB, well under the 32 KB floor). Checked
+// again here, redundantly but cheaply (a single ESP.getFreeHeap() comparison, no
+// allocation), so the "[BLE] " + line concatenation below never happens at all when
+// there isn't room for it -- RollingSdLog::append()'s own internal check remains as a
+// second guard, not replaced by this one.
+inline void append(const char* line) {
+  if (ESP.getFreeHeap() < RollingSdLog::MIN_SAFE_HEAP_BYTES) return;
+  RollingSdLog::append(DebugLog::PATH, std::string("[BLE] ") + line, DebugLog::MAX_LINES);
 }
 
 }  // namespace BleDiagLog


### PR DESCRIPTION
## Summary

BLE-R1 per `docs/ble-recovery-plan.md`: recovers the applicable stabilization fixes from stale-branch commits `0592d385`, `28562591`, `90d19895`, `835dacbc`, and the per-device-name portion of `804cfacd` -- **reimplemented fresh against current develop, not replayed verbatim**. Stabilization only: no BLE-R2+ functionality (no pairing-screen redesign, no `CrossPointSettings`/`SettingsList` BLE fields, no device.info/account.claim/device.challenge/wifi.scan/settings.push/firmware.update/book.fetch/sync.pull/sync.ack, no post-provision WiFi verification, no `BluetoothActivity`), no Phase D.

Read-only audit (prior turn) confirmed all five underlying bugs are still present on `develop`, most notably: **BLE is effectively non-functional today** -- `poll()` judges a running session against the same 70KB number `begin()` uses as its pre-flight gate, so every successful start tears itself down on its very next tick.

## Changes

**`lib/hal/BlePeripheralManager.cpp`/`.h`**
- `begin()`'s early-return now only treats `Advertising`/`Connected` as "already running" -- `PausedLowMemory` used to be folded into the same guard, so a device that ever paused for low memory could never retry BLE again for the rest of the boot session.
- Splits the pre-flight heap gate (`kHeapGateBytes`, 70KB) from a new while-running floor (`kRunningFloorBytes`, 8KB) -- `poll()` now checks the latter. This is the fix for the non-functional-BLE bug above.
- BLE-aware power-saving: the lifecycle decision lives in `main.cpp`, not `HalPowerManager`'s own low-power constant (unchanged).
- Explicit advertised name, TX power (`setPower(9)` -- adapted from the stale branch's `setPower(ESP_PWR_LVL_P9)`, which used an API shape no longer present in the currently-pinned `h2zero/NimBLE-Arduino @ ^2.3.8`), and `advertising->start()`/`isAdvertising()` failure handling, so `begin()` fails honestly instead of leaving `state_ == Advertising` over a dead radio.
- Zombie guard in `poll()`: `Advertising`-but-radio-idle-with-no-connection must persist `kZombiePersistMs` (3s) before teardown, since advertising legitimately stops for a moment during a real inbound connection's CONNECT_IND-to-connect-event window.
- Per-device advertised name (`Midad-XXXXXX` from the eFuse MAC via new public `getAdvertisedName()`, **not** `WiFi.macAddress()` -- that returns all-zeros in this state since it needs the WiFi driver initialized at least once this boot, confirmed live). Also enables NimBLE scan response and routes the name there -- **real bug found during hardware validation**: the 128-bit service UUID alone consumes 18 of the primary advertising payload's 31-byte legacy AD budget, leaving no room for the name; confirmed via a raw `AdvertisementData` capture that the name never reached the actual over-the-air advertisement without this.
- Auth characteristic now declares `WRITE | WRITE_ENC`, not `WRITE_ENC` alone -- `WRITE_ENC` alone is only the requires-encryption flag; without the `WRITE` bit itself the characteristic advertises no write support at all and a real BLE client refuses to even attempt a write. Confirmed live: a real client now sees `['write']` in the characteristic's properties. Encryption is still fully enforced. **Declaration correctness only** -- BLE-R4's actual Auth verification logic remains out of scope.

**`src/BleCommandDispatcher.cpp`**: logs `sendCommandReply()`'s delivery result (`notify()` returns `false` when no client subscribed to the Command characteristic's CCCD) -- diagnostics only, no retry/protocol behavior added.

**`src/activities/ActivityManager.cpp`**: tears BLE down before the next activity's `onEnter()`, but only when `BlePeripheral.isActive()` -- a heavy `onEnter()` (Home's cover art especially) could otherwise allocate against a NimBLE-resident heap before `poll()` gets a chance to react. Smallest stable hook: one conditional call, no BLE-owned logic added to this file.

**`src/main.cpp`**: repaint nudge + diagnostics when BLE state changes (the "BT" status-bar indicator reads live state but e-ink doesn't repaint on a timer); the BLE-aware power-saving gate; `BLE_ON`/`BLE_OFF`/`BLE_STATUS`/`RESTART` serial debug commands, adapted to `MIDAD_APP_SETTINGS.bleEnabled` (Phase B architecture -- the stale branch predates Phase B and referenced `SETTINGS.bleEnabled`/`CrossPointSettings` directly). `BLE_STATUS` reports enabled/activity/wifi-mode/reader-state/heap figures/BLE state/advertised name -- no secrets, SSIDs, credentials, or tokens.

**`src/util/BleDiagLog.h`** (new): matches the `WifiDiagLog`/`SleepDiagLog` pattern exactly. Explicitly documented as best-effort, not guaranteed -- `RollingSdLog::append()` silently skips writes below its 32KB `MIN_SAFE_HEAP_BYTES` floor, and NimBLE's own resident cost can leave meaningfully less than that free while BLE is up, so a state transition right after a successful `begin()` may not actually reach `/debug_log.txt`. Not solved here: lowering that floor, forcing the write, or building a pending-record-flushed-later mechanism would all trade a diagnostic nicety for real stability risk, which this log exists to help debug, not add to.

**`platformio.ini`**: untouched, as required -- no functional build-flag change needed. **`freeink-sdk` pin**: untouched (Safety-P0's `a485dc46` unaffected).

## Hardware validation (real Xteink X3, mandatory per the recovery plan)

Built, flashed, and driven live via serial (`BLE_STATUS`/`BLE_ON`/`BLE_OFF`) and a real BLE client (Python `bleak` against macOS CoreBluetooth) against `/dev/cu.usbmodem2201`, confirmed via `esptool chip-id` as genuine ESP32-C3 hardware (device self-identifies `Hardware detect: X3`).

- **Startup**: `BLE_ON` → `BLE_STATUS` confirms `bleState=1` (Advertising). A real scan finds the device by its correct per-device name (`Midad-E1D840`, matching this unit's actual MAC `38:44:be:e1:d8:40` -- last 3 bytes `E1D840`) and service UUID.
- **The core non-functional-BLE bug is fixed**: no immediate self-teardown observed -- `bleState` stayed `1` (Advertising) stably across repeated checks, never regressing to `0`/`3`.
- **Idle / CPU-frequency fix**: heap and `bleState` stayed stable and the device remained discoverable via fresh scans several seconds apart, well past the 3-second `IDLE_POWER_SAVING_MS` threshold multiple times over.
- **Connect**: real `bleak` client -- scan, connect (`Connected: True`), Status characteristic read (`{"state":"connected"}`), a `wifi.provision` command write with an obviously-fake test SSID/password (this build only *saves* a credential, no auto-connect-verify in R1 scope -- confirmed safe), full command write → dispatch → reply → notify round-trip delivered correctly (`{"cmd":"wifi.provision","state":"failed","reason":"unauthorized"}` -- correctly refused because this real device already has a claimed account, pre-existing `deviceIsClaimed()` logic unrelated to this PR), disconnect, and advertising resumed automatically afterward (`advertiseOnDisconnect`).
- **Encrypted Auth write**: characteristic properties now correctly show `['write']` (previously would have shown none/refused outright). The write itself timed out waiting on encryption/pairing completion -- the same documented CoreBluetooth headless-pairing limitation the original stale-branch investigation found ("Pairing is not available in Core Bluetooth" for scripted macOS clients). Declaration-level fix confirmed; full encrypted round-trip requires a real phone.
- **No Wi-Fi passwords or real credentials appear in any log or this PR** -- the test SSID/password were obvious placeholders (`TEST-NETWORK-DO-NOT-USE`).
- **Low-memory lifecycle**: not artificially forced (no physical button access this session to navigate to a memory-heavy screen), but across ~5 minutes of real testing including multiple full connect/disconnect cycles, **zero** `PausedLowMemory` transitions, zombie-teardown events, or heap-drop errors appeared in the device's own log -- heap held rock-stable.
- **Memory measurements** (this exact build, real X3): **~81,240 bytes** free immediately before `begin()` (comfortably above `kHeapGateBytes`=70KB); **~22,588 bytes** free while advertising, holding steady over several minutes and multiple connect/disconnect cycles (comfortably above `kRunningFloorBytes`=8KB, ~14KB of real margin -- more headroom than the original stale-branch session's ~12.7KB measurement had). NimBLE's actual resident cost on this build: ~58.6KB. **`kRunningFloorBytes`=8KB confirmed still sensible on current firmware, kept unchanged** -- not lowered, per instruction, since it was never observed anywhere close to being hit.
- **Activity transitions**: **not physically tested** -- no button access in this automated session to navigate Apps→Home→Settings→Apps etc. Verified at the code level only: clean build, clean `cppcheck`, and a logical review confirming the conditional `BlePeripheral.end()` correctly no-ops when BLE isn't active, and only tears down (not blocks) when it is. **Flagging this as the one hardware-validation gap from the recovery plan's checklist that a human tester with physical button access should still exercise before treating this as fully proven** -- particularly the "no rapid teardown/restart loop" and "phone can reconnect after a screen change" scenarios.

## Normal verification

- `pio run -e default`: success.
- `pio run -e simulator`: success (confirmed `src/main.cpp` actually recompiled against the new `#ifndef SIMULATOR`-guarded code, not just a cache hit -- `lib/hal/` itself is excluded from simulator builds via `lib_ignore = hal`, so `BlePeripheralManager.cpp/.h` changes have no simulator surface at all).
- `pio check` (cppcheck): no defects.
- `clang-format`: clean, no changes needed.
- Full gtest suite: 134/134 (no new host-testable logic -- this is hardware-only HAL/lifecycle code).

## Conflict-baseline re-measurement

Real `git merge` dry-run against the fixed baseline (`2cac5971`), same methodology as every prior phase: **159 files -- identical to the Safety-P0 baseline, zero new conflicts.** `lib/hal/BlePeripheralManager.cpp`/`.h` and `src/BleCommandDispatcher.cpp` all stay **clean** (not on the list) despite substantial real changes -- genuinely isolated Midad-owned surface. `src/activities/ActivityManager.cpp` and `src/main.cpp` were already conflicting; this PR's additions grow what's inside those already-diverging files without adding any new file to the list, the same pattern established across Phase B, Phase C, and Safety-P0.

## Round 2 (review fixes)

Three corrections from review at head `454ca2d1`:

1. **`ActivityManager` `onEnter()` bypass closed.** The BLE-teardown protection only lived in `loop()`'s `pendingActivity` path -- `replaceActivity()`'s `else` branch (no current activity: `currentActivity = std::move(newActivity); currentActivity->onEnter();`) called `onEnter()` directly, bypassing it. Reachable after `Pop` empties the activity stack and `goHome()` replaces straight into a fresh `HomeActivity` -- exactly the heavy-`onEnter()` scenario this protection exists for. Centralized into a new private `ActivityManager::prepareForActivityEnter()`, called from both places a freshly-constructed activity's `onEnter()` runs, so the rule can't drift out of sync between the two call sites again. Returning to an already-stacked activity (`Pop`) still doesn't need it -- that path doesn't call `onEnter()`.
2. **Reply payload no longer logged.** `BleCommandDispatcher`'s delivery-diagnostic log printed the full reply JSON (`LOG_DBG(TAG, "reply %s: %.*s", ..., replyBuf)`). This dispatcher is the shared future path for account/settings/firmware/book/sync commands, whose replies may carry identifiers, tokens, or account data that don't belong in a serial/debug log. Now logs `reply for cmd=%s: %s` with the command name and delivered/not-delivered only -- no protocol/retry behavior changed.
3. **`BleDiagLog` no longer allocates before its safety gate.** `append()` took a `const std::string&`, so every call site passing a fixed `char[]` buffer (`main.cpp`'s `bleBuf`) implicitly constructed a temporary `std::string` **before** the function body -- and therefore before `RollingSdLog`'s own `MIN_SAFE_HEAP_BYTES` (32KB) check -- ever ran. BLE-R1 explicitly lets a running session's free heap sit as low as `kRunningFloorBytes` (8KB), well under that floor, so an avoidable allocation ahead of the safety gate is exactly the kind of thing this log must not do. Now takes a raw `const char*`, checks `ESP.getFreeHeap()` against `RollingSdLog::MIN_SAFE_HEAP_BYTES` itself first with zero allocation, and only builds the `"[BLE] " + line` string once there's confirmed room. `RollingSdLog`'s own internal check remains as an unchanged second guard. Still best-effort, not guaranteed -- same design intent as before, just no longer undermined by its own call sites.

**File scope grows from 6 to 7**: `src/activities/ActivityManager.h` is newly touched -- the direct, minimal consequence of centralizing fix #1's hook into a private method that needs a declaration.

**Hardware re-verified live on the same real Xteink X3** (head `649a3227`): `BLE_STATUS` confirms the lifecycle is unaffected by these fixes (`bleState` advertising, heap figures unchanged from before); a fresh scan/connect/`wifi.provision`/notify cycle via a real BLE client still works end-to-end (scan finds `Midad-E1D840` correctly); the new `BLECMD` log line reads exactly `reply for cmd=wifi.provision: notified` -- confirmed no reply body present in the serial log.

**Activity-transition navigation remains untested** -- still no physical button access in this session. Keeping this gap exactly as explicit, not claiming it: a human tester with physical access should still exercise Apps→Home→Settings→Apps and a fresh-`HomeActivity` path specifically (the exact path fix #1 protects), confirming no crash, no reboot, no rapid BLE teardown/restart loop, and that BLE/phone reconnection works after a screen change.

**Re-verification**: `pio run -e default`/`simulator`: success. `pio check`: no defects. `clang-format`: clean. gtest: 134/134. Conflict re-measurement: **159 files, unchanged** -- `BlePeripheralManager.cpp/.h`, `BleCommandDispatcher.cpp`, and the new `BleDiagLog.h` all stay clean; `ActivityManager.h` was already conflicting before this round's touch (confirmed via real unrelated divergence in the dry-run merge -- `goToReader` signature, differing includes), so no new file joins the list.

## Not in this PR

BLE-R2 (pairing-screen redesign, status-icon redesign), BLE-R3 (device.info/account.claim/device.challenge/wifi.scan), BLE-R4 (Auth verification logic, settings.push), BLE-R5 (firmware.update, book.fetch), BLE-R6 (sync.pull/sync.ack), `BluetoothActivity`, Phase D, and the three other independent fixes flagged by the Safety-P0-adjacent audit (`FOOTNOTE_HREF_LEN`, `WifiCredentialStore` lazy-load, `HomeActivity` cover-cache) -- each is its own separate PR candidate, not bundled here.

