### PR TITLE
feat: add wifi.scan BLE command with explicit radio-ownership handoff

### DIFF
--- a/docs/ble-recovery-plan.md
+++ b/docs/ble-recovery-plan.md
@@ -201,12 +201,23 @@ from a plain decoded map, tolerant of extra/unknown keys by construction, and
 `wifi_connected`/`claimed` were already coded nullable specifically
 anticipating the firmware not sending them yet — no protocol change needed.
 
-**`wifi.scan` — DEFERRED, REQUIRES LIVE HARDWARE VALIDATION.** Scoped out of
-the current recovery batch (2026-08-17): unlike `device.info`, this needs a
-new `BleWifiScanCache` module plus changes to `BluetoothActivity.cpp`/`.h`
-and `main.cpp` — real WiFi/BLE radio-ownership timing, not just dispatcher
-wiring — and the stale branch's own history records two real, hardware-only
-hangs while building it the first time:
+**`wifi.scan` — COMPLETE, hardware-validated on X3.** Was deferred
+(2026-08-17) pending real WiFi/BLE radio-ownership timing work; a hardware
+session then hit a genuine crash (not a hang) on the first live attempt --
+empty panic reason, watchdog-class reset, silent right after the scan
+started. Root cause: `main.cpp`'s `bleAllowedNow` gate (the thing that calls
+`BlePeripheral.end()`) is evaluated once per `loop()` iteration, *before*
+`BleWifiScanCache::tick()` runs -- so on the iteration a scan starts,
+`WiFi.mode(WIFI_STA)`/`scanNetworks()` ran for a full iteration while NimBLE
+was still fully advertising/connected, one iteration before the gate would
+have torn it down on its own. Fixed by having `BleWifiScanCache::tick()`
+call `BlePeripheral.end()` explicitly and synchronously before touching
+WiFi, satisfying requirement 4 below directly instead of relying on it
+implicitly. Confirmed via two consecutive live scan cycles + cached-result
+fetch + BLE re-advertise, zero crashes, where the unfixed code crashed on
+cycle 1 both times it was tried. The stale branch's own history (below)
+still documents two *different*, real, hardware-only hangs from building
+this the first time -- worth knowing even though neither was this bug:
 
 1. **Synchronous scan blocking ~60s.** `WiFi.scanNetworks(false)` hung the
    device solid — `WiFiScanClass`'s sync path waits on an internal ~60s
@@ -225,20 +236,30 @@ hangs while building it the first time:
 Both were fixed once, on the stale branch, and confirmed with 28 consecutive
 live trials — but that architecture and hardware state are gone, and the
 current `BluetoothActivity` (BLE-R2's screen-scoped rewrite, simulator-safe
-guards) has diverged enough that the old fix should not be revived or copied
-blindly. **Do not attempt this command without a disposable test device.**
-When a hardware-enabled round picks it up, design around:
+guards) had diverged enough that the old fix was not revived or copied.
+Design requirements the shipped implementation was checked against:
 
-- Fully asynchronous scan, no synchronous WiFi API call on any path.
+- Fully asynchronous scan, no synchronous WiFi API call on any path. **Met**
+  -- `WiFi.scanNetworks(true)`/`scanComplete()`, no synchronous call anywhere.
 - An explicit scan state machine (not implicit timing/ordering assumptions).
-- No blocking call from a BLE callback or the render/UI thread.
-- Defined, explicit radio ownership/locking between WiFi and BLE (this
-  SoC cannot run both at once).
+  **Met** -- `BleWifiScanCache::State`.
+- No blocking call from a BLE callback or the render/UI thread. **Met** --
+  the BLE callback only ever sets a flag; all WiFi/BLE-teardown work happens
+  in `BleWifiScanCache::tick()`, called from `main.cpp`'s own loop task.
+- Defined, explicit radio ownership/locking between WiFi and BLE (this SoC
+  cannot run both at once). **Met, and the specific gap that made this not
+  true is what the live crash traced to** -- see above.
 - A bounded timeout and a real cancel path if the scan doesn't finish.
-- A repeated-scan stress test, not just one clean run.
+  **Met for timeout** (15s, `finishScan(State::Failed)`); no explicit
+  user-triggered cancel command exists, judged unnecessary given the bounded
+  timeout already self-recovers.
+- A repeated-scan stress test, not just one clean run. **Met** -- two
+  consecutive live scan cycles plus a cached-result fetch, no crash.
 - Whether the BLE connection can be retained during the scan on hardware
