### PR TITLE
feat: BLE pairing fix, device.challenge/wifi.autoconnect (account.claim deferred)

### DIFF
--- a/lib/hal/BlePeripheralManager.cpp
+++ b/lib/hal/BlePeripheralManager.cpp
@@ -69,23 +69,67 @@ void publishStatus() {
   g_statusChar->notify();
 }
 
+// FE-P3-RC-BLE-PAIRING-001 diagnostic instrumentation: logs the full SMP/GAP security
+// path NimBLEServerCallbacks exposes, to see what the pairing procedure actually does
+// on the peripheral side rather than inferring it from a central-side ATT timeout.
+// Read-only logging only -- no behavior changes. The passkey/confirm hooks below
+// shouldn't ever fire with mitm=false (Just Works needs none of them); logging their
+// invocation is itself diagnostic signal if they do. Each still calls through to the
+// exact NimBLEServerCallbacks base-class default so behavior is unchanged either way.
 class ServerCallbacks : public NimBLEServerCallbacks {
-  void onConnect(NimBLEServer* /*pServer*/, NimBLEConnInfo& /*connInfo*/) override {
-    LOG_DBG(TAG, "central connected");
+  void onConnect(NimBLEServer* /*pServer*/, NimBLEConnInfo& connInfo) override {
+    LOG_DBG(TAG, "central connected: addr=%s connHandle=%u bondsBefore=%d", connInfo.getAddress().toString().c_str(),
+            connInfo.getConnHandle(), NimBLEDevice::getNumBonds());
     BlePeripheral.onConnected();
     publishStatus();
   }
-  void onDisconnect(NimBLEServer* /*pServer*/, NimBLEConnInfo& /*connInfo*/, int reason) override {
-    LOG_DBG(TAG, "central disconnected, reason=%d", reason);
+  void onDisconnect(NimBLEServer* /*pServer*/, NimBLEConnInfo& connInfo, int reason) override {
+    LOG_DBG(TAG,
+            "central disconnected, reason=%d: encrypted=%d authenticated=%d bonded=%d "
+            "keySize=%u bondsAfter=%d",
+            reason, connInfo.isEncrypted(), connInfo.isAuthenticated(), connInfo.isBonded(), connInfo.getSecKeySize(),
+            NimBLEDevice::getNumBonds());
     BlePeripheral.onDisconnected();
     publishStatus();
+  }
+  // Fired on BLE_GAP_EVENT_ENC_CHANGE -- the actual pairing/encryption-establishment
+  // outcome, success or failure. NimBLEConnInfo doesn't expose the raw SMP/HCI status
+  // code (not surfaced by this library's public callback API); encrypted/authenticated/
+  // bonded state here is the closest observable proxy for "did it work."
+  void onAuthenticationComplete(NimBLEConnInfo& connInfo) override {
+    // NimBLE's public API doesn't expose a separate "was this SC (vs legacy) pairing"
+    // flag; keySize==16 is a reasonable proxy (SC pairing always negotiates 128-bit
+    // keys) but not a direct signal, so it's omitted here rather than faked.
+    LOG_DBG(TAG,
+            "auth complete: addr=%s connHandle=%u encrypted=%d authenticated=%d bonded=%d "
+            "keySize=%u bondsAfter=%d",
+            connInfo.getAddress().toString().c_str(), connInfo.getConnHandle(), connInfo.isEncrypted(),
+            connInfo.isAuthenticated(), connInfo.isBonded(), connInfo.getSecKeySize(), NimBLEDevice::getNumBonds());
+  }
+  void onIdentity(NimBLEConnInfo& connInfo) override {
+    LOG_DBG(TAG, "peer identity resolved: idAddr=%s connHandle=%u", connInfo.getIdAddress().toString().c_str(),
+            connInfo.getConnHandle());
+    NimBLEServerCallbacks::onIdentity(connInfo);
+  }
+  uint32_t onPassKeyDisplay() override {
+    LOG_DBG(TAG, "onPassKeyDisplay invoked (unexpected with mitm=false)");
+    return NimBLEServerCallbacks::onPassKeyDisplay();
+  }
+  void onPassKeyEntry(NimBLEConnInfo& connInfo) override {
+    LOG_DBG(TAG, "onPassKeyEntry invoked (unexpected with mitm=false)");
+    NimBLEServerCallbacks::onPassKeyEntry(connInfo);
+  }
+  void onConfirmPassKey(NimBLEConnInfo& connInfo, uint32_t pin) override {
+    LOG_DBG(TAG, "onConfirmPassKey invoked (unexpected with mitm=false)");
+    NimBLEServerCallbacks::onConfirmPassKey(connInfo, pin);
   }
 };
 
 class AuthCharCallbacks : public NimBLECharacteristicCallbacks {
-  void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& /*connInfo*/) override {
+  void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) override {
     const NimBLEAttValue value = pCharacteristic->getValue();
-    LOG_DBG(TAG, "auth write, %u bytes", static_cast<unsigned>(value.size()));
+    LOG_DBG(TAG, "auth write, %u bytes: encrypted=%d authenticated=%d bonded=%d", static_cast<unsigned>(value.size()),
+            connInfo.isEncrypted(), connInfo.isAuthenticated(), connInfo.isBonded());
     BlePeripheral.onAuthWritten(value.data(), value.size());
   }
 };
@@ -112,6 +156,38 @@ void BlePeripheralManager::getAdvertisedName(char* outBuf, size_t outBufLen) {
   uint8_t mac[6] = {};
   esp_efuse_mac_get_default(mac);
   snprintf(outBuf, outBufLen, "Midad-%02X%02X%02X", mac[3], mac[4], mac[5]);
+}
+
+int BlePeripheralManager::getBondCount() {
+  // NimBLEDevice::init() sets up the underlying NimBLE host task and its port-layer
+  // mutexes (including the ones the NVS-backed bond store depends on) -- before that's
+  // ever run this boot (fresh boot, BluetoothActivity never entered yet),
+  // getNumBonds()'s call chain dereferences a mutex handle that doesn't exist yet and
+  // crashes (confirmed on hardware: "assert failed: npl_freertos_mutex_pend ...
+  // (mu->handle)"). end() calls deinit(true), which clears m_initialized right back to
+  // false, so this same guard also covers "BLE was on, user left the screen" -- not
+  // just "never started this boot." Correct outcome either way: no bond count is
+  // meaningfully available when the host stack isn't currently running.
+  if (!NimBLEDevice::isInitialized()) return 0;
+  return NimBLEDevice::getNumBonds();
+}
+
+bool BlePeripheralManager::clearAllBonds() {
+  if (!NimBLEDevice::isInitialized()) return false;
+
+  // ble_gap_unpair() (what deleteAllBonds() calls per-bond) refuses to remove a bond
+  // that distributed an IRK while advertising is active -- BLE_HS_EBUSY, since it can't
+  // safely drop the peer from the controller's resolving list mid-advertisement. Any
+  // bond formed under this device's old mitm=true config did distribute an IRK, so
+  // clearing needs advertising paused for the duration.
+  NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();
+  const bool wasAdvertising = advertising != nullptr && advertising->isAdvertising();
+  if (wasAdvertising) advertising->stop();
+
+  const bool cleared = NimBLEDevice::deleteAllBonds();
+
+  if (wasAdvertising) advertising->start();
+  return cleared;
 }
 
 bool BlePeripheralManager::begin() {
@@ -204,7 +280,14 @@ bool BlePeripheralManager::begin() {
 
   service->start();
 
-  NimBLEDevice::setSecurityAuth(/*bonding=*/true, /*mitm=*/true, /*sc=*/true);
+  // mitm=false: this hardware has no display/keyboard (BLE_HS_IO_NO_INPUT_OUTPUT), so
+  // it cannot perform passkey entry or numeric comparison. Requesting mitm=true with
+  // NoInputNoOutput is unsatisfiable per the BLE spec's pairing method selection --
+  // confirmed on real hardware to leave the Auth characteristic's encrypted write
+  // hanging until the central times out ("Encryption is insufficient"). bonding and sc
+  // stay on: the link is still encrypted (LE Secure Connections) and bonded, just via
+  // unauthenticated Just Works, which is standard for headless IoT peripherals.
+  NimBLEDevice::setSecurityAuth(/*bonding=*/true, /*mitm=*/false, /*sc=*/true);
   NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
 
   NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();

--- a/lib/hal/BlePeripheralManager.h
+++ b/lib/hal/BlePeripheralManager.h
@@ -90,6 +90,17 @@ class BlePeripheralManager {
   // getHwKey() for the identical reason.
   static void getAdvertisedName(char* outBuf, size_t outBufLen);
 
+  // Number of bonds NimBLE currently has persisted in NVS -- debug/status tooling
+  // only (see BLE_STATUS in src/main.cpp). Safe to call whether or not NimBLE is
+  // currently initialized.
+  static int getBondCount();
+  // Erases every persisted bond, forcing the next pairing attempt on any peer to
+  // start from a clean security state -- debug tooling only (see BLE_CLEAR_BONDS in
+  // src/main.cpp), for exercising the "forget device, re-pair from scratch" path
+  // without needing OS-level UI on the central side. Returns false if NimBLE isn't
+  // initialized.
+  static bool clearAllBonds();
+
   // Starts advertising if the heap gate and cool-down both allow it. Returns false
   // (and logs why) otherwise -- the caller must not retry in a tight loop; back off and
   // let the caller's own poll cadence try again later. Safe to call when already

--- a/platformio.ini
+++ b/platformio.ini
@@ -290,6 +290,10 @@ build_src_filter =
   ; needs BlePeripheralManager.h too. main.cpp's own call into
   ; BleWifiScanCache::tick() is already guarded by #ifndef SIMULATOR.
   -<BleWifiScanCache.cpp>
+  ; Same rationale, same shape as BleWifiScanCache.cpp above -- BleWifiAutoConnectCache.cpp
+  ; also calls BlePeripheralManager::end() directly. main.cpp's own call into
+  ; BleWifiAutoConnectCache::tick() is already guarded by #ifndef SIMULATOR.
+  -<BleWifiAutoConnectCache.cpp>
 build_flags =
   -std=gnu++2a
   !sdl2-config --cflags --libs
@@ -351,6 +355,10 @@ build_src_filter =
   ; needs BlePeripheralManager.h too. main.cpp's own call into
   ; BleWifiScanCache::tick() is already guarded by #ifndef SIMULATOR.
   -<BleWifiScanCache.cpp>
+  ; Same rationale, same shape as BleWifiScanCache.cpp above -- BleWifiAutoConnectCache.cpp
+  ; also calls BlePeripheralManager::end() directly. main.cpp's own call into
+  ; BleWifiAutoConnectCache::tick() is already guarded by #ifndef SIMULATOR.
+  -<BleWifiAutoConnectCache.cpp>
 build_flags =
   -std=gnu++2a
   !sdl2-config --cflags --libs

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -99,62 +99,21 @@ size_t handleWifiProvision(JsonVariantConst payload, char* outBuf, size_t outBuf
   return formatReply(outBuf, outBufLen, kCmd, "ok", nullptr);
 }
 
-// account.claim/device.challenge -- the BLE account-claim flow from foulad-ebooks'
-// docs/BLE_ACCOUNT_CLAIM_PROPOSAL.md, ported from the hardware-validated commit
-// 85a23164 (branch docs/ble-phase1-hardware-validated; never merged to develop --
-// confirmed hardware-hung on the real Foulad One app's setup flow without it, see
-// HANDOFF FE-P3-RC-BLE-PAIRING-001). Like wifi.provision, these run entirely on the
-// unclaimed-device path: physical possession of the reader is the security model,
-// not a credential check -- there is nothing to check against yet on a device with
-// no account. Once claimed, everything past this point needs the real
-// Auth-characteristic check (still Phase 2 work, see BleCommandDispatcher::pump()).
-
-size_t handleAccountClaim(JsonVariantConst payload, char* outBuf, size_t outBufLen) {
-  constexpr char kCmd[] = "account.claim";
-  // Same unclaimed-device gate as wifi.provision -- a device that already has a
-  // Foulad eBooks account must not have it silently overwritten by anyone who
-  // picks it up and holds Confirm.
-  if (deviceIsClaimed()) {
-    LOG_DBG(TAG, "account.claim refused: device already claimed");
-    return formatReply(outBuf, outBufLen, kCmd, "failed", "unauthorized");
-  }
-
-  const char* username = payload["username"] | "";
-  const char* token = payload["token"] | "";
-  if (!username || username[0] == '\0' || !token || token[0] == '\0') {
-    return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
-  }
-
-  // Same sink the QR flow writes to (FouladQrLoginActivity.cpp's Approved case) --
-  // every existing OPDS call keeps working unchanged, no new credential type.
-  // RenderLock, same as handleWifiProvision(): SD and the e-ink display share one
-  // SPI bus, so a task doing blocking SD I/O (addServer() persists to opds.json) off
-  // the render task holds this for the duration.
-  RenderLock lock;
-  OpdsServer server;
-  server.name = FOULAD_EBOOKS_NAME;
-  server.url = FOULAD_EBOOKS_URL;
-  server.username = username;
-  server.password = token;
-  server.isDeviceToken = true;
-  if (!OPDS_STORE.addServer(server)) {
-    // Username only, never here either -- see the success log below for why.
-    LOG_ERR(TAG, "account.claim: addServer failed");
-    return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");
-  }
-
-  // Deliberately no restart here (unlike the QR flow's silentRestartToFouladEbooks()):
-  // that flow restarts because it's mid-screen-transition into browsing the catalog;
-  // this is a BLE command mid-session, and forcing a reboot here would kill the reply
-  // notify and any further commands the phone still means to send (e.g. this is
-  // commonly followed by wifi.provision in the same session). The device picks the
-  // credential up naturally next time it navigates to Foulad eBooks.
-  // Outcome only, not the username: pump()'s own policy (see its comment) is no
-  // identifier/credential data in the serial/debug log for any command past this
-  // dispatcher, and username is an account identifier by that same standard.
-  LOG_INF(TAG, "account.claim: ok");
-  return formatReply(outBuf, outBufLen, kCmd, "ok", nullptr);
-}
+// account.claim is intentionally NOT implemented here. A first port (from the
+// hardware-validated but never-merged commit 85a23164) persisted whatever
+// {username, token} a BLE peer sent, gated only on !deviceIsClaimed() -- no
+// verification that the payload ever came from a real, server-authorized claim.
+// HANDOFF FE-P3-RC-ACCOUNT-CLAIM-TRUST-001 found this exploitable as an
+// unauthenticated denial-of-service: any BLE-proximate attacker, no Midad account
+// needed, can lock an *unclaimed* reader into a permanently non-functional claimed
+// state before its real owner ever sets it up (device.challenge doesn't gate this --
+// it's a stateless echo with no link to account.claim at all). CodeRabbit flagged
+// this on PR #168; the fix isn't a firmware tweak, it's a signed-assertion protocol
+// spanning foulad-ebooks/foulad-one/foulad-eink (design: HANDOFF
+// FE-P3-RC-ACCOUNT-CLAIM-SIGNED-PROOF-DESIGN-002) -- deferred to that follow-up
+// rather than shipping this gap. Until then, `account.claim` falls through to
+// dispatch()'s "unsupported" reply below, same as any command this firmware
+// doesn't implement.
 
 size_t handleDeviceChallenge(JsonVariantConst payload, char* outBuf, size_t outBufLen) {
   constexpr char kCmd[] = "device.challenge";
@@ -404,9 +363,6 @@ size_t dispatch(const char* cmd, JsonVariantConst payload, char* outBuf, size_t 
   }
   if (strcmp(cmd, "device.info") == 0) {
     return handleDeviceInfo(outBuf, outBufLen);
-  }
-  if (strcmp(cmd, "account.claim") == 0) {
-    return handleAccountClaim(payload, outBuf, outBufLen);
   }
   if (strcmp(cmd, "device.challenge") == 0) {
     return handleDeviceChallenge(payload, outBuf, outBufLen);

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -292,8 +292,23 @@ size_t handleWifiAutoconnect(char* outBuf, size_t outBufLen) {
       doc["state"] = "ok";
       doc["ssid"] = BleWifiAutoConnectCache::lastKnownSsid();
       doc["rssi"] = BleWifiAutoConnectCache::lastKnownRssi();
+      // ssid is Wi-Fi-network-controlled (JSON-escaping an adversarial SSID can push
+      // the reply past outBufLen) -- measure before serializing rather than assume it
+      // fits, same rule as device.info/device.challenge. Only consume() once the
+      // reply is known to fit: otherwise a truncated reply goes out AND the cached
+      // result is gone, leaving the phone with no way to ever learn the real outcome.
+      if (measureJson(doc) > outBufLen) {
+        doc.remove("ssid");
+      }
+      if (measureJson(doc) > outBufLen) {
+        return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
+      }
+      const size_t replyLen = serializeJson(doc, outBuf, outBufLen);
+      if (replyLen == 0) {
+        return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
+      }
       BleWifiAutoConnectCache::consume();
-      return serializeJson(doc, outBuf, outBufLen);
+      return replyLen;
     }
 
     case BleWifiAutoConnectCache::State::Failed:

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -217,7 +217,12 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
   //     lib/data/ble/midad_ble_client.dart's DeviceInfo.fromReply()), which only
   //     knows these flat keys. Deprecate the flat fields once that app ships a build
   //     reading the nested form instead -- not yet.
-  const bool wifiSaved = BleWifiAutoConnectCache::hasSavedCredential();
+  // device.info's wifi.saved has no room for a third "couldn't check" state (unlike
+  // wifi.autoconnect's dedicated reply below, which does) -- StoreLoadFailed reports
+  // as false here, the conservative choice: claiming "saved" when the store couldn't
+  // actually be read would be worse than under-reporting it.
+  const bool wifiSaved =
+      BleWifiAutoConnectCache::checkSavedCredential() == BleWifiAutoConnectCache::CredentialCheckResult::HasCredential;
   const bool wifiConnected = BleWifiAutoConnectCache::lastKnownConnected();
   const std::string& wifiSsid = BleWifiAutoConnectCache::lastKnownSsid();
   const int32_t wifiRssi = BleWifiAutoConnectCache::lastKnownRssi();
@@ -294,8 +299,16 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
 size_t handleWifiAutoconnect(char* outBuf, size_t outBufLen) {
   constexpr char kCmd[] = "wifi.autoconnect";
   switch (BleWifiAutoConnectCache::currentState()) {
-    case BleWifiAutoConnectCache::State::Idle:
-      if (!BleWifiAutoConnectCache::hasSavedCredential()) {
+    case BleWifiAutoConnectCache::State::Idle: {
+      // StoreLoadFailed and NoCredential both mean "nothing to attempt," but not for
+      // the same reason -- collapsing them once made a real wifi.json read failure
+      // report identically to a reader that was simply never configured, hiding a
+      // genuine storage problem from the phone.
+      const auto credCheck = BleWifiAutoConnectCache::checkSavedCredential();
+      if (credCheck == BleWifiAutoConnectCache::CredentialCheckResult::StoreLoadFailed) {
+        return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");
+      }
+      if (credCheck == BleWifiAutoConnectCache::CredentialCheckResult::NoCredential) {
         return formatReply(outBuf, outBufLen, kCmd, "skipped", "no_saved_credentials");
       }
       BleWifiAutoConnectCache::requestConnect();
@@ -308,6 +321,7 @@ size_t handleWifiAutoconnect(char* outBuf, size_t outBufLen) {
         return formatReply(outBuf, outBufLen, kCmd, "failed", "busy");
       }
       return formatReply(outBuf, outBufLen, kCmd, "started", nullptr);
+    }
 
     case BleWifiAutoConnectCache::State::PendingStart:
     case BleWifiAutoConnectCache::State::Connecting:

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -127,6 +127,10 @@ size_t handleAccountClaim(JsonVariantConst payload, char* outBuf, size_t outBufL
 
   // Same sink the QR flow writes to (FouladQrLoginActivity.cpp's Approved case) --
   // every existing OPDS call keeps working unchanged, no new credential type.
+  // RenderLock, same as handleWifiProvision(): SD and the e-ink display share one
+  // SPI bus, so a task doing blocking SD I/O (addServer() persists to opds.json) off
+  // the render task holds this for the duration.
+  RenderLock lock;
   OpdsServer server;
   server.name = FOULAD_EBOOKS_NAME;
   server.url = FOULAD_EBOOKS_URL;
@@ -134,7 +138,8 @@ size_t handleAccountClaim(JsonVariantConst payload, char* outBuf, size_t outBufL
   server.password = token;
   server.isDeviceToken = true;
   if (!OPDS_STORE.addServer(server)) {
-    LOG_ERR(TAG, "account.claim: addServer failed for username=%s", username);
+    // Username only, never here either -- see the success log below for why.
+    LOG_ERR(TAG, "account.claim: addServer failed");
     return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");
   }
 
@@ -144,7 +149,10 @@ size_t handleAccountClaim(JsonVariantConst payload, char* outBuf, size_t outBufL
   // notify and any further commands the phone still means to send (e.g. this is
   // commonly followed by wifi.provision in the same session). The device picks the
   // credential up naturally next time it navigates to Foulad eBooks.
-  LOG_INF(TAG, "account.claim: signed in as '%s'", username);
+  // Outcome only, not the username: pump()'s own policy (see its comment) is no
+  // identifier/credential data in the serial/debug log for any command past this
+  // dispatcher, and username is an account identifier by that same standard.
+  LOG_INF(TAG, "account.claim: ok");
   return formatReply(outBuf, outBufLen, kCmd, "ok", nullptr);
 }
 
@@ -158,11 +166,18 @@ size_t handleDeviceChallenge(JsonVariantConst payload, char* outBuf, size_t outB
   // verbatim so the phone can forward it to claim-by-serial. See foulad-ebooks'
   // docs/BLE_ACCOUNT_CLAIM_PROPOSAL.md for why this alone is a sufficient check
   // (the nonce is single-use, 60s TTL, and only reaches this device over an
-  // already-connected BLE session with whoever is physically holding it).
+  // already-connected BLE session with whoever is physically holding it). The
+  // real challenge is a fixed 32 chars (DeviceClaimChallenge::issue()), but a
+  // malformed/oversized nonce from a non-conforming caller must not silently
+  // truncate into invalid JSON the same way device.info's reply once did --
+  // measure before serializing rather than assume it fits.
   JsonDocument doc;
   doc["cmd"] = kCmd;
   doc["state"] = "ok";
   doc["echo"] = nonce;
+  if (measureJson(doc) > outBufLen) {
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
+  }
   return serializeJson(doc, outBuf, outBufLen);
 }
 

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <string>
 
+#include "BleWifiAutoConnectCache.h"
 #include "BleWifiScanCache.h"
 #include "FouladEbooksConfig.h"
 #include "OpdsServerStore.h"
@@ -98,6 +99,73 @@ size_t handleWifiProvision(JsonVariantConst payload, char* outBuf, size_t outBuf
   return formatReply(outBuf, outBufLen, kCmd, "ok", nullptr);
 }
 
+// account.claim/device.challenge -- the BLE account-claim flow from foulad-ebooks'
+// docs/BLE_ACCOUNT_CLAIM_PROPOSAL.md, ported from the hardware-validated commit
+// 85a23164 (branch docs/ble-phase1-hardware-validated; never merged to develop --
+// confirmed hardware-hung on the real Foulad One app's setup flow without it, see
+// HANDOFF FE-P3-RC-BLE-PAIRING-001). Like wifi.provision, these run entirely on the
+// unclaimed-device path: physical possession of the reader is the security model,
+// not a credential check -- there is nothing to check against yet on a device with
+// no account. Once claimed, everything past this point needs the real
+// Auth-characteristic check (still Phase 2 work, see BleCommandDispatcher::pump()).
+
+size_t handleAccountClaim(JsonVariantConst payload, char* outBuf, size_t outBufLen) {
+  constexpr char kCmd[] = "account.claim";
+  // Same unclaimed-device gate as wifi.provision -- a device that already has a
+  // Foulad eBooks account must not have it silently overwritten by anyone who
+  // picks it up and holds Confirm.
+  if (deviceIsClaimed()) {
+    LOG_DBG(TAG, "account.claim refused: device already claimed");
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "unauthorized");
+  }
+
+  const char* username = payload["username"] | "";
+  const char* token = payload["token"] | "";
+  if (!username || username[0] == '\0' || !token || token[0] == '\0') {
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
+  }
+
+  // Same sink the QR flow writes to (FouladQrLoginActivity.cpp's Approved case) --
+  // every existing OPDS call keeps working unchanged, no new credential type.
+  OpdsServer server;
+  server.name = FOULAD_EBOOKS_NAME;
+  server.url = FOULAD_EBOOKS_URL;
+  server.username = username;
+  server.password = token;
+  server.isDeviceToken = true;
+  if (!OPDS_STORE.addServer(server)) {
+    LOG_ERR(TAG, "account.claim: addServer failed for username=%s", username);
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "storage_error");
+  }
+
+  // Deliberately no restart here (unlike the QR flow's silentRestartToFouladEbooks()):
+  // that flow restarts because it's mid-screen-transition into browsing the catalog;
+  // this is a BLE command mid-session, and forcing a reboot here would kill the reply
+  // notify and any further commands the phone still means to send (e.g. this is
+  // commonly followed by wifi.provision in the same session). The device picks the
+  // credential up naturally next time it navigates to Foulad eBooks.
+  LOG_INF(TAG, "account.claim: signed in as '%s'", username);
+  return formatReply(outBuf, outBufLen, kCmd, "ok", nullptr);
+}
+
+size_t handleDeviceChallenge(JsonVariantConst payload, char* outBuf, size_t outBufLen) {
+  constexpr char kCmd[] = "device.challenge";
+  const char* nonce = payload["nonce"] | "";
+  if (!nonce || nonce[0] == '\0') {
+    return formatReply(outBuf, outBufLen, kCmd, "failed", "invalid_payload");
+  }
+  // Pure proof-of-possession -- no crypto, just echo the server-issued nonce back
+  // verbatim so the phone can forward it to claim-by-serial. See foulad-ebooks'
+  // docs/BLE_ACCOUNT_CLAIM_PROPOSAL.md for why this alone is a sufficient check
+  // (the nonce is single-use, 60s TTL, and only reaches this device over an
+  // already-connected BLE session with whoever is physically holding it).
+  JsonDocument doc;
+  doc["cmd"] = kCmd;
+  doc["state"] = "ok";
+  doc["echo"] = nonce;
+  return serializeJson(doc, outBuf, outBufLen);
+}
+
 // Read-only device identification -- no side effects, no state mutation, works
 // whether the device is claimed or not. Physical possession of the reader (it's
 // sitting there, in BluetoothActivity, advertising) is the security model for this
@@ -120,22 +188,131 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
   }
   doc["model"] = gpio.deviceIsX3() ? "Xteink X3" : "Xteink X4";
   doc["firmware_version"] = CROSSPOINT_VERSION;
-  doc["wifi_connected"] = WiFi.status() == WL_CONNECTED;
   doc["claimed"] = deviceIsClaimed();
 
-  // CROSSPOINT_VERSION embeds the branch name + short SHA on dev/RC builds
-  // (scripts/git_branch.py) and can run long enough to blow the BLE payload budget
-  // together with the other fields. Truncate just this field rather than dropping
-  // the whole reply -- the phone only needs enough to identify the base version, not
-  // the exact dev tag, in this fallback case.
+  // HANDOFF FE-P3-RC-BLE-PROTOCOL-COMPAT-001: two representations of the exact same
+  // Wi-Fi state, generated from one source (BleWifiAutoConnectCache's cached outcome,
+  // NOT live WiFi.status() -- by the time any BLE caller can ask, WiFi has already
+  // been torn back down to WIFI_MODE_NULL to let BLE resume advertising, so a live
+  // read would almost always show disconnected regardless of what the last attempt
+  // actually did). Never includes the password.
+  //   - "wifi": {...} -- the preferred nested form for the app version that reads it.
+  //   - top-level "wifi_saved"/"wifi_connected"/"wifi_ssid"/"wifi_rssi" -- flat
+  //     compatibility fields for the currently-shipped app (foulad-one @ main,
+  //     lib/data/ble/midad_ble_client.dart's DeviceInfo.fromReply()), which only
+  //     knows these flat keys. Deprecate the flat fields once that app ships a build
+  //     reading the nested form instead -- not yet.
+  const bool wifiSaved = BleWifiAutoConnectCache::hasSavedCredential();
+  const bool wifiConnected = BleWifiAutoConnectCache::lastKnownConnected();
+  const std::string& wifiSsid = BleWifiAutoConnectCache::lastKnownSsid();
+  const int32_t wifiRssi = BleWifiAutoConnectCache::lastKnownRssi();
+
+  JsonObject wifi = doc["wifi"].to<JsonObject>();
+  wifi["saved"] = wifiSaved;
+  wifi["connected"] = wifiConnected;
+  if (wifiConnected) {
+    wifi["ssid"] = wifiSsid;
+    wifi["rssi"] = wifiRssi;
+  }
+  doc["wifi_saved"] = wifiSaved;
+  doc["wifi_connected"] = wifiConnected;
+  if (wifiConnected) {
+    doc["wifi_ssid"] = wifiSsid;
+    doc["wifi_rssi"] = wifiRssi;
+  }
+
+  // Fit into the BLE payload budget (kMaxPayloadLen, 160 bytes). Measured live: even
+  // with a short release-style firmware_version, cmd/state/serial/model/claimed plus
+  // BOTH full Wi-Fi representations runs to ~250+ bytes -- there is no way to always
+  // send everything, so this trims in priority order, least-consumed-today first.
+  // serializeJson() below has no bounds awareness of its own: given a doc that
+  // doesn't fit, it silently writes a truncated (and therefore unparseable) prefix
+  // rather than erroring, which is exactly what shipped here once wifi{} first
+  // pushed a real dev-build firmware_version over the edge -- confirmed live: a
+  // reply cut off mid-object at "wifi":{"saved":. Order below: drop what nothing
+  // shipped reads yet (nested saved/rssi/ssid, flat saved) before touching what the
+  // currently-shipped app actually depends on (flat connected/ssid/rssi), and drop
+  // nested "connected" -- the one nested field with real near-term value -- only
+  // once firmware_version is already fully shrunk and there's truly nothing else
+  // left to give up.
+  if (measureJson(doc) > outBufLen) wifi.remove("saved");
+  if (measureJson(doc) > outBufLen) doc.remove("wifi_saved");
+  if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("rssi");
+  if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("ssid");
   while (measureJson(doc) > outBufLen) {
     std::string fw = doc["firmware_version"].as<std::string>();
-    if (fw.size() <= 1) break;  // give up rather than loop forever
+    // Must stop at size()==0, not size()<=1: fw.size() is unsigned, and resize(size()-1)
+    // on an already-empty string underflows to SIZE_MAX rather than a negative number.
+    // A size-1 firmware_version legitimately needs one more shrink to empty -- confirmed
+    // live: a real build's version string ("1") left the whole reply exactly 1 byte over
+    // budget with nothing else left to trim, and stopping here at size<=1 silently
+    // shipped a truncated, unparseable JSON reply instead of fixing the one byte.
+    if (fw.empty()) break;  // give up rather than loop forever
     fw.resize(fw.size() - 1);
     doc["firmware_version"] = fw;
   }
+  // Below this point, none of the remaining removals are gated on wifiConnected --
+  // confirmed live that the disconnected case (wifi:{"connected":false} plus flat
+  // wifi_saved/wifi_connected, no ssid/rssi to have dropped yet) is the tighter one,
+  // not the connected case: with firmware_version already empty there was still
+  // nothing left to trim and the reply truncated ("wifi_connect...). Order: flat
+  // rssi/ssid first (only reachable with an unusually long SSID even after
+  // firmware_version is empty) -- these are what the shipped app actually depends
+  // on, so kept as long as possible; then nested "connected" and finally the whole
+  // nested "wifi" object, since flat "wifi_connected" (never touched here) is the
+  // one field this whole compat layer exists to guarantee reaches the app.
+  if (measureJson(doc) > outBufLen) doc.remove("wifi_rssi");
+  if (measureJson(doc) > outBufLen) doc.remove("wifi_ssid");
+  if (measureJson(doc) > outBufLen) wifi.remove("connected");
+  if (measureJson(doc) > outBufLen) doc.remove("wifi");
 
   return serializeJson(doc, outBuf, outBufLen);
+}
+
+// Async, cross-reconnect -- same shape as handleWifiScan() below (see its comment
+// for the full mutual-exclusion rationale this mirrors). A phone call sequence is:
+// call 1 (with a saved credential available) kicks off the attempt and gets
+// "started" (BLE disconnects shortly after); once WiFi mode returns to NULL BLE
+// re-advertises; call 2 (after reconnect) gets "ok"/"failed", or the phone can skip
+// straight to a plain device.info call and read wifi.connected there instead --
+// either reads the same BleWifiAutoConnectCache outcome.
+size_t handleWifiAutoconnect(char* outBuf, size_t outBufLen) {
+  constexpr char kCmd[] = "wifi.autoconnect";
+  switch (BleWifiAutoConnectCache::currentState()) {
+    case BleWifiAutoConnectCache::State::Idle:
+      if (!BleWifiAutoConnectCache::hasSavedCredential()) {
+        return formatReply(outBuf, outBufLen, kCmd, "skipped", "no_saved_credentials");
+      }
+      BleWifiAutoConnectCache::requestConnect();
+      // requestConnect() silently no-ops (state stays Idle) when BleWifiScanCache is
+      // active -- confirmed live this mutual-exclusion guard is real, not
+      // theoretical: an earlier version without it let an overlapping wifi.scan call
+      // abort an in-flight saved-network connection. Report it honestly rather than
+      // claiming "started" for a request that didn't actually take.
+      if (BleWifiAutoConnectCache::currentState() == BleWifiAutoConnectCache::State::Idle) {
+        return formatReply(outBuf, outBufLen, kCmd, "failed", "busy");
+      }
+      return formatReply(outBuf, outBufLen, kCmd, "started", nullptr);
+
+    case BleWifiAutoConnectCache::State::PendingStart:
+    case BleWifiAutoConnectCache::State::Connecting:
+      return formatReply(outBuf, outBufLen, kCmd, "in_progress", nullptr);
+
+    case BleWifiAutoConnectCache::State::Done: {
+      JsonDocument doc;
+      doc["cmd"] = kCmd;
+      doc["state"] = "ok";
+      doc["ssid"] = BleWifiAutoConnectCache::lastKnownSsid();
+      doc["rssi"] = BleWifiAutoConnectCache::lastKnownRssi();
+      BleWifiAutoConnectCache::consume();
+      return serializeJson(doc, outBuf, outBufLen);
+    }
+
+    case BleWifiAutoConnectCache::State::Failed:
+      BleWifiAutoConnectCache::consume();
+      return formatReply(outBuf, outBufLen, kCmd, "failed", nullptr);
+  }
+  return 0;
 }
 
 // Async, cross-reconnect: the actual scan runs entirely in BleWifiScanCache::tick()
@@ -152,6 +329,11 @@ size_t handleWifiScan(char* outBuf, size_t outBufLen) {
   switch (BleWifiScanCache::currentState()) {
     case BleWifiScanCache::State::Idle:
       BleWifiScanCache::requestScan();
+      // Same honesty check as handleWifiAutoconnect(): requestScan() silently no-ops
+      // when BleWifiAutoConnectCache is active.
+      if (BleWifiScanCache::currentState() == BleWifiScanCache::State::Idle) {
+        return formatReply(outBuf, outBufLen, kCmd, "failed", "busy");
+      }
       return formatReply(outBuf, outBufLen, kCmd, "started", nullptr);
 
     case BleWifiScanCache::State::PendingStart:
@@ -194,8 +376,17 @@ size_t dispatch(const char* cmd, JsonVariantConst payload, char* outBuf, size_t 
   if (strcmp(cmd, "device.info") == 0) {
     return handleDeviceInfo(outBuf, outBufLen);
   }
+  if (strcmp(cmd, "account.claim") == 0) {
+    return handleAccountClaim(payload, outBuf, outBufLen);
+  }
+  if (strcmp(cmd, "device.challenge") == 0) {
+    return handleDeviceChallenge(payload, outBuf, outBufLen);
+  }
   if (strcmp(cmd, "wifi.scan") == 0) {
     return handleWifiScan(outBuf, outBufLen);
+  }
+  if (strcmp(cmd, "wifi.autoconnect") == 0) {
+    return handleWifiAutoconnect(outBuf, outBufLen);
   }
   // Explicit reply, not silence -- an older reader talking to a newer phone app
   // should fail as "needs a firmware update," not hang. See docs/ble-module-tasks.md's

--- a/src/BleWifiAutoConnectCache.cpp
+++ b/src/BleWifiAutoConnectCache.cpp
@@ -60,6 +60,14 @@ std::optional<WifiCredential> pickCredential() {
 void finishConnect(State result) {
   activityManager.requestUpdateAndWait();  // see tick()'s PendingStart case
   if (result != State::Done) {
+    // Every non-Done exit clears the cached success fields here, centrally --
+    // confirmed live this was missed on the PendingStart error paths (no saved
+    // credential / storage load failure), which left a stale lastConnected=true
+    // from an earlier successful attempt sitting behind a state that had already
+    // moved to Failed, so device.info would report a connection that was no longer
+    // real. The Connecting-timeout path used to set this locally before calling in
+    // here too; centralizing removes the second place this could be forgotten.
+    lastConnected = false;
     WiFi.disconnect(true, true);
   }
   WiFi.mode(WIFI_MODE_NULL);
@@ -155,7 +163,6 @@ void tick() {
       }
       if (millis() - connectStartMillis > kConnectTimeoutMs) {
         LOG_DBG(TAG, "connect timed out after %u ms", static_cast<unsigned>(kConnectTimeoutMs));
-        lastConnected = false;
         finishConnect(State::Failed);
         return;
       }

--- a/src/BleWifiAutoConnectCache.cpp
+++ b/src/BleWifiAutoConnectCache.cpp
@@ -75,9 +75,10 @@ void finishConnect(State result) {
 }
 }  // namespace
 
-bool hasSavedCredential() {
-  if (!ensureWifiStoreLoaded()) return false;
-  return WIFI_STORE.getCredentialCount() > 0;
+CredentialCheckResult checkSavedCredential() {
+  if (!ensureWifiStoreLoaded()) return CredentialCheckResult::StoreLoadFailed;
+  return WIFI_STORE.getCredentialCount() > 0 ? CredentialCheckResult::HasCredential
+                                             : CredentialCheckResult::NoCredential;
 }
 
 State currentState() { return state; }
@@ -131,7 +132,7 @@ void tick() {
       }
       const auto cred = pickCredential();
       if (!cred) {
-        LOG_ERR(TAG, "requestConnect() with no saved credential -- caller should have checked hasSavedCredential()");
+        LOG_ERR(TAG, "requestConnect() with no saved credential -- caller should have checked checkSavedCredential()");
         finishConnect(State::Failed);
         return;
       }

--- a/src/BleWifiAutoConnectCache.cpp
+++ b/src/BleWifiAutoConnectCache.cpp
@@ -1,0 +1,167 @@
+#include "BleWifiAutoConnectCache.h"
+
+#include <BlePeripheralManager.h>
+#include <HalStorage.h>
+#include <WiFi.h>
+
+#include <optional>
+
+#include "BleWifiScanCache.h"
+#include "Logging.h"
+#include "WifiCredentialStore.h"
+#include "activities/Activity.h"
+#include "activities/ActivityManager.h"
+#include "activities/RenderLock.h"
+
+extern ActivityManager activityManager;
+
+namespace BleWifiAutoConnectCache {
+
+namespace {
+constexpr char TAG[] = "BLEWIFIAUTO";
+// Matches WifiSelectionActivity::AUTO_CONNECTION_TIMEOUT_MS -- same "known-good
+// network, fail fast rather than dragging BLE setup out" reasoning applies here.
+constexpr uint32_t kConnectTimeoutMs = 7000;
+
+State state = State::Idle;
+uint32_t connectStartMillis = 0;
+
+bool lastConnected = false;
+std::string lastSsid;
+int32_t lastRssi = 0;
+
+// Mirrors handleWifiProvision()'s lazy-load: BLE has no guarantee any activity ever
+// loaded WIFI_STORE's in-memory state this boot. Storage.exists() distinguishes "never
+// saved any credential" (fine, nothing to load) from "file exists but failed to load"
+// (real corruption -- bail rather than acting on stale/empty in-memory state).
+bool ensureWifiStoreLoaded() {
+  RenderLock lock;
+  if (!Storage.exists(WifiCredentialStore::getFilePath())) return true;  // nothing saved yet
+  if (!WIFI_STORE.loadFromFile()) {
+    LOG_ERR(TAG, "wifi.json exists but failed to load");
+    return false;
+  }
+  return true;
+}
+
+std::optional<WifiCredential> pickCredential() {
+  const std::string lastConnectedSsid = WIFI_STORE.getLastConnectedSsid();
+  if (!lastConnectedSsid.empty()) {
+    if (auto cred = WIFI_STORE.findCredential(lastConnectedSsid)) {
+      return cred;
+    }
+  }
+  return WIFI_STORE.getCredentialAt(0);
+}
+
+// Always releases the radio back to BLE on the way out, whether the attempt
+// succeeded or failed -- see this file's header comment for why device.info must
+// read the cached outcome here rather than live WiFi.status().
+void finishConnect(State result) {
+  activityManager.requestUpdateAndWait();  // see tick()'s PendingStart case
+  if (result != State::Done) {
+    WiFi.disconnect(true, true);
+  }
+  WiFi.mode(WIFI_MODE_NULL);
+  state = result;
+}
+}  // namespace
+
+bool hasSavedCredential() {
+  if (!ensureWifiStoreLoaded()) return false;
+  return WIFI_STORE.getCredentialCount() > 0;
+}
+
+State currentState() { return state; }
+
+void requestConnect() {
+  // Mutual exclusion with BleWifiScanCache: both drive the same WiFi radio through
+  // independent state machines ticked every main-loop iteration, and neither
+  // originally checked the other. Confirmed live: a wifi.scan call landing while this
+  // cache is Connecting reaches its PendingStart handler's WiFi.disconnect() call,
+  // which aborts the in-flight connection to the saved network -- two consecutive
+  // real hardware timeouts traced directly to this race (BLEWIFISCAN "starting scan"
+  // logged inside the BLEWIFIAUTO Connecting window). Refusing to start while the
+  // other cache is active is a strict startup gate, not a use of the radio itself, so
+  // it's safe to check unconditionally.
+  if (state != State::Idle) return;
+  if (BleWifiScanCache::currentState() != BleWifiScanCache::State::Idle) return;
+  state = State::PendingStart;
+}
+
+void consume() {
+  if (state == State::Done || state == State::Failed) {
+    state = State::Idle;
+  }
+}
+
+bool lastKnownConnected() { return lastConnected; }
+const std::string& lastKnownSsid() { return lastSsid; }
+int32_t lastKnownRssi() { return lastRssi; }
+
+void tick() {
+  switch (state) {
+    case State::Idle:
+    case State::Done:
+    case State::Failed:
+      return;
+
+    case State::PendingStart: {
+      // Same render-lock and BLE-teardown-ordering rules as
+      // BleWifiScanCache::tick()'s PendingStart case -- see that file's comments for
+      // the full hardware-crash history both guards were built from. Repeating both
+      // here rather than sharing code with the already hardware-validated wifi.scan
+      // path, so this new command can't regress it.
+      activityManager.requestUpdateAndWait();
+      if (BlePeripheral.isActive()) {
+        BlePeripheral.end();
+      }
+
+      if (!ensureWifiStoreLoaded()) {
+        finishConnect(State::Failed);
+        return;
+      }
+      const auto cred = pickCredential();
+      if (!cred) {
+        LOG_ERR(TAG, "requestConnect() with no saved credential -- caller should have checked hasSavedCredential()");
+        finishConnect(State::Failed);
+        return;
+      }
+
+      LOG_DBG(TAG, "connecting to saved network: %s", cred->ssid.c_str());
+      WiFi.persistent(false);
+      WiFi.mode(WIFI_STA);
+      WiFi.disconnect(true, true);
+      delay(100);
+      if (!cred->password.empty()) {
+        WiFi.begin(cred->ssid.c_str(), cred->password.c_str());
+      } else {
+        WiFi.begin(cred->ssid.c_str());
+      }
+      lastSsid = cred->ssid;
+      connectStartMillis = millis();
+      state = State::Connecting;
+      return;
+    }
+
+    case State::Connecting: {
+      if (WiFi.status() == WL_CONNECTED) {
+        lastConnected = true;
+        lastRssi = WiFi.RSSI();
+        WIFI_STORE.setLastConnectedSsid(lastSsid);
+        LOG_DBG(TAG, "connected: ssid=%s rssi=%d", lastSsid.c_str(), static_cast<int>(lastRssi));
+        finishConnect(State::Done);
+        return;
+      }
+      if (millis() - connectStartMillis > kConnectTimeoutMs) {
+        LOG_DBG(TAG, "connect timed out after %u ms", static_cast<unsigned>(kConnectTimeoutMs));
+        lastConnected = false;
+        finishConnect(State::Failed);
+        return;
+      }
+      return;
+    }
+  }
+}
+
+}  // namespace BleWifiAutoConnectCache

--- a/src/BleWifiAutoConnectCache.h
+++ b/src/BleWifiAutoConnectCache.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// Owns the wifi.autoconnect BLE command's async connect lifecycle -- same shape and
+// safety rules as BleWifiScanCache (see that header's comment for the full rationale;
+// this mirrors it deliberately rather than sharing a base, to avoid touching the
+// already hardware-validated wifi.scan path). See HANDOFF FE-P3-RC-BLE-WIFI-COEXIST-001.
+//
+// WiFi.begin()/WiFi.mode() can only safely happen from src/main.cpp's own loop() tick,
+// never from a BLE command callback, and BLE tears itself down the instant WiFi leaves
+// WIFI_MODE_NULL (main.cpp's bleAllowedNow gate). So a connect attempt necessarily
+// outlives the BLE connection that requested it: wifi.autoconnect replies "started",
+// the phone reconnects once WiFi mode returns to NULL (whether the attempt succeeded or
+// failed -- this cache always releases the radio back to BLE), and a second
+// wifi.autoconnect call (or device.info, via lastKnownConnected()/lastKnownSsid())
+// reads back the cached outcome.
+namespace BleWifiAutoConnectCache {
+
+enum class State { Idle, PendingStart, Connecting, Done, Failed };
+
+// Whether a saved credential exists to even attempt -- cheap, synchronous, lazy-loads
+// WIFI_STORE from SD if not already loaded this boot (RenderLock-guarded, mirrors
+// BleCommandDispatcher's own wifi.provision lazy-load pattern). Safe to call anytime.
+bool hasSavedCredential();
+
+// Call once per main-loop tick (src/main.cpp), after BleWifiScanCache::tick().
+void tick();
+
+State currentState();
+
+// Only meaningful when Idle -- starts the connect attempt on the next tick(). A no-op
+// if an attempt is already pending/in-flight (idempotent against a phone retry), AND
+// a no-op if BleWifiScanCache is mid-scan (see requestConnect()'s .cpp comment --
+// confirmed live that without this guard, an overlapping wifi.scan call kills an
+// in-flight connect attempt via WiFi.disconnect()). Check currentState() after
+// calling to see whether the request actually took.
+void requestConnect();
+
+// Resets Done/Failed back to Idle, mirroring BleWifiScanCache::consume().
+void consume();
+
+// Most recent verified outcome. Valid immediately after a Done/Failed result and
+// persists until the next requestConnect() -- device.info reads these directly rather
+// than live WiFi.status(), since by the time any BLE caller can ask, WiFi has already
+// been torn back down to WIFI_MODE_NULL to let BLE resume. A snapshot of the last
+// attempt, not "is WiFi connected right now."
+bool lastKnownConnected();
+const std::string& lastKnownSsid();
+int32_t lastKnownRssi();
+
+}  // namespace BleWifiAutoConnectCache

--- a/src/BleWifiAutoConnectCache.h
+++ b/src/BleWifiAutoConnectCache.h
@@ -20,10 +20,17 @@ namespace BleWifiAutoConnectCache {
 
 enum class State { Idle, PendingStart, Connecting, Done, Failed };
 
+// NoCredential and StoreLoadFailed both mean "nothing to attempt," but for different
+// reasons the phone shouldn't see as the same thing: a genuinely unconfigured reader
+// vs. a corrupted/unreadable wifi.json. Collapsing them (an earlier version of this
+// function just returned bool) made a real storage error look identical to "nothing
+// saved yet" over BLE, masking it from the client entirely.
+enum class CredentialCheckResult { NoCredential, HasCredential, StoreLoadFailed };
+
 // Whether a saved credential exists to even attempt -- cheap, synchronous, lazy-loads
 // WIFI_STORE from SD if not already loaded this boot (RenderLock-guarded, mirrors
 // BleCommandDispatcher's own wifi.provision lazy-load pattern). Safe to call anytime.
-bool hasSavedCredential();
+CredentialCheckResult checkSavedCredential();
 
 // Call once per main-loop tick (src/main.cpp), after BleWifiScanCache::tick().
 void tick();

--- a/src/BleWifiScanCache.cpp
+++ b/src/BleWifiScanCache.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "BleWifiAutoConnectCache.h"
 #include "Logging.h"
 // ActivityManager.h's inline constructor default-constructs a
 // std::unique_ptr<Activity> member; Activity.h must be visible here too or
@@ -43,9 +44,17 @@ void finishScan(State result) {
 }  // namespace
 
 void requestScan() {
-  if (state == State::Idle) {
-    state = State::PendingStart;
-  }
+  // Mutual exclusion with BleWifiAutoConnectCache: both drive the same WiFi radio
+  // through independent state machines ticked every main-loop iteration, and neither
+  // originally checked the other. Confirmed live: a wifi.scan call landing while that
+  // cache is Connecting reaches this file's own PendingStart handler's
+  // WiFi.disconnect() call below, which aborts the in-flight connection to the saved
+  // network -- two consecutive real hardware timeouts traced directly to this race.
+  // Refusing to start while the other cache is active is a strict startup gate, not
+  // a change to this module's own (already hardware-validated) scan lifecycle.
+  if (state != State::Idle) return;
+  if (BleWifiAutoConnectCache::currentState() != BleWifiAutoConnectCache::State::Idle) return;
+  state = State::PendingStart;
 }
 
 State currentState() { return state; }

--- a/src/BleWifiScanCache.h
+++ b/src/BleWifiScanCache.h
@@ -32,7 +32,11 @@ void tick();
 State currentState();
 
 // Only meaningful when Idle -- starts the scan on the next tick(). A no-op if a
-// scan is already pending/in-flight (idempotent against a phone retry).
+// scan is already pending/in-flight (idempotent against a phone retry), AND a no-op
+// if BleWifiAutoConnectCache is mid-connect (see requestScan()'s .cpp comment --
+// confirmed live that without this guard, an overlapping wifi.scan call kills an
+// in-flight saved-network connection attempt). Check currentState() after calling to
+// see whether the request actually took.
 void requestScan();
 
 // Valid only right after currentState() == Done.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 
 #include "ArabicFontSystem.h"
 #include "BleCommandDispatcher.h"
+#include "BleWifiAutoConnectCache.h"
 #include "BleWifiScanCache.h"
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
@@ -946,6 +947,7 @@ void loop() {
   BlePeripheral.poll();
   BleCommandDispatcher::pump();
   BleWifiScanCache::tick();
+  BleWifiAutoConnectCache::tick();
 
   // Diagnostics + repaint nudge. The "BT" indicator in BaseTheme::drawHeader() reads
   // live BlePeripheral state, but e-ink screens don't repaint on a timer -- without an
@@ -1028,13 +1030,22 @@ void loop() {
         BlePeripheralManager::getAdvertisedName(advName, sizeof(advName));
         logSerial.printf(
             "BLE_STATUS: userRequested=%d activity=%s wifiMode=%d isReader=%d freeHeap=%u maxAlloc=%u gate=%u "
-            "floor=%u bleState=%d name=%s\n",
+            "floor=%u bleState=%d name=%s bonds=%d\n",
             BlePeripheral.isUserRequested(), activityManager.currentActivityDebugName(),
             static_cast<int>(WiFi.getMode()), activityManager.isReaderActivity(),
             static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()),
             static_cast<unsigned>(BlePeripheralManager::kHeapGateBytes),
             static_cast<unsigned>(BlePeripheralManager::kRunningFloorBytes), static_cast<int>(BlePeripheral.state()),
-            advName);
+            advName, BlePeripheralManager::getBondCount());
+#endif
+      } else if (cmd == "BLE_CLEAR_BONDS") {
+#ifndef SIMULATOR
+        // Debug tooling only, same rationale as BLE_STATUS above: exercises the
+        // "forget device, re-pair from scratch" path from a USB test harness without
+        // needing OS-level "forget this device" UI on the central side.
+        const bool cleared = BlePeripheralManager::clearAllBonds();
+        logSerial.printf("BLE_CLEAR_BONDS: %s, bonds=%d\n", cleared ? "ok" : "failed",
+                         BlePeripheralManager::getBondCount());
 #endif
       } else if (cmd == "RESTART") {
         // Lets a scripted USB test harness reboot the device to exercise boot-path


### PR DESCRIPTION
## Summary

- **Fixes a real hardware-confirmed BLE pairing bug**: `mitm=true` combined with `BLE_HS_IO_NO_INPUT_OUTPUT` is an unsatisfiable pairing requirement on hardware with no display/keyboard — confirmed live to hang every encrypted Auth-characteristic write for 30s then fail. Fixed to `mitm=false` (bonding + Secure Connections stay on). Adds `BLE_STATUS`/`BLE_CLEAR_BONDS` debug tooling and peripheral-side NimBLE security-event logging used to diagnose it.
- **Ports `device.challenge`** from the hardware-validated but never-merged commit `85a23164`, closing the confirmed release blocker where the real Foulad One app's `device.challenge` got `"unsupported"` and setup stalled on "The reader didn't confirm it's the one connected."
- **`account.claim` is deliberately NOT included.** An earlier version of this PR ported `account.claim` from the same commit, gated only on `!deviceIsClaimed()`. Deeper review (prompted by CodeRabbit, then a full trust-boundary analysis) found this exploitable as an unauthenticated denial-of-service: `device.challenge` is a stateless echo with no session link to `account.claim`, so any BLE-proximate attacker — no Midad account needed — could permanently lock an *unclaimed* reader into a false-claimed state before its real owner ever sets it up. This isn't a firmware-only fix; the replacement is a signed-assertion protocol spanning `foulad-ebooks`/`foulad-one`/`foulad-eink` (design doc: HANDOFF `FE-P3-RC-ACCOUNT-CLAIM-SIGNED-PROOF-DESIGN-002`, not yet implemented). `account.claim` was removed cleanly (not commented out) and now falls through to the dispatcher's existing `"unsupported"` reply, confirmed live over BLE against a fabricated claim payload — see analysis in HANDOFF `FE-P3-RC-ACCOUNT-CLAIM-TRUST-001`.
- **Adds `wifi.autoconnect`**: on request, tears BLE down using the same synchronous lifecycle `wifi.scan` already validated, attempts the saved Wi-Fi network, and re-advertises regardless of outcome. New `BleWifiAutoConnectCache` mirrors `BleWifiScanCache`'s proven state-machine shape rather than sharing code, so the already-validated scan path isn't touched. The two caches now guard against running concurrently — confirmed live that an overlapping `wifi.scan` call aborted an in-flight saved-network connection via `WiFi.disconnect()`, traced from two real hardware timeouts.
- **Extends `device.info`** with a preferred nested `wifi{saved,connected,ssid,rssi}` object plus flat `wifi_saved`/`wifi_connected`/`wifi_ssid`/`wifi_rssi` compatibility fields for the currently-shipped phone app, generated from one source. Both representations together don't fit the 160-byte BLE payload budget in the general case, so oversized replies trim in priority order (least-consumed-today first) rather than silently truncating into invalid JSON — a real truncation bug hit and fixed twice while building this out.

## Test plan

- [x] `pio run -e default` — build succeeds
- [x] `pio run -e sticky` — build succeeds
- [x] `pio check -e default` (cppcheck) — no defects
- [x] `./bin/clang-format-fix` — clean
- [x] Unit tests — 160/160 pass
- [x] Hardware (real X3): BLE connect/pair/bond over multiple reflash cycles, no crash
- [x] Hardware: `device.info` valid JSON in connected/disconnected states, both wifi{} and flat fields correct
- [x] Hardware: `wifi.autoconnect` full teardown → connect → re-advertise → reconnect cycle, including failure path (timeout) and the fixed concurrency race with `wifi.scan`
- [x] Hardware: `device.challenge` echoes nonce correctly
- [x] Hardware: `wifi.scan` regression-clean
- [x] Heap stability across repeated BLE/Wi-Fi transition cycles (steady ~24.6KB free)
- [x] Hardware: `account.claim` (fabricated `{username, token}` payload) returns `{"cmd":"account.claim","state":"unsupported"}` — confirms the clean removal took effect at the protocol level, not just at compile time
- [x] Hardware: post-removal regression pass — `device.info`, `device.challenge`, `wifi.scan`, `wifi.autoconnect` all still function correctly, no crash across repeated connect/disconnect cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e
