### PR TITLE
fix: stop OTA-signing app check from boot-looping unsigned builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -64,7 +64,12 @@ build_flags =
   -DHAVE_CURVE25519
   -DHAVE_SNI
   -Wno-bidi-chars
-  -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort,--wrap=bootloader_common_check_efuse_blk_validity
+  ; --wrap=esp_secure_boot_init_checks: see src/OtaSigningBootGuard.cpp. Gated
+  ; by OTA_SIGNING_BOOT_CHECK_ENABLED (only defined for the release/RC envs
+  ; below), not by a per-env custom_sdkconfig -- keeps custom_sdkconfig
+  ; byte-identical across every C3/S3 env (see that file's header comment for
+  ; why that matters).
+  -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort,--wrap=bootloader_common_check_efuse_blk_validity,--wrap=esp_secure_boot_init_checks
   -fno-exceptions
 
 build_unflags =
@@ -112,16 +117,25 @@ custom_sdkconfig =
   ; Phase 1 Milestone 1 (authenticated OTA spike): compile esp_ota_ops/esp_image_format
   ; with app-image-signature verification, without hardware Secure Boot (no eFuse burn,
   ; works on already-deployed devices). RSA-3072 is the only signing scheme SOC_SECURE_
-  ; BOOT_V2_RSA supports on both ESP32-C3 and ESP32-S3. SECURE_SIGNED_ON_UPDATE_NO_SECURE_
-  ; BOOT (default y once NO_SECURE_BOOT is on) is what actually gates OTA installs -- it
-  ; makes esp_ota_end()/esp_ota_set_boot_partition() reject an unsigned or badly-signed
-  ; image. SECURE_BOOT_BUILD_SIGNED_BINARIES is left off deliberately: PlatformIO's own
-  ; build (not idf.py) produces firmware.bin, and whether it even honors ESP-IDF's
-  ; CMake auto-sign target is exactly the open question this spike answers -- see the
-  ; Milestone 1 report. Until a real release-signing step exists, every locally-built
-  ; and CI-built firmware.bin stays unsigned; this only changes what a *device already
-  ; running this firmware* will accept as its next OTA update, since the option only
-  ; changes esp_ota_ops.c's compiled behavior, not what this build itself produces.
+  ; BOOT_V2_RSA supports on both ESP32-C3 and ESP32-S3. SECURE_BOOT_BUILD_SIGNED_BINARIES
+  ; is left off deliberately: PlatformIO's own build (not idf.py) produces firmware.bin,
+  ; and whether it even honors ESP-IDF's CMake auto-sign target is exactly the open
+  ; question this spike answers -- see the Milestone 1 report. Until a real
+  ; release-signing step exists, every locally-built and CI-built firmware.bin stays
+  ; unsigned.
+  ;
+  ; SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT gates OTA installs (esp_ota_end()/
+  ; esp_ota_set_boot_partition() reject an unsigned or badly-signed image) -- but it
+  ; ALSO wires check_signature_on_update_check() into esp_secure_boot_init_checks(),
+  ; which runs at every BOOT (components/efuse/src/esp_efuse_startup.c's
+  ; ESP_SYSTEM_INIT_FN(init_efuse, ...)), not just at OTA-install time as this
+  ; comment previously (incorrectly) claimed. It aborts() if the *running* app
+  ; carries zero signature blocks -- true for every unsigned build this pipeline
+  ; produces. Applying this Kconfig identically to every env is intentional (see
+  ; src/OtaSigningBootGuard.cpp for why per-env custom_sdkconfig isn't safe here);
+  ; the boot-time abort is suppressed for dev/diagnostic envs via a linker --wrap
+  ; on esp_secure_boot_init_checks itself, gated by the OTA_SIGNING_BOOT_CHECK_ENABLED
+  ; build_flag (release/RC envs only). See FE-P3-OTA-SIGNING-CONFIG-001.
   CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT=y
   CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME=y
   CONFIG_SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT=y
@@ -222,6 +236,9 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
+  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
+  ; boot-time app-signature check actually run.
+  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1
 
 [env:gh_release_rc]
 extends = base
@@ -232,6 +249,9 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
+  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
+  ; boot-time app-signature check actually run.
+  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1
 
 [env:slim]
 extends = base
@@ -391,6 +411,9 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
+  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
+  ; boot-time app-signature check actually run.
+  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1
 
 [env:sticky-gh_release_rc]
 extends = base
@@ -402,3 +425,6 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
+  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
+  ; boot-time app-signature check actually run.
+  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -421,10 +421,10 @@ board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
   ${base.build_flags}
+  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
+  ; boot-time app-signature check actually run.
+  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1
   -DFREEINK_DEVICE_STICKY=1
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
-  ; See src/OtaSigningBootGuard.cpp -- only the real release/RC envs let the
-  ; boot-time app-signature check actually run.
-  -DOTA_SIGNING_BOOT_CHECK_ENABLED=1

--- a/src/OtaSigningBootGuard.cpp
+++ b/src/OtaSigningBootGuard.cpp
@@ -1,0 +1,34 @@
+// esp_secure_boot_init_checks() (esp-idf bootloader_support/src/secure_boot.c)
+// runs on every single boot via ESP_SYSTEM_INIT_FN(init_efuse, CORE, BIT(0), 140)
+// in components/efuse/src/esp_efuse_startup.c -- not just at OTA-install time,
+// despite CONFIG_SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT's own Kconfig help text
+// (and this project's original PR #156) both describing it as install-time-only.
+// With that option set (platformio.ini [base] custom_sdkconfig, applied to every
+// env), if the *running* app carries zero signature blocks it calls abort()
+// immediately, then again on every subsequent boot -- confirmed boot-looping a
+// real X3 the moment an unsigned dev build was flashed
+// (FE-P3-OTA-SIGNING-CONFIG-001).
+//
+// Giving dev/diagnostic envs a different custom_sdkconfig than release envs (the
+// seemingly obvious fix) isn't safe here: pioarduino's Arduino-core build cache
+// is keyed by board, not by env, so two same-board envs with differing
+// custom_sdkconfig content corrupt each other's cached custom_component_remove
+// state (confirmed empirically -- esp_insights/rainmaker silently stopped being
+// excluded from an unrelated env's build). This wraps the boot-time check itself
+// instead, via -Wl,--wrap=esp_secure_boot_init_checks (platformio.ini [base]
+// build_flags, identical for every env) gated by a build_flag that IS safe to
+// vary per env: OTA_SIGNING_BOOT_CHECK_ENABLED, defined only for
+// gh_release/gh_release_rc/sticky-gh_release/sticky-gh_release_rc. Every env
+// keeps a byte-identical custom_sdkconfig and the underlying signature-
+// verification code (esp_ota_ops.c) stays compiled in and unchanged for
+// everyone -- this only skips the boot-time self-check for envs that, by
+// design, never carry a production signature.
+#include <esp_secure_boot.h>
+
+extern "C" void __real_esp_secure_boot_init_checks(void);
+
+extern "C" void __wrap_esp_secure_boot_init_checks(void) {
+#ifdef OTA_SIGNING_BOOT_CHECK_ENABLED
+  __real_esp_secure_boot_init_checks();
+#endif
+}


### PR DESCRIPTION
## Root cause

`CONFIG_SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT` (PR #156) wires `check_signature_on_update_check()` into `esp_secure_boot_init_checks()`, which ESP-IDF runs on **every boot** via `ESP_SYSTEM_INIT_FN(init_efuse, CORE, BIT(0), 140)` in `components/efuse/src/esp_efuse_startup.c:101-103` — not just at OTA-install time, despite PR #156's own commit message and this option's Kconfig help text both describing it as install-time-only. Directly re-verified against the pinned ESP-IDF source (`components/bootloader_support/src/secure_boot.c:153-193`): if the *running* app carries zero signature blocks, it logs `"This app is not signed, but check signature on update is enabled in config"` and calls `abort()` — true for every build this pipeline currently produces, since no production signing key exists yet.

## Why the X3 boot-looped

Confirmed on real hardware during the resumed Phase 3 hardware session: flashing `default_tls_measure` to a connected X3 boot-looped it — 26 consecutive `abort()`s at an identical PC (resolved via `addr2line` to `secure_boot.c:163`), one per ~1s reboot cycle. This affects every real-device env built from current `develop` (`default`, `sticky`, `slim`, etc.), not just the TLS harness — none of them carry a signature.

Separately (related, tracked but out of scope for this fix): `auto-release.yml` has been failing at the sign step (`OTA_SIGNING_KEY is not set`) on every push to `develop` since PR #156 merged — confirmed via `gh run list`. No new RC/release artifact has published since. This means no already-shipped end-user device is affected by the boot-loop; only local/CI builds are.

## Why not just give dev envs a different `custom_sdkconfig`

That was my first approach and it isn't safe: pioarduino's Arduino-core build cache is keyed by board, not by env, so two same-board envs with differing `custom_sdkconfig` content corrupt each other's cached `custom_component_remove` state. Confirmed empirically via bisection — with divergent `custom_sdkconfig` across envs, `esp_insights`/`esp_rainmaker` silently stopped being excluded from an unrelated env's build (`https_server.crt.S not found`), reproducibly, even when the divergent env was never built in that session. Renaming the interpolation key, trimming its content, and removing per-env references one at a time all failed to fix it — only removing the divergence entirely did. This looks like a genuine pioarduino/platform-espressif32 (55.03.37) limitation, not something wrong with the Kconfig content itself.

## The actual fix

Wraps `esp_secure_boot_init_checks()` itself instead (`src/OtaSigningBootGuard.cpp`, via `-Wl,--wrap` in `platformio.ini [base]`, identical across every env — the same technique this project already uses for `panic_abort`/`panic_print_backtrace`/`bootloader_common_check_efuse_blk_validity`). Gated by a `build_flag` that IS safe to vary per env: `OTA_SIGNING_BOOT_CHECK_ENABLED`, defined only for `gh_release`/`gh_release_rc`/`sticky-gh_release`/`sticky-gh_release_rc`.

- Every env keeps a byte-identical `custom_sdkconfig` (avoids the cache bug entirely).
- The underlying signature-verification code (`esp_ota_ops.c`, OTA-install-time) stays compiled in and unchanged for everyone — this does **not** remove OTA signature verification globally.
- Release/RC envs still exercise the real boot-time self-check once a genuine production signature exists.
- Dev/diagnostic envs (`default`, `default_tls_measure`, `sticky`, `sticky_tls_measure`, `slim`) skip only the boot-time self-check — since none of them are ever meant to carry a production signature.

## Verification

- **Hardware**: `default` and `default_tls_measure` both reflashed to the X3 that previously boot-looped — both boot cleanly now (`default_tls_measure` ran its full 3-bundle TLS measurement harness to completion, no crash).
- **Build matrix** (all 8 real-device/release envs, compile-clean): `default`, `sticky`, `default_tls_measure`, `sticky_tls_measure`, `gh_release`, `gh_release_rc`, `sticky-gh_release`, `sticky-gh_release_rc`.
- `pio check` (cppcheck): clean on `default` and `sticky`.
- `./bin/clang-format-fix -g`: clean.
- Host unit tests: 160/160 passed.

## Test plan
- [x] Reflash `default` to the X3 that boot-looped — confirm clean boot (free heap stable, no `abort()`/reboot in serial log)
- [x] Reflash `default_tls_measure` to the same X3 — confirm the harness completes instead of boot-looping
- [x] Compile-check all 8 real-device/release envs
- [x] `pio check`, `clang-format-fix -g`, host unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)