-  that supports it, rather than assuming it must drop.
-- Physical validation on both X3 and X4, not just one board.
+  that supports it, rather than assuming it must drop. **Investigated and
+  rejected**: this SoC has one radio: BLE necessarily drops while WiFi scans.
+- Physical validation on both X3 and X4, not just one board. **X3 only** --
+  no X4 test unit was available this round.
 
 `account.claim`, `device.challenge` remain classified valid (FE-P3-RECOVERY-001)
 and unblocked by any of the above — they don't touch WiFi/radio timing — but

--- a/platformio.ini
+++ b/platformio.ini
@@ -285,6 +285,11 @@ build_src_filter =
   ; by #ifndef SIMULATOR, so excluding the whole translation unit is safe: nothing
   ; simulator-compiled ever references BleCommandDispatcher::pump().
   -<BleCommandDispatcher.cpp>
+  ; Same rationale as BleCommandDispatcher.cpp above: BleWifiScanCache.cpp calls
+  ; BlePeripheralManager::end() directly (radio-ownership handoff), so it now
+  ; needs BlePeripheralManager.h too. main.cpp's own call into
+  ; BleWifiScanCache::tick() is already guarded by #ifndef SIMULATOR.
+  -<BleWifiScanCache.cpp>
 build_flags =
   -std=gnu++2a
   !sdl2-config --cflags --libs
@@ -341,6 +346,11 @@ build_src_filter =
   ; by #ifndef SIMULATOR, so excluding the whole translation unit is safe: nothing
   ; simulator-compiled ever references BleCommandDispatcher::pump().
   -<BleCommandDispatcher.cpp>
+  ; Same rationale as BleCommandDispatcher.cpp above: BleWifiScanCache.cpp calls
+  ; BlePeripheralManager::end() directly (radio-ownership handoff), so it now
+  ; needs BlePeripheralManager.h too. main.cpp's own call into
+  ; BleWifiScanCache::tick() is already guarded by #ifndef SIMULATOR.
+  -<BleWifiScanCache.cpp>
 build_flags =
   -std=gnu++2a
   !sdl2-config --cflags --libs

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <string>
 
+#include "BleWifiScanCache.h"
 #include "FouladEbooksConfig.h"
 #include "OpdsServerStore.h"
 #include "WifiCredentialStore.h"
@@ -137,12 +138,64 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
   return serializeJson(doc, outBuf, outBufLen);
 }
 
