### PR TITLE
fix: BLE wifi.provision credential loss + Home menu touch mis-hit

### DIFF
--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -2,6 +2,7 @@
 
 #include <ArduinoJson.h>
 #include <BlePeripheralManager.h>
+#include <HalStorage.h>
 #include <Logging.h>
 
 #include <algorithm>
@@ -10,6 +11,7 @@
 #include "FouladEbooksConfig.h"
 #include "OpdsServerStore.h"
 #include "WifiCredentialStore.h"
+#include "activities/RenderLock.h"
 
 namespace BleCommandDispatcher {
 
@@ -66,8 +68,21 @@ size_t handleWifiProvision(JsonVariantConst payload, char* outBuf, size_t outBuf
   // WIFI_STORE's in-memory state; without this, addCredential() below would
   // save over wifi.json with only this one credential, discarding every
   // previously-saved network. fromJson() fully replaces in-memory state from
-  // disk, so this is safe to call unconditionally.
-  WIFI_STORE.loadFromFile();
+  // disk, so this is safe to call unconditionally. Storage.exists() decides
+  // "missing" (fine, first boot) vs. "exists but failed to load" (real
+  // corruption -- bail rather than saving over it) the same way
+  // MidadAppSettings::loadFromFile() does, since loadFromFile()'s plain bool
+  // return collapses both cases into false.
+  //
+  // Mirrors WifiSelectionActivity::onEnter(): SD and the e-ink display share
+  // one SPI bus, so a task doing blocking SD I/O off the render task holds
+  // RenderLock for the duration.
+  RenderLock lock;
+  const bool wifiStoreExists = Storage.exists(WifiCredentialStore::getFilePath());
+  if (wifiStoreExists && !WIFI_STORE.loadFromFile()) {
+    LOG_ERR(TAG, "wifi.provision: wifi.json exists but failed to load");
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");
+  }
 
   if (!WIFI_STORE.addCredential(ssid, password)) {
     LOG_ERR(TAG, "wifi.provision: addCredential failed for ssid=%s", ssid);

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -62,6 +62,13 @@ size_t handleWifiProvision(JsonVariantConst payload, char* outBuf, size_t outBuf
     return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
   }
 
+  // BLE has no guarantee WifiSelectionActivity ever ran this boot to populate
+  // WIFI_STORE's in-memory state; without this, addCredential() below would
+  // save over wifi.json with only this one credential, discarding every
+  // previously-saved network. fromJson() fully replaces in-memory state from
+  // disk, so this is safe to call unconditionally.
+  WIFI_STORE.loadFromFile();
+
   if (!WIFI_STORE.addCredential(ssid, password)) {
     LOG_ERR(TAG, "wifi.provision: addCredential failed for ssid=%s", ssid);
     return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -430,15 +430,24 @@ void HomeActivity::loop() {
       metrics.homeContinueReadingInMenu ? selectorIndex : selectorIndex - recentBooks.size();
   const int renderedMenuCount =
       menuCount - (metrics.homeContinueReadingInMenu ? 0 : static_cast<int>(recentBooks.size()));
-  int menuRow = -1;
-  // Row height from the theme, not the metrics table: RoundedRaff draws
-  // font-derived rows and the touch grid must match the visuals exactly.
-  const int menuRowHeight = GUI.getMenuRowHeight(renderer);
-  const auto menuTouch = mappedInput.rowTouch(menuRow, menuTop, menuRowHeight + metrics.menuSpacing, renderedMenuCount,
-                                              0, INT32_MAX, menuRowHeight);
+  // Hit-test through the theme, not a fixed row grid: FouladTheme draws this
+  // as a horizontal icon bar (see FouladTheme::drawButtonMenu), and the touch
+  // grid must match whatever the active theme actually drew.
+  const Rect menuRect{0, menuTop, renderer.getScreenWidth(), renderer.getScreenHeight() - menuTop};
+  int menuButton = -1;
+  int touchX = 0;
+  int touchY = 0;
+  MappedInputManager::RowTouch menuTouch = MappedInputManager::RowTouch::None;
+  if (mappedInput.wasScreenTouchDown(touchX, touchY) &&
+      GUI.buttonMenuIndexFromPoint(renderer, menuRect, renderedMenuCount, touchX, touchY, menuButton)) {
+    menuTouch = MappedInputManager::RowTouch::Down;
+  } else if (mappedInput.wasScreenTapped(touchX, touchY) &&
+             GUI.buttonMenuIndexFromPoint(renderer, menuRect, renderedMenuCount, touchX, touchY, menuButton)) {
+    menuTouch = MappedInputManager::RowTouch::Tap;
+  }
   if (menuTouch != MappedInputManager::RowTouch::None) {
     const int touchedIndex =
-        metrics.homeContinueReadingInMenu ? menuRow : menuRow + static_cast<int>(recentBooks.size());
+        metrics.homeContinueReadingInMenu ? menuButton : menuButton + static_cast<int>(recentBooks.size());
     if (menuTouch == MappedInputManager::RowTouch::Down) {
       if (selectorIndex != touchedIndex) {
         selectorIndex = touchedIndex;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -863,6 +863,17 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
+bool BaseTheme::buttonMenuIndexFromPoint(const GfxRenderer&, const Rect rect, const int buttonCount, const int,
+                                         const int y, int& index) const {
+  if (buttonCount <= 0) return false;
+  const int rowStep = BaseMetrics::values.menuRowHeight + BaseMetrics::values.menuSpacing;
+  if (rowStep <= 0 || y < rect.y) return false;
+  const int row = (y - rect.y) / rowStep;
+  if (row >= buttonCount || (y - rect.y) % rowStep >= BaseMetrics::values.menuRowHeight) return false;
+  index = row;
+  return true;
+}
+
 Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int marginX = metrics.popupMarginX;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -863,13 +863,18 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
-bool BaseTheme::buttonMenuIndexFromPoint(const GfxRenderer&, const Rect rect, const int buttonCount, const int,
+bool BaseTheme::buttonMenuIndexFromPoint(const GfxRenderer&, const Rect rect, const int buttonCount, const int x,
                                          const int y, int& index) const {
   if (buttonCount <= 0) return false;
   const int rowStep = BaseMetrics::values.menuRowHeight + BaseMetrics::values.menuSpacing;
-  if (rowStep <= 0 || y < rect.y) return false;
-  const int row = (y - rect.y) / rowStep;
-  if (row >= buttonCount || (y - rect.y) % rowStep >= BaseMetrics::values.menuRowHeight) return false;
+  if (rowStep <= 0) return false;
+  const int left = rect.x + BaseMetrics::values.contentSidePadding;
+  const int right = rect.x + rect.width - BaseMetrics::values.contentSidePadding;
+  if (x < left || x >= right) return false;
+  const int top = rect.y + BaseMetrics::values.verticalSpacing;
+  if (y < top) return false;
+  const int row = (y - top) / rowStep;
+  if (row >= buttonCount || (y - top) % rowStep >= BaseMetrics::values.menuRowHeight) return false;
   index = row;
   return true;
 }

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -295,6 +295,12 @@ class BaseTheme {
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon) const;
+  // Hit-test counterpart to drawButtonMenu(), same shape as tabIndexFromPoint()
+  // above: HomeActivity's touch grid must match whatever a theme override
+  // actually draws (e.g. FouladTheme's horizontal icon bar vs. this class's
+  // vertical rows), so each override owns its own inverse of its draw math.
+  virtual bool buttonMenuIndexFromPoint(const GfxRenderer& renderer, Rect rect, int buttonCount, int x, int y,
+                                        int& index) const;
   virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
   virtual void drawOptionPopup(const GfxRenderer& renderer, const char* title, const std::vector<std::string>& options,
                                int selectedIndex) const;

--- a/src/components/themes/foulad/FouladTheme.cpp
+++ b/src/components/themes/foulad/FouladTheme.cpp
@@ -566,3 +566,27 @@ void FouladTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, const int but
     }
   }
 }
+
+// Inverse of drawButtonMenu()'s tile geometry above -- barY/tileWidth/tileX
+// must be derived the same way or taps land on the wrong tile (or none).
+bool FouladTheme::buttonMenuIndexFromPoint(const GfxRenderer& renderer, const Rect rect, const int buttonCount,
+                                           const int x, const int y, int& index) const {
+  if (buttonCount <= 0) return false;
+  constexpr int kGlyphStripHeight = 20;
+  const int barY = renderer.getScreenHeight() - kMenuBandHeight - kGlyphStripHeight;
+  if (y < barY || y >= barY + kMenuBandHeight) return false;
+
+  const int totalGaps = kMenuGap * (buttonCount - 1);
+  const int tileWidth = (rect.width - kMenuPadding * 2 - totalGaps) / buttonCount;
+  const int tileStep = tileWidth + kMenuGap;
+  if (tileWidth <= 0 || tileStep <= 0) return false;
+
+  const int relX = x - (rect.x + kMenuPadding);
+  if (relX < 0) return false;
+  const int slotIndex = relX / tileStep;
+  if (slotIndex >= buttonCount || relX % tileStep >= tileWidth) return false;
+
+  const bool rtl = I18N.isRtl();
+  index = rtl ? buttonCount - 1 - slotIndex : slotIndex;
+  return true;
+}

--- a/src/components/themes/foulad/FouladTheme.h
+++ b/src/components/themes/foulad/FouladTheme.h
@@ -33,4 +33,6 @@ class FouladTheme : public LyraTheme {
   void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                       const std::function<std::string(int index)>& buttonLabel,
                       const std::function<UIIcon(int index)>& rowIcon) const override;
+  bool buttonMenuIndexFromPoint(const GfxRenderer& renderer, Rect rect, int buttonCount, int x, int y,
+                                int& index) const override;
 };


### PR DESCRIPTION
## Summary

First item in the Phase 3 recovery sequence (FE-P3-RECOVERY-001): two bugs confirmed live on `develop` today, independent of any stranded branch. Scoped deliberately narrow per FE-P3-QUICKFIX-001.

**1. `BleCommandDispatcher::handleWifiProvision()` never loaded `WIFI_STORE` from disk before mutating it.** Only `WifiSelectionActivity::onEnter()` called `WIFI_STORE.loadFromFile()`. A `wifi.provision` BLE write on a boot where that screen was never opened ran against an empty in-memory credential list, so `addCredential()` + `saveToFile()` silently overwrote `wifi.json` with just the one new network — every previously-saved network lost, no error, no log. Fix: call `WIFI_STORE.loadFromFile()` once, unconditionally, before `addCredential()`. Safe because `WifiCredentialStore::fromJson()` fully replaces in-memory state from disk (`credentials.clear()` then repopulate), so this is idempotent regardless of what else has already loaded it this boot.

**2. `HomeActivity`'s bottom menu-bar touch handling used `rowTouch()` (vertical-row hit test), but `FouladTheme::drawButtonMenu()` renders that bar as a horizontal strip of same-Y tiles.** `rowTouch()`'s row index is derived purely from Y (its `xStart`/`xEnd` params only gate pass/fail, they don't distinguish columns) — so **any tap anywhere on the bar resolved to row 0, the first tile, regardless of which icon was actually tapped.** Root cause: `FouladTheme` overrides `drawButtonMenu()` with a horizontal-bar layout but the touch code in `HomeActivity` was never updated from the base theme's row-based contract. Fix: added `BaseTheme::buttonMenuIndexFromPoint()` (virtual hit-test counterpart to `drawButtonMenu()`, default mirrors the base row layout) with a `FouladTheme` override that's the algebraic inverse of `drawButtonMenu()`'s own tile geometry (same `barY`/`tileWidth`/`kMenuGap` constants, same RTL slot mapping). Mirrors the existing `tabIndexFromPoint()` pattern already established in this codebase for the same "theme owns hit-test to match its own draw" problem. `HomeActivity` now calls the theme hit-test instead of `rowTouch()`.

## Explicitly out of scope for this PR

- Simulator infrastructure (a separate, pre-existing `FreeInkApp.h`/freeink-sdk libdep gap prevents `pio run -e simulator` from building at all right now — unrelated to this change, tracked separately as Phase-3 technical debt, not fixed here)
- Other BLE command recovery (device.info, device.challenge, etc. — later batches in the FE-P3-RECOVERY-001 sequence)
- OTA signing work
- Other touch/S3 work
- Any change to the screen-scoped BLE lifecycle architecture (BLE-R1/R2 stays the baseline)

## Validation

- `pio run` (default, ESP32-C3): SUCCESS, RAM 17.9% / Flash 77.8% — no measurable change from baseline
- `pio run -e sticky` (ESP32-S3): SUCCESS
- `pio check` (cppcheck, default): "No defects found"
- `./bin/clang-format-fix -g`: clean
- Simulator smoke test: could not run (pre-existing, unrelated build gap noted above)
- Hardware validation: pending — not requested for this PR per the standing hardware-access constraint (no disposable test device confirmed yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)