### PR TITLE
chore: validate live-upstream thin-fork-guard (disposable, do not merge)

### DIFF
--- a/docs/.thin-fork-guard-validation-marker
+++ b/docs/.thin-fork-guard-validation-marker
@@ -1,0 +1,3 @@
+Disposable validation marker for the live-upstream thin-fork-guard fix (PR #150, merged 9d4d1f2c).
+This file exists only to trigger a real PR run of thin-fork-guard / thin-fork-guard-trusted
+from develop. The PR that adds this file is not intended to merge — close without merging.


### PR DESCRIPTION
Disposable validation PR for PR #150 (merged 9d4d1f2c), which changed thin-fork-guard.yml / thin-fork-guard-trusted.yml to fetch crosspoint-reader/crosspoint-reader directly instead of the origin/upstream mirror.

Purpose: confirm both guard workflows run and PASS from current develop with the live-upstream fetch, per the documented security-boundary-file maintenance procedure's step 5 (re-validate after trusted-evaluator logic changes) and the authorized PR #150 maintenance-window step 6.

This PR is not intended to merge. Close without merging once checks are observed.