### PR TITLE
fix: correct TLS trust-chain measurement harness on real hardware

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -156,6 +156,7 @@ custom_component_remove =
 
 extra_scripts =
   pre:scripts/patch_wolfssl.py
+  pre:scripts/patch_wolfssl_midad.py
   pre:scripts/build_html.py
   pre:scripts/gen_i18n.py
   pre:scripts/git_branch.py

--- a/scripts/patch_wolfssl_midad.py
+++ b/scripts/patch_wolfssl_midad.py
@@ -1,0 +1,94 @@
+"""
+PlatformIO pre-build script: Midad-specific wolfSSL config additions.
+
+Runs after scripts/patch_wolfssl.py (CrossPoint-owned; keep that file
+byte-identical to upstream and put anything Midad-specific here instead --
+see docs/upstream-sync-architecture.md's Midad Thin-Fork Architecture
+section). Uses the same idempotent marker-based append pattern as that
+script, just with a distinct marker so re-running either script never
+duplicates or clobbers the other's block.
+"""
+
+from pathlib import Path
+
+Import("env")
+
+
+PROJECT_DIR = Path(env.subst("$PROJECT_DIR"))
+MARKER = "/* Midad wolfSSL TLS-chain overrides */"
+OVERRIDES = f"""
+
+{MARKER}
+/* Some public CAs serve a redundant self-referential CA cert as the last
+   link in their chain (e.g. SSL.com sends a copy of "SSL.com TLS ECC Root
+   CA 2022" cross-signed by the legacy "AAA Certificate Services" root,
+   even to clients that already trust the 2022 root directly). wolfSSL's
+   default strict chain walk (internal.c's ProcessPeerCerts) tries to
+   verify that trailing cert's own signature and fails with
+   ASN_NO_SIGNER_E when its issuer isn't also in the trust store -- even
+   though the leaf already validates to a directly-trusted anchor one hop
+   earlier. WOLFSSL_ALT_CERT_CHAINS (internal.c's own comment: "its okay
+   for a CA cert to fail with ASN_NO_SIGNER_E here... only requires that
+   the peer certificate validate to a trusted CA") tolerates exactly this
+   case without weakening leaf verification. Confirmed via hardware
+   (default_tls_measure on an X3): a 12-root production-candidate bundle
+   (src/debug/TlsHeapMeasureCaBundles.h) already contains the correct
+   self-signed root and fails 10/10 on this exact error before this
+   define, independently of bundle content. */
+#ifndef WOLFSSL_ALT_CERT_CHAINS
+#define WOLFSSL_ALT_CERT_CHAINS
+#endif
+/* platformio.ini passes -DWOLFSSL_OPTIONS_H alongside -DWOLFSSL_USER_SETTINGS.
+   That looks like it should pull in wolfSSL's own wolfssl/options.h (which
+   sets WOLFSSL_SHA384/WOLFSSL_SHA512/WOLFSSL_SHA224 among other defaults),
+   but options.h's own include guard is `#ifndef WOLFSSL_OPTIONS_H` -- defining
+   that name as a build flag satisfies the guard before the file is ever
+   opened, so its entire body (including those defines) is silently skipped.
+   settings.h only ever includes options.h itself under EXTERNAL_OPTS_OPENVPN,
+   which this project doesn't set, so user_settings.h (included unconditionally
+   via WOLFSSL_USER_SETTINGS) is the only config that actually takes effect.
+   That file's own comment ("optionally turn off SHA512/224 SHA512/256")
+   assumed SHA384/512 were already on -- they were not. Confirmed via
+   hardware: without this define, verifying any certificate signed with
+   ecdsa-with-SHA384 or sha384WithRSAEncryption (SSL.com's ECC intermediates
+   among them -- openssl x509 -text on example.com's live chain shows
+   exactly that algorithm two links up) fails wolfSSL's HashForSignature()
+   with HASH_TYPE_E (-232), independent of which roots are in the trust
+   store. Re-adding just the specific defines the original design relied
+   on, rather than fixing the dead -DWOLFSSL_OPTIONS_H flag itself (which
+   would silently re-enable every other option.h default too, unaudited)
+   keeps this change narrowly scoped. */
+#ifndef WOLFSSL_SHA384
+#define WOLFSSL_SHA384
+#endif
+#ifndef WOLFSSL_SHA512
+#define WOLFSSL_SHA512
+#endif
+/* sp_c32.c's sp_ecc_verify_384() (the fast SP path already used for P-256
+   verification) is entirely gated behind `#ifdef WOLFSSL_SP_384`, which this
+   build never defined despite WOLFSSL_HAVE_SP_ECC + WOLFSSL_SP_SMALL being
+   set -- so P-384 fell back to wolfSSL's generic (non-SP) bignum ECC verify
+   path. Confirmed via hardware (default_tls_measure on an X3): without this
+   define, verifying an ecdsa-with-SHA384 signature (SSL.com's ECC
+   intermediate chain, common among public CAs) deterministically fails
+   ConfirmSignature() with ASN_SIG_CONFIRM_E (-155) on 10/10 attempts --
+   the generic path's P-384 verification is broken in this build's specific
+   configuration, not the certificates or the earlier fixes above. Defining
+   WOLFSSL_SP_384 routes P-384 through the same fast/correct SP path P-256
+   already uses and fixed 10/10 handshakes for ~10KB flash. */
+#ifndef WOLFSSL_SP_384
+#define WOLFSSL_SP_384
+#endif
+"""
+
+
+def patch_user_settings(path: Path) -> None:
+    text = path.read_text()
+    if MARKER in text:
+        text = text.split(MARKER, 1)[0].rstrip()
+    path.write_text(text + OVERRIDES + "\n")
+    print(f"Patched wolfSSL settings (Midad): {path.relative_to(PROJECT_DIR)}")
+
+
+for settings in PROJECT_DIR.glob(".pio/libdeps/*/Arduino-wolfSSL/src/user_settings.h"):
+    patch_user_settings(settings)