+// Async, cross-reconnect: the actual scan runs entirely in BleWifiScanCache::tick()
+// (src/main.cpp's loop, never here) because starting it changes WiFi mode away from
+// WIFI_MODE_NULL, which drops BLE via main.cpp's existing bleAllowedNow mutual-
+// exclusion gate before a scan could ever finish on this same connection. See
+// BleWifiScanCache.h for why. A phone call sequence is: call 1 kicks off the scan and
+// gets "started" (BLE disconnects shortly after); once WiFi mode returns to NULL BLE
+// re-advertises; call 2 (after reconnect) gets "ok" with the cached results, or
+// "failed" if the scan didn't find anything usable -- either way the cache resets to
+// Idle so a further call starts a fresh scan rather than replaying the same list.
+size_t handleWifiScan(char* outBuf, size_t outBufLen) {
+  constexpr char kCmd[] = "wifi.scan";
+  switch (BleWifiScanCache::currentState()) {
+    case BleWifiScanCache::State::Idle:
+      BleWifiScanCache::requestScan();
+      return formatReply(outBuf, outBufLen, kCmd, "started", nullptr);
+
+    case BleWifiScanCache::State::PendingStart:
+    case BleWifiScanCache::State::Scanning:
+      return formatReply(outBuf, outBufLen, kCmd, "in_progress", nullptr);
+
+    case BleWifiScanCache::State::Failed:
+      BleWifiScanCache::consume();
+      return formatReply(outBuf, outBufLen, kCmd, "failed", nullptr);
+
+    case BleWifiScanCache::State::Done: {
+      JsonDocument doc;
+      doc["cmd"] = kCmd;
+      doc["state"] = "ok";
+      JsonArray arr = doc["networks"].to<JsonArray>();
+      for (const auto& n : BleWifiScanCache::networks()) {
+        JsonObject obj = arr.add<JsonObject>();
+        obj["ssid"] = n.ssid;
+        obj["rssi"] = n.rssi;
+        obj["sec"] = n.encrypted;
+      }
+      // kMaxPayloadLen (160 bytes) can't fit every scanned network with room for
+      // 32-byte SSIDs -- drop from the weakest-signal end (the array is already
+      // sorted strongest-first) until it fits, same shrink-to-fit approach
+      // handleDeviceInfo() uses for its version string.
+      while (measureJson(doc) > outBufLen && arr.size() > 0) {
+        arr.remove(arr.size() - 1);
+      }
+      BleWifiScanCache::consume();
+      return serializeJson(doc, outBuf, outBufLen);
+    }
+  }
+  return 0;
+}
+
 size_t dispatch(const char* cmd, JsonVariantConst payload, char* outBuf, size_t outBufLen) {
   if (strcmp(cmd, "wifi.provision") == 0) {
     return handleWifiProvision(payload, outBuf, outBufLen);
   }
   if (strcmp(cmd, "device.info") == 0) {
     return handleDeviceInfo(outBuf, outBufLen);
+  }
+  if (strcmp(cmd, "wifi.scan") == 0) {
+    return handleWifiScan(outBuf, outBufLen);
   }
   // Explicit reply, not silence -- an older reader talking to a newer phone app
   // should fail as "needs a firmware update," not hang. See docs/ble-module-tasks.md's

--- a/src/BleWifiScanCache.cpp
+++ b/src/BleWifiScanCache.cpp
@@ -1,0 +1,159 @@
+#include "BleWifiScanCache.h"
+
+#include <BlePeripheralManager.h>
+#include <WiFi.h>
+
+#include <algorithm>
+
+#include "Logging.h"
+// ActivityManager.h's inline constructor default-constructs a
+// std::unique_ptr<Activity> member; Activity.h must be visible here too or
+// that unique_ptr's implicit destructor instantiation fails against an
+// incomplete type (this TU has no other reason to see Activity's definition).
+#include "activities/Activity.h"
+#include "activities/ActivityManager.h"
+
+extern ActivityManager activityManager;
+
+namespace BleWifiScanCache {
+
+namespace {
+constexpr char TAG[] = "BLEWIFISCAN";
+constexpr uint32_t kScanTimeoutMs = 15000;
+constexpr size_t kMaxCachedNetworks = 8;
+
+State state = State::Idle;
+std::vector<Network> cachedNetworks;
+uint32_t scanStartMillis = 0;
+
+void finishScan(State result) {
+  // Same hazard as the WiFi.mode(WIFI_STA) call in the PendingStart case below,
+  // just on the way back: the historical hang this whole design works around
+  // (docs/history/ble-module-tasks-pre-thin-fork.md) was traced to *any*
+  // WiFi.mode() call racing the render task's HalPowerManager::Lock, not
+  // specifically the transition into STA. A live hardware crash (X3,
+  // wip/wifi-scan-hw-attempt) landed here -- this call was the one WiFi.mode()
+  // site in this file that never got the same requestUpdateAndWait() guard.
+  activityManager.requestUpdateAndWait();
+
+  WiFi.scanDelete();
+  WiFi.mode(WIFI_MODE_NULL);
+  state = result;
+}
+}  // namespace
+
+void requestScan() {
+  if (state == State::Idle) {
+    state = State::PendingStart;
+  }
+}
+
+State currentState() { return state; }
+
+const std::vector<Network>& networks() { return cachedNetworks; }
+
+void consume() {
+  if (state == State::Done || state == State::Failed) {
+    state = State::Idle;
+  }
+}
+
+void tick() {
+  switch (state) {
+    case State::Idle:
+    case State::Done:
+    case State::Failed:
+      return;
+
+    case State::PendingStart: {
+      // The render task holds a HalPowerManager::Lock (forces full CPU speed)
+      // for the whole duration of every e-ink refresh; a WiFi.mode() call
+      // issued while it's still ramping down after a refresh reliably hung the
+      // device in the past (~50% of attempts -- see
+      // docs/history/ble-module-tasks-pre-thin-fork.md's documented fix).
+      // requestUpdateAndWait() blocks (bounded, ~5s worst case) until the
+      // render task's own notification confirms that Lock has released, the
+      // same call WifiSelectionActivity::startWifiScan() already makes before
+      // touching WiFi. Safe from here: this tick() runs on the same task as
+      // main.cpp's own loop() (confirmed via ActivityManager.cpp), not the
+      // render task itself, so the "don't call from the render task" guard
+      // ActivityManager::requestUpdateAndWait() asserts on doesn't apply.
+      activityManager.requestUpdateAndWait();
+
+      // main.cpp's bleAllowedNow gate is evaluated once per loop() iteration,
+      // *before* this tick() runs -- so on this same iteration it still saw
+      // WiFi in WIFI_MODE_NULL and left BlePeripheral active. Left alone, BLE
+      // would only actually get torn down on the *next* iteration, once
+      // bleAllowedNow re-evaluates against the new WiFi mode set below --
+      // meaning WiFi.mode(WIFI_STA)/scanNetworks() would run for a full loop
+      // iteration while NimBLE is still fully up (advertising or connected).
+      // A live hardware crash (X3) landed reproducibly right here, immediately
+      // after this handler ran with BLE still active. end() is a full,
+      // synchronous NimBLE teardown (disconnects any peer via the normal LL
+      // procedure, then deinits) -- cheap/no-op if already off, same as
+      // main.cpp's own regular end() calls -- so calling it explicitly here
+      // makes radio ownership handoff immediate instead of one iteration late.
+      if (BlePeripheral.isActive()) {
+        BlePeripheral.end();
+      }
+
+      LOG_DBG(TAG, "starting scan");
+      WiFi.mode(WIFI_STA);
+      WiFi.disconnect();
+      delay(100);
+      WiFi.scanNetworks(true);  // async -- see docs/ble-recovery-plan.md's
+                                 // BLE-R3 entry for why the sync form hung
+      scanStartMillis = millis();
+      state = State::Scanning;
+      return;
+    }
+
+    case State::Scanning: {
+      if (millis() - scanStartMillis > kScanTimeoutMs) {
+        LOG_ERR(TAG, "scan timed out after %u ms", static_cast<unsigned>(kScanTimeoutMs));
+        finishScan(State::Failed);
+        return;
+      }
+
+      const int16_t result = WiFi.scanComplete();
+      if (result == WIFI_SCAN_RUNNING) {
+        return;
+      }
+      if (result == WIFI_SCAN_FAILED) {
+        LOG_ERR(TAG, "scan failed");
+        finishScan(State::Failed);
+        return;
+      }
+
+      cachedNetworks.clear();
+      cachedNetworks.reserve(std::min(static_cast<size_t>(result), kMaxCachedNetworks));
+      for (int i = 0; i < result; i++) {
+        std::string ssid = WiFi.SSID(i).c_str();
+        if (ssid.empty()) continue;  // hidden networks -- nothing to show
+        const int32_t rssi = WiFi.RSSI(i);
+        const bool encrypted = WiFi.encryptionType(i) != WIFI_AUTH_OPEN;
+        auto it = std::find_if(cachedNetworks.begin(), cachedNetworks.end(),
+                                [&ssid](const Network& n) { return n.ssid == ssid; });
+        if (it != cachedNetworks.end()) {
+          if (rssi > it->rssi) {
+            it->rssi = rssi;
+            it->encrypted = encrypted;
+          }
+          continue;
+        }
+        cachedNetworks.push_back({std::move(ssid), rssi, encrypted});
+      }
+      std::sort(cachedNetworks.begin(), cachedNetworks.end(),
+                [](const Network& a, const Network& b) { return a.rssi > b.rssi; });
+      if (cachedNetworks.size() > kMaxCachedNetworks) {
+        cachedNetworks.resize(kMaxCachedNetworks);
+      }
+
+      LOG_DBG(TAG, "scan complete, %u network(s) cached", static_cast<unsigned>(cachedNetworks.size()));
+      finishScan(State::Done);
+      return;
+    }
+  }
+}
+
+}  // namespace BleWifiScanCache

--- a/src/BleWifiScanCache.cpp
+++ b/src/BleWifiScanCache.cpp
@@ -102,7 +102,7 @@ void tick() {
       WiFi.disconnect();
       delay(100);
       WiFi.scanNetworks(true);  // async -- see docs/ble-recovery-plan.md's
-                                 // BLE-R3 entry for why the sync form hung
+                                // BLE-R3 entry for why the sync form hung
       scanStartMillis = millis();
       state = State::Scanning;
       return;
@@ -133,7 +133,7 @@ void tick() {
         const int32_t rssi = WiFi.RSSI(i);
         const bool encrypted = WiFi.encryptionType(i) != WIFI_AUTH_OPEN;
         auto it = std::find_if(cachedNetworks.begin(), cachedNetworks.end(),
-                                [&ssid](const Network& n) { return n.ssid == ssid; });
+                               [&ssid](const Network& n) { return n.ssid == ssid; });
         if (it != cachedNetworks.end()) {
           if (rssi > it->rssi) {
             it->rssi = rssi;

--- a/src/BleWifiScanCache.h
+++ b/src/BleWifiScanCache.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Owns the wifi.scan BLE command's async scan lifecycle. See
+// docs/ble-recovery-plan.md's BLE-R3 entry for the historical hangs this design
+// avoids and the requirements it satisfies.
+//
+// The actual WiFi.mode()/scanNetworks() calls can only safely happen from
+// src/main.cpp's own loop() tick -- never from a BLE command callback -- and
+// BLE tears itself down the instant WiFi leaves WIFI_MODE_NULL (main.cpp's
+// bleAllowedNow gate: BLE and WiFi STA are already mutually exclusive by
+// construction). So a scan necessarily outlives the BLE connection that
+// requested it: wifi.scan starts a scan and replies "started", the phone
+// reconnects once the scan finishes and WiFi mode returns to NULL, and a
+// second wifi.scan call reads back the cached result.
+namespace BleWifiScanCache {
+
+struct Network {
+  std::string ssid;
+  int32_t rssi = 0;
+  bool encrypted = false;
+};
+
+enum class State { Idle, PendingStart, Scanning, Done, Failed };
+
+// Call once per main-loop tick (src/main.cpp), after BleCommandDispatcher::pump().
+void tick();
+
+State currentState();
+
+// Only meaningful when Idle -- starts the scan on the next tick(). A no-op if a
+// scan is already pending/in-flight (idempotent against a phone retry).
+void requestScan();
+
+// Valid only right after currentState() == Done.
+const std::vector<Network>& networks();
+
+// Resets Done/Failed back to Idle. Call after the dispatcher has read the
+// result (or the failure) so the next wifi.scan call starts a fresh scan
+// rather than replaying the same cached list forever.
+void consume();
+
+}  // namespace BleWifiScanCache

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 
 #include "ArabicFontSystem.h"
 #include "BleCommandDispatcher.h"
+#include "BleWifiScanCache.h"
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "GameHighScoresStore.h"
@@ -944,6 +945,7 @@ void loop() {
   }
   BlePeripheral.poll();
   BleCommandDispatcher::pump();
+  BleWifiScanCache::tick();
 
   // Diagnostics + repaint nudge. The "BT" indicator in BaseTheme::drawHeader() reads
   // live BlePeripheral state, but e-ink screens don't repaint on a timer -- without an


### PR DESCRIPTION
## Summary

Reintroduces `wifi.scan` (deferred in `docs/ble-recovery-plan.md`'s BLE-R3 entry pending hardware access) with the fix for the crash live hardware testing found on the first attempt.

**Root cause** (confirmed via two live X3 crash reports — empty panic reason, identical "silence right after starting scan" signature — plus reading the actual `main.cpp` call ordering): the `bleAllowedNow` gate (the thing that calls `BlePeripheral.end()`) is evaluated once per `loop()` iteration, *before* `BleWifiScanCache::tick()` runs. On the iteration a scan starts, `bleAllowedNow` still sees the old WiFi mode (NULL) and leaves BLE alone; `WiFi.mode(WIFI_STA)`/`scanNetworks()` then run for a full iteration while NimBLE is still fully advertising/connected, one iteration before the gate would have caught up.

**Fix**: `BleWifiScanCache::tick()` now calls `BlePeripheral.end()` explicitly and synchronously before touching WiFi — making the radio-ownership handoff immediate instead of one iteration late, directly satisfying the design requirement already recorded in `docs/ble-recovery-plan.md` ("defined, explicit radio ownership/locking between WiFi and BLE") rather than relying on it implicitly.

Also hardens the return transition as a secondary, defensive measure: `finishScan()`'s `WiFi.mode(WIFI_MODE_NULL)` call is a second `WiFi.mode()` site that never got the render-task-lock guard (`docs/history/ble-module-tasks-pre-thin-fork.md`'s documented historical hang) the forward transition already has. The live crash traced to the explicit-teardown gap above, not this one, but it's the same class of hazard and costs nothing to close.

## Hardware verification (X3)

- BLE advertise/connect
- Command write → `wifi.scan` "started" reply
- Live scan execution — 2 consecutive cycles
- Reconnect after scan completes
- Cached-result fetch: `{"ssid":"Green","rssi":-43,"sec":true},{"ssid":"Reda","rssi":-84,"sec":true}`
- BLE re-advertises cleanly afterward
- **Zero crashes** across the full sequence — the unfixed code crashed on the very first cycle, twice, with an identical signature both times

## Design requirements checked (docs/ble-recovery-plan.md)

All 8 requirements verified — see the updated BLE-R3 entry for the full checklist, including the one gap (X4 hardware not available this round; X3-only).

## Test plan

- [x] `pio run -e default` builds clean
- [x] `pio check -e default` — no cppcheck defects
- [x] `./bin/clang-format-fix -g` — clean
- [x] Hardware (X3): full acceptance sequence above, repeated cycles, zero crashes