### PR TITLE
fix: match Dependabot auto-merge method to proposed ruleset

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
           (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
            steps.meta.outputs.update-type == 'version-update:semver-patch') &&
           steps.meta.outputs.package-ecosystem != 'submodules'
-        run: gh pr merge --auto --rebase "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/upstream-sync-architecture.md
+++ b/docs/upstream-sync-architecture.md
@@ -937,19 +937,17 @@ ruleset below directly with `"enforcement": "active"` — there is no safer
 staged alternative on this account tier, so watch the first few real PRs
 after activation closely.
 
-**Pre-activation compatibility gap: Dependabot auto-merge uses `--rebase`.**
-`.github/workflows/dependabot-auto-merge.yml` currently runs
+**Pre-activation compatibility gap: Dependabot auto-merge used `--rebase`
+(resolved).** `.github/workflows/dependabot-auto-merge.yml` used to run
 `gh pr merge --auto --rebase "$PR_URL"`. The proposed ruleset's `pull_request`
 rule only allows `["merge", "squash"]` — not `rebase` — so activating the
-ruleset as designed would silently break Dependabot's auto-merge path the
-next time it tries to land a minor/patch bump (the merge attempt would be
+ruleset as designed would have silently broken Dependabot's auto-merge path
+the next time it tried to land a minor/patch bump (the merge attempt would be
 rejected by the ruleset, not obviously in a way that points back at this
-mismatch). **Tracked as a separate, tiny, Midad-owned follow-up PR** — change
-`--rebase` to `--squash` in that one workflow — to land after this PR merges
-and the trusted-evaluator validation passes, but *before* the ruleset is
-ever applied. Not bundled into this PR; not a reason to change the proposed
-ruleset's merge-method list instead unless a fresh review finds a reason to
-prefer that direction.
+mismatch). Fixed in a small, Midad-owned follow-up PR that changed
+`--rebase` to `--squash` in that one workflow, landed after PR #144 merged
+and the disposable trusted-evaluator security validation (PR #145) passed,
+before the ruleset is applied.
 
 **`file_path_restriction` does not belong in this ruleset — verified, not
 assumed.** The prior version of this section proposed a `file_path_restriction`


### PR DESCRIPTION
## Summary
- The proposed GitHub ruleset (documented in `docs/upstream-sync-architecture.md`) only allows `merge`/`squash` as merge methods on `develop`.
- `dependabot-auto-merge.yml` was calling `gh pr merge --auto --rebase`, which the ruleset would silently reject once activated -- Dependabot's minor/patch auto-merge would just stop working with no obvious link back to this mismatch.
- Switches that one call to `--squash`, matching Midad's normal PR convention. No other behavior changes.

## Test plan
- [x] `actionlint .github/workflows/dependabot-auto-merge.yml` -- clean
- [x] Diff limited to the merge-method flag and the corresponding doc note in `docs/upstream-sync-architecture.md`
- [ ] CI (Test Status, thin-fork-guard-trusted) -- pending on this PR