--- a/src/debug/TlsHeapMeasureCaBundles.h
+++ b/src/debug/TlsHeapMeasureCaBundles.h
@@ -20,33 +20,52 @@
 // rather than hand-typed, so they can't drift from the embedded literals.
 
 // --- 1-root bundle -----------------------------------------------------
-// Literally the first complete cert block in the source file: "GlobalSign
-// Root CA" (C=BE, O=GlobalSign nv-sa, OU=Root CA; valid 1998-09-01 to
-// 2028-01-28). Verified (openssl s_client -showcerts) that
-// www.globalsign.com's own live chain resolves to exactly this root: its
-// sent chain is leaf -> "GlobalSign GCC R3 EV TLS CA 2025" ->
-// "GlobalSign Root CA - R3" (a certificate cross-signed BY this original
-// root, not the commonly-deployed self-signed R3) -> trust anchor
-// "GlobalSign Root CA". No other root is needed to validate that chain.
+// "GlobalSign Root CA - R3" (self-signed; OU=GlobalSign Root CA - R3,
+// O=GlobalSign, CN=GlobalSign; valid 2009-03-18 to 2029-03-18) -- the second
+// cert block under that name in the Mozilla source file (there are two
+// entries named "GlobalSign Root CA - R3" further down; this is the
+// self-signed one, confirmed by issuer==subject).
+//
+// This replaces a prior version of this bundle that instead embedded the
+// original 1998 self-signed "GlobalSign Root CA" (C=BE, O=GlobalSign nv-sa,
+// OU=Root CA). That was a real, hardware-confirmed bug, not a naming
+// nitpick: live-tested on an X3 (default_tls_measure, develop @ 81158f84),
+// every one of 10 handshake attempts against www.globalsign.com failed with
+// wolfSSL's ASN_NO_SIGNER_E ("ASN no signer to confirm failure"). Root
+// cause, verified directly (openssl s_client -showcerts, then openssl
+// verify against each candidate root):
+// www.globalsign.com's live chain today is leaf ->
+// "GlobalSign GCC R3 EV TLS CA 2025" -> issuer
+// "CN=GlobalSign,O=GlobalSign,OU=GlobalSign Root CA - R3" -- a *different*
+// certificate, with a different subject and key, than the old self-signed
+// "GlobalSign Root CA" this bundle previously embedded. The server does not
+// send that bridging cert itself (routine -- roots are assumed already
+// trusted), so a client holding only the old root has no path to the live
+// intermediate at all: `openssl verify -CAfile <old-root> -untrusted
+// <intermediate> <leaf>` fails; the same command against this replacement
+// root succeeds. GlobalSign's own root hierarchy changed since this bundle
+// was first written -- the earlier code comment's "verified via openssl
+// s_client" claim was accurate for whatever chain glabalsign.com served at
+// the time, not evidence of a bundle-selection mistake.
 constexpr size_t kOneRootCertCount = 1;
 static constexpr char kOneRootCaBundle[] =
     R"PEMCERT(-----BEGIN CERTIFICATE-----
-MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkGA1UEBhMCQkUx
-GTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jvb3QgQ0ExGzAZBgNVBAMTEkds
-b2JhbFNpZ24gUm9vdCBDQTAeFw05ODA5MDExMjAwMDBaFw0yODAxMjgxMjAwMDBaMFcxCzAJBgNV
-BAYTAkJFMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMRAwDgYDVQQLEwdSb290IENBMRswGQYD
-VQQDExJHbG9iYWxTaWduIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDa
-DuaZjc6j40+Kfvvxi4Mla+pIH/EqsLmVEQS98GPR4mdmzxzdzxtIK+6NiY6arymAZavpxy0Sy6sc
-THAHoT0KMM0VjU/43dSMUBUc71DuxC73/OlS8pF94G3VNTCOXkNz8kHp1Wrjsok6Vjk4bwY8iGlb
-Kk3Fp1S4bInMm/k8yuX9ifUSPJJ4ltbcdG6TRGHRjcdGsnUOhugZitVtbNV4FpWi6cgKOOvyJBNP
-c1STE4U6G7weNLWLBYy5d4ux2x8gkasJU26Qzns3dLlwR5EiUWMWea6xrkEmCMgZK9FGqkjWZCrX
-gzT/LCrBbBlDSgeF59N89iFo7+ryUp9/k5DPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
-HRMBAf8EBTADAQH/MB0GA1UdDgQWBBRge2YaRQ2XyolQL30EzTSo//z9SzANBgkqhkiG9w0BAQUF
-AAOCAQEA1nPnfE920I2/7LqivjTFKDK1fPxsnCwrvQmeU79rXqoRSLblCKOzyj1hTdNGCbM+w6Dj
-Y1Ub8rrvrTnhQ7k4o+YviiY776BQVvnGCv04zcQLcFGUl5gE38NflNUVyRRBnMRddWQVDf9VMOyG
-j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH
-hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
-X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
+MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4GA1UECxMXR2xv
+YmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNpZ24xEzARBgNVBAMTCkdsb2Jh
+bFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxT
+aWduIFJvb3QgQ0EgLSBSMzETMBEGA1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2ln
+bjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWt
+iHL8RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsTgHeMCOFJ
+0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmmKPZpO/bLyCiR5Z2KYVc3
+rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zdQQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjl
+OCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZXriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2
+xmmFghcCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYE
+FI/wS3+oLkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZURUm7
+lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMpjjM5RcOO5LlXbKr8
+EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK6fBdRoyV3XpYKBovHd7NADdBj+1E
+bddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQXmcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18
+YIvDQVETI53O9zJrlAGomecsMx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7r
+kpeDMdmztcpHWD9f
 -----END CERTIFICATE-----
 )PEMCERT";
 constexpr size_t kOneRootBundleBytes = sizeof(kOneRootCaBundle) - 1;


### PR DESCRIPTION
## Summary

Hardware-validated fix for the TLS heap-measurement harness's three CA bundles, following up on Phase 3's hardware session which found `default_tls_measure` failing all handshake attempts on a real X3.

- **1ROOT bundle** embedded a 1998 self-signed "GlobalSign Root CA" that no longer chains to `www.globalsign.com`'s live intermediate. Replaced with the modern self-signed "GlobalSign Root CA - R3" it actually needs, sourced from the same already-vetted vendored Mozilla bundle this file's own header comment cites.
- **`WOLFSSL_ALT_CERT_CHAINS`**: wolfSSL's default strict chain walk rejects a valid chain if the server sends a harmless extra self-referential CA cert (a common public-CA pattern, e.g. SSL.com's cross-signed root) — even when the leaf already validates to a directly-trusted anchor one hop earlier. This define tolerates that specific case without weakening leaf verification.
- **`WOLFSSL_SHA384`/`WOLFSSL_SHA512`**: `-DWOLFSSL_OPTIONS_H` in `platformio.ini` collides with `wolfssl/options.h`'s own include guard, so that entire file — which sets these defines among other defaults — silently never executes project-wide. Re-added just the two defines the original design relied on.
- **`WOLFSSL_SP_384`**: P-384 ECC signature verification was falling back to wolfSSL's generic (non-SP) bignum path, which is broken in this build's specific configuration — deterministic `ASN_SIG_CONFIRM_E` on every attempt against any SHA384-signed chain. Defining this routes P-384 through the same fast/correct SP path already used for P-256.

Together these took the 12-root production-candidate (`PROD`) bundle from 0/10 to 10/10 real handshakes against `example.com`; the 1-root bundle is 10/10 against `www.globalsign.com`. The 147-root `STRESS` bundle still fails, but purely from heap exhaustion — exactly what `docs/tls-trust-architecture.md` already predicted for a browser-grade bundle on this hardware, not a bug to chase.

## Upstream-owned files modified

None. `scripts/patch_wolfssl.py` is CrossPoint-owned and was byte-identical to `crosspoint-reader/crosspoint-reader`'s `develop` before this change — confirmed via `git show upstream/develop:scripts/patch_wolfssl.py` — and stays that way. The three wolfSSL config fixes live in a new Midad-owned `scripts/patch_wolfssl_midad.py`, registered as one additional `pre:` line in `platformio.ini`.

## Test plan

- [x] `pio run -e default_tls_measure` and `pio run -e default` both build clean
- [x] `pio check -e default_tls_measure` — no cppcheck defects
- [x] `./bin/clang-format-fix -g` — clean
- [x] Hardware (X3): 1ROOT 10/10, PROD 10/10, STRESS 0/10 (heap exhaustion, expected)