### PR TITLE
fix: protect device.info's wifi.saved from the 160-byte trim

### DIFF
--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -179,8 +179,16 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
 
   // JSON building + payload-budget trimming lives in BleDeviceInfoPayload.cpp, with
   // no ESP-IDF dependency, so it can be exercised by host-side unit tests -- see
-  // test/ble_device_info_payload/.
-  return buildDeviceInfoPayload(info, outBuf, outBufLen);
+  // test/ble_device_info_payload/. A 0 return means it couldn't fit even after
+  // trimming everything trimmable -- pump() silently drops a 0-length reply (no
+  // notification at all), which reads to the phone as "device never replied"
+  // (indistinguishable from a hang) rather than an explicit failure. Same guard
+  // pattern as every other handler in this file.
+  const size_t len = buildDeviceInfoPayload(info, outBuf, outBufLen);
+  if (len == 0) {
+    return formatReply(outBuf, outBufLen, "device.info", "failed", "invalid_payload");
+  }
+  return len;
 }
 
 // Async, cross-reconnect -- same shape as handleWifiScan() below (see its comment

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -203,21 +203,27 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
   // Fit into the BLE payload budget (kMaxPayloadLen, 160 bytes). Measured live: even
   // with a short release-style firmware_version, cmd/state/serial/model/claimed plus
   // BOTH full Wi-Fi representations runs to ~250+ bytes -- there is no way to always
-  // send everything, so this trims in priority order, least-consumed-today first.
-  // serializeJson() below has no bounds awareness of its own: given a doc that
-  // doesn't fit, it silently writes a truncated (and therefore unparseable) prefix
-  // rather than erroring, which is exactly what shipped here once wifi{} first
-  // pushed a real dev-build firmware_version over the edge -- confirmed live: a
-  // reply cut off mid-object at "wifi":{"saved":. Order below: drop what nothing
-  // shipped reads yet (nested saved/rssi/ssid, flat saved) before touching what the
-  // currently-shipped app actually depends on (flat connected/ssid/rssi), and drop
-  // nested "connected" -- the one nested field with real near-term value -- only
-  // once firmware_version is already fully shrunk and there's truly nothing else
-  // left to give up.
-  if (measureJson(doc) > outBufLen) wifi.remove("saved");
-  if (measureJson(doc) > outBufLen) doc.remove("wifi_saved");
+  // send everything, so this trims in priority order. serializeJson() below has no
+  // bounds awareness of its own: given a doc that doesn't fit, it silently writes a
+  // truncated (and therefore unparseable) prefix rather than erroring, which is
+  // exactly what shipped here once wifi{} first pushed a real dev-build
+  // firmware_version over the edge -- confirmed live: a reply cut off mid-object at
+  // "wifi":{"saved":.
+  //
+  // Order below is corrected from an earlier version that dropped "saved" first on
+  // the assumption nothing shipped read it yet -- confirmed live (HANDOFF
+  // MIDAD-E2E-TF168-001) that assumption was wrong: the real shipped app's
+  // BleProvisionScreen decides whether to show the Wi-Fi entry form at all from
+  // wifi.saved, and a trimmed-away "saved" made a reader with saved credentials look
+  // like it had none, sending every setup attempt through the manual Wi-Fi form
+  // regardless of what was actually on the SD card. "saved" and "connected" (both
+  // booleans, a few bytes each) now survive as long as possible; the cosmetic
+  // ssid/rssi strings/ints (nested and flat) and firmware_version are what actually
+  // give the budget back, so those go first.
   if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("rssi");
   if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("ssid");
+  if (wifiConnected && measureJson(doc) > outBufLen) doc.remove("wifi_rssi");
+  if (wifiConnected && measureJson(doc) > outBufLen) doc.remove("wifi_ssid");
   while (measureJson(doc) > outBufLen) {
     std::string fw = doc["firmware_version"].as<std::string>();
     // Must stop at size()==0, not size()<=1: fw.size() is unsigned, and resize(size()-1)
@@ -230,19 +236,15 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
     fw.resize(fw.size() - 1);
     doc["firmware_version"] = fw;
   }
-  // Below this point, none of the remaining removals are gated on wifiConnected --
-  // confirmed live that the disconnected case (wifi:{"connected":false} plus flat
-  // wifi_saved/wifi_connected, no ssid/rssi to have dropped yet) is the tighter one,
-  // not the connected case: with firmware_version already empty there was still
-  // nothing left to trim and the reply truncated ("wifi_connect...). Order: flat
-  // rssi/ssid first (only reachable with an unusually long SSID even after
-  // firmware_version is empty) -- these are what the shipped app actually depends
-  // on, so kept as long as possible; then nested "connected" and finally the whole
-  // nested "wifi" object, since flat "wifi_connected" (never touched here) is the
-  // one field this whole compat layer exists to guarantee reaches the app.
-  if (measureJson(doc) > outBufLen) doc.remove("wifi_rssi");
-  if (measureJson(doc) > outBufLen) doc.remove("wifi_ssid");
+  // "connected" before "saved": saved is the earlier, more foundational routing
+  // decision (whether to attempt provisioning at all vs. skip straight to the
+  // account-claim step), so it stays if only one of the two can survive. Flat and
+  // nested versions of each are dropped together so the compatibility fallback
+  // (used only once "wifi" is removed entirely below) never ends up half-populated.
   if (measureJson(doc) > outBufLen) wifi.remove("connected");
