### PR TITLE
feat: add sticky_tls_measure env for S3 TLS heap measurement

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -365,6 +365,22 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2
 
+; Sticky/S3 counterpart to default_tls_measure -- same TlsHeapMeasureActivity/
+; TlsHeapMeasureCaBundles source, just compiled for the S3/Xtensa board instead
+; of C3/RISC-V, since default_tls_measure extends env:default and cannot run on
+; this MCU family. Never flash this for daily use.
+;   pio run -e sticky_tls_measure -t upload
+[env:sticky_tls_measure]
+extends = env:sticky
+build_flags =
+  ${env:sticky.build_flags}
+  -DTLS_HEAP_MEASURE_HARNESS=1
+  ; scripts/git_branch.py only injects CROSSPOINT_VERSION for PIOENV in
+  ; ('default', 'sticky'); set it explicitly here (same pattern as
+  ; default_tls_measure above and gh_release/slim below) so HalSystem.cpp's
+  ; use of the macro still compiles.
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-tls-measure\"
+
 [env:sticky-gh_release]
 extends = base
 board = esp32-s3-devkitc1-n16r8


### PR DESCRIPTION
## Summary
- Closes a gap found while finalizing the FE-P3-HARDWARE-SESSION-PLAN-001 playbook: `default_tls_measure` (PR #161) extends `env:default`, which targets the C3/RISC-V board. Sticky is a separate MCU family (S3/Xtensa) built from `env:sticky` -- the harness cannot run there without its own env.
- Adds `[env:sticky_tls_measure]` mirroring `[env:default_tls_measure]` exactly: same `TLS_HEAP_MEASURE_HARNESS` flag, same `CROSSPOINT_VERSION` workaround (`scripts/git_branch.py` only injects the macro for `default`/`sticky`), extends `env:sticky` instead of `env:default`. No source changes -- `TlsHeapMeasureActivity.cpp/.h` and `TlsHeapMeasureCaBundles.h` are unchanged and compile as-is for S3.
- `TLS_HEAP_MEASURE_HARNESS` remains defined only in these two envs; every normal/release env is unaffected.

## Test plan
- [x] `pio run -e sticky_tls_measure` -- builds clean (RAM 20.7%, Flash 74.0%)
- [x] `./bin/clang-format-fix -g` -- no-op (INI-only change)
- [x] `scripts/thin-fork-guard.sh` -- PASS, no new conflicting files, no new Midad-side divergence