+  if (measureJson(doc) > outBufLen) doc.remove("wifi_connected");
+  if (measureJson(doc) > outBufLen) doc.remove("wifi_saved");
+  if (measureJson(doc) > outBufLen) wifi.remove("saved");
   if (measureJson(doc) > outBufLen) doc.remove("wifi");
 
   return serializeJson(doc, outBuf, outBufLen);

--- a/src/BleCommandDispatcher.cpp
+++ b/src/BleCommandDispatcher.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <string>
 
+#include "BleDeviceInfoPayload.h"
 #include "BleWifiAutoConnectCache.h"
 #include "BleWifiScanCache.h"
 #include "FouladEbooksConfig.h"
@@ -145,9 +146,7 @@ size_t handleDeviceChallenge(JsonVariantConst payload, char* outBuf, size_t outB
 // sitting there, in BluetoothActivity, advertising) is the security model for this
 // and every other unclaimed-device BLE command, not a credential check.
 size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
-  JsonDocument doc;
-  doc["cmd"] = "device.info";
-  doc["state"] = "ok";
+  DeviceInfoPayloadInput info;
   // Not FouladDeviceTracking::getSerialNumber() -- it derives from WiFi.macAddress(),
   // which reads the STA netif's MAC and is only valid while that netif exists.
   // esp_efuse_mac_get_default() reads the same base MAC directly from eFuse, with no
@@ -158,96 +157,30 @@ size_t handleDeviceInfo(char* outBuf, size_t outBufLen) {
     esp_efuse_mac_get_default(mac);
     char serial[18];
     snprintf(serial, sizeof(serial), "XTE-%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-    doc["serial"] = serial;
+    info.serial = serial;
   }
-  doc["model"] = gpio.deviceIsX3() ? "Xteink X3" : "Xteink X4";
-  doc["firmware_version"] = CROSSPOINT_VERSION;
-  doc["claimed"] = deviceIsClaimed();
+  info.model = gpio.deviceIsX3() ? "Xteink X3" : "Xteink X4";
+  info.firmwareVersion = CROSSPOINT_VERSION;
+  info.claimed = deviceIsClaimed();
 
-  // HANDOFF FE-P3-RC-BLE-PROTOCOL-COMPAT-001: two representations of the exact same
-  // Wi-Fi state, generated from one source (BleWifiAutoConnectCache's cached outcome,
-  // NOT live WiFi.status() -- by the time any BLE caller can ask, WiFi has already
-  // been torn back down to WIFI_MODE_NULL to let BLE resume advertising, so a live
-  // read would almost always show disconnected regardless of what the last attempt
-  // actually did). Never includes the password.
-  //   - "wifi": {...} -- the preferred nested form for the app version that reads it.
-  //   - top-level "wifi_saved"/"wifi_connected"/"wifi_ssid"/"wifi_rssi" -- flat
-  //     compatibility fields for the currently-shipped app (foulad-one @ main,
-  //     lib/data/ble/midad_ble_client.dart's DeviceInfo.fromReply()), which only
-  //     knows these flat keys. Deprecate the flat fields once that app ships a build
-  //     reading the nested form instead -- not yet.
+  // BleWifiAutoConnectCache's cached outcome, NOT live WiFi.status() -- by the time
+  // any BLE caller can ask, WiFi has already been torn back down to WIFI_MODE_NULL to
+  // let BLE resume advertising, so a live read would almost always show disconnected
+  // regardless of what the last attempt actually did. Never includes the password.
   // device.info's wifi.saved has no room for a third "couldn't check" state (unlike
   // wifi.autoconnect's dedicated reply below, which does) -- StoreLoadFailed reports
   // as false here, the conservative choice: claiming "saved" when the store couldn't
   // actually be read would be worse than under-reporting it.
-  const bool wifiSaved =
+  info.wifiSaved =
       BleWifiAutoConnectCache::checkSavedCredential() == BleWifiAutoConnectCache::CredentialCheckResult::HasCredential;
-  const bool wifiConnected = BleWifiAutoConnectCache::lastKnownConnected();
-  const std::string& wifiSsid = BleWifiAutoConnectCache::lastKnownSsid();
-  const int32_t wifiRssi = BleWifiAutoConnectCache::lastKnownRssi();
+  info.wifiConnected = BleWifiAutoConnectCache::lastKnownConnected();
+  info.wifiSsid = BleWifiAutoConnectCache::lastKnownSsid();
+  info.wifiRssi = BleWifiAutoConnectCache::lastKnownRssi();
 
-  JsonObject wifi = doc["wifi"].to<JsonObject>();
-  wifi["saved"] = wifiSaved;
-  wifi["connected"] = wifiConnected;
-  if (wifiConnected) {
-    wifi["ssid"] = wifiSsid;
-    wifi["rssi"] = wifiRssi;
-  }
-  doc["wifi_saved"] = wifiSaved;
-  doc["wifi_connected"] = wifiConnected;
-  if (wifiConnected) {
-    doc["wifi_ssid"] = wifiSsid;
-    doc["wifi_rssi"] = wifiRssi;
-  }
-
-  // Fit into the BLE payload budget (kMaxPayloadLen, 160 bytes). Measured live: even
-  // with a short release-style firmware_version, cmd/state/serial/model/claimed plus
-  // BOTH full Wi-Fi representations runs to ~250+ bytes -- there is no way to always
-  // send everything, so this trims in priority order. serializeJson() below has no
-  // bounds awareness of its own: given a doc that doesn't fit, it silently writes a
-  // truncated (and therefore unparseable) prefix rather than erroring, which is
-  // exactly what shipped here once wifi{} first pushed a real dev-build
-  // firmware_version over the edge -- confirmed live: a reply cut off mid-object at
-  // "wifi":{"saved":.
-  //
-  // Order below is corrected from an earlier version that dropped "saved" first on
-  // the assumption nothing shipped read it yet -- confirmed live (HANDOFF
-  // MIDAD-E2E-TF168-001) that assumption was wrong: the real shipped app's
-  // BleProvisionScreen decides whether to show the Wi-Fi entry form at all from
-  // wifi.saved, and a trimmed-away "saved" made a reader with saved credentials look
-  // like it had none, sending every setup attempt through the manual Wi-Fi form
-  // regardless of what was actually on the SD card. "saved" and "connected" (both
-  // booleans, a few bytes each) now survive as long as possible; the cosmetic
-  // ssid/rssi strings/ints (nested and flat) and firmware_version are what actually
-  // give the budget back, so those go first.
-  if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("rssi");
-  if (wifiConnected && measureJson(doc) > outBufLen) wifi.remove("ssid");
-  if (wifiConnected && measureJson(doc) > outBufLen) doc.remove("wifi_rssi");
-  if (wifiConnected && measureJson(doc) > outBufLen) doc.remove("wifi_ssid");
-  while (measureJson(doc) > outBufLen) {
-    std::string fw = doc["firmware_version"].as<std::string>();
-    // Must stop at size()==0, not size()<=1: fw.size() is unsigned, and resize(size()-1)
-    // on an already-empty string underflows to SIZE_MAX rather than a negative number.
-    // A size-1 firmware_version legitimately needs one more shrink to empty -- confirmed
-    // live: a real build's version string ("1") left the whole reply exactly 1 byte over
-    // budget with nothing else left to trim, and stopping here at size<=1 silently
-    // shipped a truncated, unparseable JSON reply instead of fixing the one byte.
-    if (fw.empty()) break;  // give up rather than loop forever
-    fw.resize(fw.size() - 1);
-    doc["firmware_version"] = fw;
-  }
-  // "connected" before "saved": saved is the earlier, more foundational routing
-  // decision (whether to attempt provisioning at all vs. skip straight to the
-  // account-claim step), so it stays if only one of the two can survive. Flat and
-  // nested versions of each are dropped together so the compatibility fallback
-  // (used only once "wifi" is removed entirely below) never ends up half-populated.
-  if (measureJson(doc) > outBufLen) wifi.remove("connected");
-  if (measureJson(doc) > outBufLen) doc.remove("wifi_connected");
-  if (measureJson(doc) > outBufLen) doc.remove("wifi_saved");
-  if (measureJson(doc) > outBufLen) wifi.remove("saved");
-  if (measureJson(doc) > outBufLen) doc.remove("wifi");
-
-  return serializeJson(doc, outBuf, outBufLen);
+  // JSON building + payload-budget trimming lives in BleDeviceInfoPayload.cpp, with
+  // no ESP-IDF dependency, so it can be exercised by host-side unit tests -- see
+  // test/ble_device_info_payload/.
+  return buildDeviceInfoPayload(info, outBuf, outBufLen);
 }
 
 // Async, cross-reconnect -- same shape as handleWifiScan() below (see its comment

--- a/src/BleDeviceInfoPayload.cpp
+++ b/src/BleDeviceInfoPayload.cpp
@@ -88,7 +88,15 @@ size_t buildDeviceInfoPayload(const DeviceInfoPayloadInput& in, char* outBuf, si
     // live: a real build's version string ("1") left the whole reply exactly 1 byte over
     // budget with nothing else left to trim, and stopping here at size<=1 silently
     // shipped a truncated, unparseable JSON reply instead of fixing the one byte.
-    if (fw.empty()) break;  // give up rather than loop forever
+    if (fw.empty()) {
+      // An empty string still costs ~22 bytes ("firmware_version":"") that the
+      // higher-priority connected/saved fields below need -- and every shrunken
+      // intermediate value (e.g. "1.2.3-a-much-longer-devel") is itself a silently
+      // truncated version string the app has no way to distinguish from a real one.
+      // Drop the key entirely; a missing field reads as unknown, which is honest.
+      doc.remove("firmware_version");
+      break;
+    }
     fw.resize(fw.size() - 1);
     doc["firmware_version"] = fw;
   }

--- a/src/BleDeviceInfoPayload.cpp
+++ b/src/BleDeviceInfoPayload.cpp
@@ -1,0 +1,112 @@
+#include "BleDeviceInfoPayload.h"
+
+#include <ArduinoJson.h>
+
+namespace BleCommandDispatcher {
+
+size_t buildDeviceInfoPayload(const DeviceInfoPayloadInput& in, char* outBuf, size_t outBufLen) {
+  JsonDocument doc;
+  doc["cmd"] = "device.info";
+  doc["state"] = "ok";
+  doc["serial"] = in.serial;
+  doc["model"] = in.model;
+  doc["firmware_version"] = in.firmwareVersion;
+  doc["claimed"] = in.claimed;
+
+  // HANDOFF FE-P3-RC-BLE-PROTOCOL-COMPAT-001: two representations of the exact same
+  // Wi-Fi state.
+  //   - "wifi": {...} -- the nested form.
+  //   - top-level "wifi_saved"/"wifi_connected"/"wifi_ssid"/"wifi_rssi" -- flat
+  //     compatibility fields.
+  // The shipped app (foulad-one @ main, lib/data/ble/midad_ble_client.dart's
+  // DeviceInfo.fromReply()) prefers the nested "wifi" object whenever it's present at
+  // all, and only falls back to the flat fields when "wifi" is entirely absent -- it
+  // does NOT fall back per-field. If "wifi" is present but missing a key (e.g.
+  // "connected" trimmed out while "wifi_connected" survives), fromReply() reads that
+  // key as null/unknown from the nested object; it never reaches for the flat
+  // sibling. That makes the nested and flat pair for each field a single unit from
+  // the client's point of view -- trimming must drop both halves of a pair together
+  // or never drop either, see the atomic removals below.
+  // device.info's wifi.saved has no room for a third "couldn't check" state (unlike
+  // wifi.autoconnect's dedicated reply, which does) -- callers report a failed saved-
+  // credential check as wifiSaved=false, the conservative choice: claiming "saved"
+  // when the store couldn't actually be read would be worse than under-reporting it.
+  JsonObject wifi = doc["wifi"].to<JsonObject>();
+  wifi["saved"] = in.wifiSaved;
+  wifi["connected"] = in.wifiConnected;
+  if (in.wifiConnected) {
+    wifi["ssid"] = in.wifiSsid;
+    wifi["rssi"] = in.wifiRssi;
+  }
+  doc["wifi_saved"] = in.wifiSaved;
+  doc["wifi_connected"] = in.wifiConnected;
+  if (in.wifiConnected) {
+    doc["wifi_ssid"] = in.wifiSsid;
+    doc["wifi_rssi"] = in.wifiRssi;
+  }
+
+  // Fit into the BLE payload budget (kMaxPayloadLen, 160 bytes). Measured live: even
+  // with a short release-style firmware_version, cmd/state/serial/model/claimed plus
+  // BOTH full Wi-Fi representations runs to ~250+ bytes -- there is no way to always
+  // send everything, so this trims in priority order. serializeJson() below has no
+  // bounds awareness of its own: given a doc that doesn't fit, it silently writes a
+  // truncated (and therefore unparseable) prefix rather than erroring, which is
+  // exactly what shipped here once wifi{} first pushed a real dev-build
+  // firmware_version over the edge -- confirmed live: a reply cut off mid-object at
+  // "wifi":{"saved":.
+  //
+  // Order below is corrected from an earlier version that dropped "saved" first on
+  // the assumption nothing shipped read it yet -- confirmed live (HANDOFF
+  // MIDAD-E2E-TF168-001) that assumption was wrong: the real shipped app's
+  // BleProvisionScreen decides whether to show the Wi-Fi entry form at all from
+  // wifi.saved, and a trimmed-away "saved" made a reader with saved credentials look
+  // like it had none, sending every setup attempt through the manual Wi-Fi form
+  // regardless of what was actually on the SD card. "saved" and "connected" (both
+  // booleans, a few bytes each) now survive as long as possible; the cosmetic
+  // ssid/rssi strings/ints (nested and flat) and firmware_version are what actually
+  // give the budget back, so those go first.
+  //
+  // Each pair's nested and flat halves are removed inside the SAME `if`, gated on one
+  // measurement -- not two independent `if`s each re-measuring after the other's
+  // removal. Two independent ifs can each individually fit the doc after removing
+  // just one half (e.g. dropping only wifi.rssi already brings it under budget),
+  // leaving the other half's sibling behind -- exactly the half-populated nested/flat
+  // mismatch the client can't tolerate (see the comment above).
+  if (in.wifiConnected && measureJson(doc) > outBufLen) {
+    wifi.remove("rssi");
+    doc.remove("wifi_rssi");
+  }
+  if (in.wifiConnected && measureJson(doc) > outBufLen) {
+    wifi.remove("ssid");
+    doc.remove("wifi_ssid");
+  }
+  while (measureJson(doc) > outBufLen) {
+    std::string fw = doc["firmware_version"].as<std::string>();
+    // Must stop at size()==0, not size()<=1: fw.size() is unsigned, and resize(size()-1)
+    // on an already-empty string underflows to SIZE_MAX rather than a negative number.
+    // A size-1 firmware_version legitimately needs one more shrink to empty -- confirmed
+    // live: a real build's version string ("1") left the whole reply exactly 1 byte over
+    // budget with nothing else left to trim, and stopping here at size<=1 silently
+    // shipped a truncated, unparseable JSON reply instead of fixing the one byte.
+    if (fw.empty()) break;  // give up rather than loop forever
+    fw.resize(fw.size() - 1);
+    doc["firmware_version"] = fw;
+  }
+  // "connected" before "saved": saved is the earlier, more foundational routing
+  // decision (whether to attempt provisioning at all vs. skip straight to the
+  // account-claim step), so it stays if only one of the two can survive.
+  if (measureJson(doc) > outBufLen) {
+    wifi.remove("connected");
+    doc.remove("wifi_connected");
+  }
+  if (measureJson(doc) > outBufLen) {
+    wifi.remove("saved");
+    doc.remove("wifi_saved");
+  }
+  if (measureJson(doc) > outBufLen) doc.remove("wifi");
+
+  if (measureJson(doc) > outBufLen) return 0;
+  return serializeJson(doc, outBuf, outBufLen);
+}
+
+}  // namespace BleCommandDispatcher

--- a/src/BleDeviceInfoPayload.h
+++ b/src/BleDeviceInfoPayload.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+// Hardware-independent half of device.info's reply: given already-resolved field
+// values, builds and budget-trims the JSON payload. Split out from
+// BleCommandDispatcher.cpp (which gathers the values from eFuse/HalGPIO/
+// BleWifiAutoConnectCache) so this trimming logic -- the part that has twice shipped
+// a real bug (dropping "saved" first, then leaving nested/flat pairs half-populated)
+// -- can be exercised by host-side unit tests without any ESP-IDF dependency. See
+// test/ble_device_info_payload/.
+namespace BleCommandDispatcher {
+
+struct DeviceInfoPayloadInput {
+  std::string serial;
+  std::string model;
+  std::string firmwareVersion;
+  bool claimed = false;
+  bool wifiSaved = false;
+  bool wifiConnected = false;
+  std::string wifiSsid;
+  int32_t wifiRssi = 0;
+};
+
+// Writes the device.info JSON reply into outBuf (capacity outBufLen) and returns the
+// serialized length, or 0 if it could not be made to fit even after trimming
+// everything trimmable. Never writes a truncated/unparseable prefix -- see the
+// priority-trim comment in the .cpp for why serializeJson() alone can't be trusted to
+// respect outBufLen.
+size_t buildDeviceInfoPayload(const DeviceInfoPayloadInput& in, char* outBuf, size_t outBufLen);
+
+}  // namespace BleCommandDispatcher

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,17 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# Pinned to the same version platformio.ini's [env:default]/[env:sticky]/[env:slim]
+# lib_deps use (bblanchon/ArduinoJson @ 7.4.2) so host tests exercise identical
+# trimming/serialization behavior to the firmware build.
+FetchContent_Declare(
+  ArduinoJson
+  GIT_REPOSITORY https://github.com/bblanchon/ArduinoJson.git
+  GIT_TAG v7.4.2
+)
+set(ARDUINOJSON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(ArduinoJson)
+
 set(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 add_library(crosspoint_test_common INTERFACE)
@@ -51,3 +62,4 @@ add_subdirectory(opds_filename)
 add_subdirectory(combining_marks)
 add_subdirectory(credential_integrity)
 add_subdirectory(token_boundary)
+add_subdirectory(ble_device_info_payload)

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -89,6 +89,7 @@ TEST(BuildDeviceInfoPayload, ConnectedPairNeverPartiallyPopulated) {
   for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
     const size_t len = buildDeviceInfoPayload(in, buf, budget);
     if (len == 0) continue;  // budget too tight to produce anything -- fine
+    ASSERT_LE(len, budget) << "budget=" << budget << " returned a reply larger than the requested budget";
     JsonDocument doc = parseValid(buf, len);
     const bool nestedHasConnected = doc["wifi"].is<JsonObject>() && doc["wifi"]["connected"].is<bool>();
     const bool flatHasConnected = doc["wifi_connected"].is<bool>();
@@ -103,7 +104,8 @@ TEST(BuildDeviceInfoPayload, SavedPairNeverPartiallyPopulated) {
   char buf[kMaxPayloadLen];
   for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
     const size_t len = buildDeviceInfoPayload(in, buf, budget);
-    if (len == 0) continue;
+    if (len == 0) continue;  // budget too tight to produce anything -- fine
+    ASSERT_LE(len, budget) << "budget=" << budget << " returned a reply larger than the requested budget";
     JsonDocument doc = parseValid(buf, len);
     const bool nestedHasSaved = doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>();
     const bool flatHasSaved = doc["wifi_saved"].is<bool>();
@@ -118,7 +120,8 @@ TEST(BuildDeviceInfoPayload, SsidRssiPairsNeverPartiallyPopulated) {
   char buf[kMaxPayloadLen];
   for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
     const size_t len = buildDeviceInfoPayload(in, buf, budget);
-    if (len == 0) continue;
+    if (len == 0) continue;  // budget too tight to produce anything -- fine
+    ASSERT_LE(len, budget) << "budget=" << budget << " returned a reply larger than the requested budget";
     JsonDocument doc = parseValid(buf, len);
     const bool nestedHasSsid = doc["wifi"].is<JsonObject>() && doc["wifi"]["ssid"].is<const char*>();
     const bool flatHasSsid = doc["wifi_ssid"].is<const char*>();
@@ -179,7 +182,8 @@ TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
   // Find a budget tight enough that at most one of connected/saved survives.
   for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
     const size_t len = buildDeviceInfoPayload(in, buf, budget);
-    if (len == 0) continue;
+    if (len == 0) continue;  // budget too tight to produce anything -- fine
+    ASSERT_LE(len, budget) << "budget=" << budget << " returned a reply larger than the requested budget";
     JsonDocument doc = parseValid(buf, len);
     const bool hasConnected =
         (doc["wifi"].is<JsonObject>() && doc["wifi"]["connected"].is<bool>()) || doc["wifi_connected"].is<bool>();

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <ArduinoJson.h>
+
+#include <string>
+
+#include "BleDeviceInfoPayload.h"
+
+namespace {
+
+using BleCommandDispatcher::buildDeviceInfoPayload;
+using BleCommandDispatcher::DeviceInfoPayloadInput;
+
+// Mirrors lib/hal/BlePeripheralManager.h's kMaxPayloadLen -- the real BLE GATT
+// payload budget every device.info reply must fit inside.
+constexpr size_t kMaxPayloadLen = 160;
+
+DeviceInfoPayloadInput baseInput() {
+  DeviceInfoPayloadInput in;
+  in.serial = "XTE-AABBCCDDEEFF";
+  in.model = "Xteink X3";
+  in.firmwareVersion = "1.2.3";
+  in.claimed = false;
+  in.wifiSaved = true;
+  in.wifiConnected = true;
+  in.wifiSsid = "HomeNetwork";
+  in.wifiRssi = -55;
+  return in;
+}
+
+// Parses the reply and asserts it's syntactically valid JSON, returning the parsed
+// document for further field assertions.
+JsonDocument parseValid(const char* buf, size_t len) {
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, buf, len);
+  EXPECT_EQ(err, DeserializationError::Ok) << "reply was not valid JSON: " << std::string(buf, len);
+  return doc;
+}
+
+// A generously large outBufLen (unlike the real 160-byte GATT budget) should trigger
+// no trimming at all -- both full Wi-Fi representations survive intact.
+TEST(BuildDeviceInfoPayload, NoTrimmingWhenBufferIsGenerous) {
+  char buf[512];
+  const size_t len = buildDeviceInfoPayload(baseInput(), buf, sizeof(buf));
+  ASSERT_GT(len, 0u);
+  JsonDocument doc = parseValid(buf, len);
+  EXPECT_TRUE(doc["wifi"]["connected"].is<bool>());
+  EXPECT_TRUE(doc["wifi"]["saved"].is<bool>());
+  EXPECT_TRUE(doc["wifi_connected"].is<bool>());
+  EXPECT_TRUE(doc["wifi_saved"].is<bool>());
+}
+
+// The actual production call site always passes outBufLen == kMaxPayloadLen -- this
+// is the case that must trim.
+TEST(BuildDeviceInfoPayload, NeverExceeds160BytesAtRealBudgetConnected) {
+  char buf[kMaxPayloadLen];
+  const size_t len = buildDeviceInfoPayload(baseInput(), buf, kMaxPayloadLen);
+  ASSERT_GT(len, 0u);
+  EXPECT_LE(len, kMaxPayloadLen);
+  JsonDocument doc = parseValid(buf, len);
+  EXPECT_STREQ(doc["cmd"], "device.info");
+}
+
+TEST(BuildDeviceInfoPayload, NeverExceeds160BytesAtRealBudgetDisconnected) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.wifiConnected = false;
+  in.wifiSsid.clear();
+  in.wifiRssi = 0;
+  char buf[kMaxPayloadLen];
+  const size_t len = buildDeviceInfoPayload(in, buf, kMaxPayloadLen);
+  ASSERT_GT(len, 0u);
+  EXPECT_LE(len, kMaxPayloadLen);
+  parseValid(buf, len);
+}
+
+// This is the exact scenario CodeRabbit flagged: a budget tight enough that removing
+// just ONE half of the connected pair (either wifi.connected or wifi_connected) would
+// already fit, which is precisely what the old two-independent-`if`s code did wrong.
+// We can't easily force that exact byte count from the real 160-byte constant with
+// today's field sizes (confirmed today's real payload fits after firmware_version
+// trimming alone), so this drives the budget down directly to probe the trimming
+// logic's atomicity independent of what the current mandatory-field sizes happen to
+// be -- verifying the *invariant* holds, not just today's specific measurements.
+TEST(BuildDeviceInfoPayload, ConnectedPairNeverPartiallyPopulated) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.wifiSsid = "AVeryLongNetworkNameThatTakesUpSpace";
+  char buf[kMaxPayloadLen];
+  // Sweep every budget from "everything fits" down to "almost nothing fits" and
+  // check the invariant at each point, rather than guessing one magic byte count.
+  for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
+    const size_t len = buildDeviceInfoPayload(in, buf, budget);
+    if (len == 0) continue;  // budget too tight to produce anything -- fine
+    JsonDocument doc = parseValid(buf, len);
+    const bool nestedHasConnected = doc["wifi"].is<JsonObject>() && doc["wifi"]["connected"].is<bool>();
+    const bool flatHasConnected = doc["wifi_connected"].is<bool>();
+    EXPECT_EQ(nestedHasConnected, flatHasConnected)
+        << "budget=" << budget << " nested/flat 'connected' pair is half-populated: " << std::string(buf, len);
+  }
+}
+
+TEST(BuildDeviceInfoPayload, SavedPairNeverPartiallyPopulated) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.wifiSsid = "AVeryLongNetworkNameThatTakesUpSpace";
+  char buf[kMaxPayloadLen];
+  for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
+    const size_t len = buildDeviceInfoPayload(in, buf, budget);
+    if (len == 0) continue;
+    JsonDocument doc = parseValid(buf, len);
+    const bool nestedHasSaved = doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>();
+    const bool flatHasSaved = doc["wifi_saved"].is<bool>();
+    EXPECT_EQ(nestedHasSaved, flatHasSaved)
+        << "budget=" << budget << " nested/flat 'saved' pair is half-populated: " << std::string(buf, len);
+  }
+}
+
+TEST(BuildDeviceInfoPayload, SsidRssiPairsNeverPartiallyPopulated) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.wifiSsid = "AVeryLongNetworkNameThatTakesUpSpace";
+  char buf[kMaxPayloadLen];
+  for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
+    const size_t len = buildDeviceInfoPayload(in, buf, budget);
+    if (len == 0) continue;
+    JsonDocument doc = parseValid(buf, len);
+    const bool nestedHasSsid = doc["wifi"].is<JsonObject>() && doc["wifi"]["ssid"].is<const char*>();
+    const bool flatHasSsid = doc["wifi_ssid"].is<const char*>();
+    EXPECT_EQ(nestedHasSsid, flatHasSsid)
+        << "budget=" << budget << " nested/flat 'ssid' pair is half-populated: " << std::string(buf, len);
+
+    const bool nestedHasRssi = doc["wifi"].is<JsonObject>() && doc["wifi"]["rssi"].is<int>();
+    const bool flatHasRssi = doc["wifi_rssi"].is<int>();
+    EXPECT_EQ(nestedHasRssi, flatHasRssi)
+        << "budget=" << budget << " nested/flat 'rssi' pair is half-populated: " << std::string(buf, len);
+  }
+}
+
+// "saved" is the most-protected field: it must survive trimming of the cosmetic
+// ssid/rssi fields and of firmware_version, and only get dropped (if ever) after
+// "connected" is already gone. Force this by giving firmware_version enough length
+// to guarantee those earlier trims are exercised before "saved" is at risk.
+TEST(BuildDeviceInfoPayload, SavedSurvivesAfterCosmeticAndFirmwareVersionTrim) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.firmwareVersion = "1.2.3-a-much-longer-development-build-string-than-shipped-versions-use";
+  char buf[kMaxPayloadLen];
+  const size_t len = buildDeviceInfoPayload(in, buf, kMaxPayloadLen);
+  ASSERT_GT(len, 0u);
+  EXPECT_LE(len, kMaxPayloadLen);
+  JsonDocument doc = parseValid(buf, len);
+  // firmware_version must actually have been shortened (proves the trim ran) while
+  // "saved" is still present somewhere (nested and/or flat).
+  const std::string fw = doc["firmware_version"] | std::string();
+  EXPECT_LT(fw.size(), in.firmwareVersion.size());
+  const bool savedPresent =
+      (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
+  EXPECT_TRUE(savedPresent);
+}
+
+// "connected" is dropped before "saved" when only one can survive.
+TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
+  DeviceInfoPayloadInput in = baseInput();
+  in.serial = "XTE-0011223344556677889900";  // deliberately oversized to force heavy trimming
+  in.model = "Xteink X3 Extended Model Name For Testing";
+  in.firmwareVersion = "1.2.3-a-much-longer-development-build-string-than-shipped-versions-use";
+  char buf[kMaxPayloadLen];
+  // Find a budget tight enough that at most one of connected/saved survives.
+  for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
+    const size_t len = buildDeviceInfoPayload(in, buf, budget);
+    if (len == 0) continue;
+    JsonDocument doc = parseValid(buf, len);
+    const bool hasConnected =
+        (doc["wifi"].is<JsonObject>() && doc["wifi"]["connected"].is<bool>()) || doc["wifi_connected"].is<bool>();
+    const bool hasSaved = (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
+    if (hasSaved && !hasConnected) {
+      // Found the priority boundary: saved survived, connected didn't. This is the
+      // required order -- test passes.
+      SUCCEED();
+      return;
+    }
+    ASSERT_FALSE(hasConnected && !hasSaved)
+        << "budget=" << budget << " 'connected' survived while 'saved' was dropped -- wrong priority order: "
+        << std::string(buf, len);
+  }
+}
+
+TEST(BuildDeviceInfoPayload, TooTightToFitReturnsZeroNotTruncatedJson) {
+  DeviceInfoPayloadInput in = baseInput();
+  char buf[8];
+  const size_t len = buildDeviceInfoPayload(in, buf, sizeof(buf));
+  EXPECT_EQ(len, 0u);
+}
+
+}  // namespace

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -151,6 +151,14 @@ TEST(BuildDeviceInfoPayload, SavedSurvivesAfterCosmeticAndFirmwareVersionTrim) {
   const bool savedPresent =
       (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
   EXPECT_TRUE(savedPresent);
+  // The test name claims cosmetic fields were trimmed -- prove it, not just infer it
+  // from firmware_version shrinking and saved surviving.
+  const bool ssidPresent =
+      (doc["wifi"].is<JsonObject>() && doc["wifi"]["ssid"].is<const char*>()) || doc["wifi_ssid"].is<const char*>();
+  const bool rssiPresent =
+      (doc["wifi"].is<JsonObject>() && doc["wifi"]["rssi"].is<int>()) || doc["wifi_rssi"].is<int>();
+  EXPECT_FALSE(ssidPresent);
+  EXPECT_FALSE(rssiPresent);
 }
 
 // "connected" is dropped before "saved" when only one can survive. Deliberately

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -145,12 +145,15 @@ TEST(BuildDeviceInfoPayload, SavedSurvivesAfterCosmeticAndFirmwareVersionTrim) {
   EXPECT_LE(len, kMaxPayloadLen);
   JsonDocument doc = parseValid(buf, len);
   // firmware_version must actually have been shortened (proves the trim ran) while
-  // "saved" is still present somewhere (nested and/or flat).
+  // "saved" survives in its preferred nested form -- the shipped client reads nested
+  // wifi.saved whenever "wifi" is present at all (see the atomicity comment in
+  // BleDeviceInfoPayload.cpp), so this is the representation that actually matters
+  // for this test's specific budget/pressure, not just "present somewhere."
   const std::string fw = doc["firmware_version"] | std::string();
   EXPECT_LT(fw.size(), in.firmwareVersion.size());
-  const bool savedPresent =
-      (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
-  EXPECT_TRUE(savedPresent);
+  ASSERT_TRUE(doc["wifi"].is<JsonObject>());
+  EXPECT_TRUE(doc["wifi"]["saved"].is<bool>());
+  EXPECT_TRUE(doc["wifi"]["saved"].as<bool>());
   // The test name claims cosmetic fields were trimmed -- prove it, not just infer it
   // from firmware_version shrinking and saved surviving.
   const bool ssidPresent =

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -153,12 +153,17 @@ TEST(BuildDeviceInfoPayload, SavedSurvivesAfterCosmeticAndFirmwareVersionTrim) {
   EXPECT_TRUE(savedPresent);
 }
 
-// "connected" is dropped before "saved" when only one can survive.
+// "connected" is dropped before "saved" when only one can survive. Deliberately
+// keeps serial/model at their real fixed-format sizes (neither ever shrinks in
+// production -- an oversized serial/model here would just push the doc's floor high
+// enough that connected+saved always get removed together, never exposing the
+// boundary this test exists to check). firmwareVersion is the field that's actually
+// arbitrary-length in practice, so it's the one padded out to force heavy trimming.
 TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
   DeviceInfoPayloadInput in = baseInput();
-  in.serial = "XTE-0011223344556677889900";  // deliberately oversized to force heavy trimming
-  in.model = "Xteink X3 Extended Model Name For Testing";
-  in.firmwareVersion = "1.2.3-a-much-longer-development-build-string-than-shipped-versions-use";
+  in.firmwareVersion =
+      "1.2.3-a-much-longer-development-build-string-than-shipped-versions-use-padded-to-be-extremely-long-for-"
+      "testing-purposes-only";
   char buf[kMaxPayloadLen];
   // Find a budget tight enough that at most one of connected/saved survives.
   for (size_t budget = kMaxPayloadLen; budget >= 40; --budget) {
@@ -179,6 +184,8 @@ TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
         << "budget=" << budget
         << " 'connected' survived while 'saved' was dropped -- wrong priority order: " << std::string(buf, len);
   }
+  FAIL() << "never found a budget where 'saved' survived without 'connected' -- the sweep didn't exercise the "
+            "priority boundary this test exists to check";
 }
 
 TEST(BuildDeviceInfoPayload, TooTightToFitReturnsZeroNotTruncatedJson) {

--- a/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
+++ b/test/ble_device_info_payload/BleDeviceInfoPayloadTest.cpp
@@ -1,6 +1,5 @@
-#include <gtest/gtest.h>
-
 #include <ArduinoJson.h>
+#include <gtest/gtest.h>
 
 #include <string>
 
@@ -168,7 +167,8 @@ TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
     JsonDocument doc = parseValid(buf, len);
     const bool hasConnected =
         (doc["wifi"].is<JsonObject>() && doc["wifi"]["connected"].is<bool>()) || doc["wifi_connected"].is<bool>();
-    const bool hasSaved = (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
+    const bool hasSaved =
+        (doc["wifi"].is<JsonObject>() && doc["wifi"]["saved"].is<bool>()) || doc["wifi_saved"].is<bool>();
     if (hasSaved && !hasConnected) {
       // Found the priority boundary: saved survived, connected didn't. This is the
       // required order -- test passes.
@@ -176,8 +176,8 @@ TEST(BuildDeviceInfoPayload, ConnectedDroppedBeforeSavedUnderExtremePressure) {
       return;
     }
     ASSERT_FALSE(hasConnected && !hasSaved)
-        << "budget=" << budget << " 'connected' survived while 'saved' was dropped -- wrong priority order: "
-        << std::string(buf, len);
+        << "budget=" << budget
+        << " 'connected' survived while 'saved' was dropped -- wrong priority order: " << std::string(buf, len);
   }
 }
 

--- a/test/ble_device_info_payload/CMakeLists.txt
+++ b/test/ble_device_info_payload/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(BleDeviceInfoPayloadTest
+  BleDeviceInfoPayloadTest.cpp
+  ${REPO_ROOT}/src/BleDeviceInfoPayload.cpp
+)
+
+target_include_directories(BleDeviceInfoPayloadTest PRIVATE
+  ${REPO_ROOT}/src
+)
+
+target_link_libraries(BleDeviceInfoPayloadTest PRIVATE
+  crosspoint_test_common
+  ArduinoJson
+  GTest::gtest_main
+)
+
+gtest_discover_tests(BleDeviceInfoPayloadTest)


### PR DESCRIPTION
## Summary

Found during `MIDAD-E2E-TF168-001`'s real-iPhone end-to-end setup test (PR #168 follow-up).

`handleDeviceInfo()`'s trim-priority order dropped `wifi.saved` (both nested and flat forms) first when the reply didn't fit the 160-byte BLE budget, on the assumption nothing shipped read it yet. That assumption was wrong: the shipped `foulad-one` app's `BleProvisionScreen` decides whether to show the manual Wi-Fi entry form from exactly this field. A reader with a longer `firmware_version` string (or any other pressure on the budget) had `wifi.saved` trimmed away before the app ever saw it -- making a reader with saved credentials look like it had none, sending every setup attempt through the manual form instead of skipping past it.

Reordered so cosmetic `ssid`/`rssi` fields (nested and flat) and `firmware_version` give up the budget first; `wifi.saved`/`wifi.connected` (a few bytes each) now survive as long as possible, with `saved` protected longer than `connected` since it's the earlier, more foundational routing decision.

## Test plan

- [x] `pio run -e default` -- build succeeds
- [x] `pio check -e default` (cppcheck) -- no defects
- [x] `./bin/clang-format-fix` -- clean
- [x] Hardware (real X3): `device.info` reply that previously came back as `"wifi":{},"wifi_connected":false` (both saved fields trimmed) now returns `"wifi":{"saved":true},"wifi_saved":true`, correctly reflecting the reader's actual 3 saved credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KutP9jXvzNMMoxHSrx9q7e