### PR TITLE
fix: move SNTP shutdown behind HalClock

### DIFF
--- a/lib/hal/HalClock.cpp
+++ b/lib/hal/HalClock.cpp
@@ -111,6 +111,12 @@ bool HalClock::quickSyncSystemTime() {
   return false;
 }
 
+void HalClock::stopSntp() {
+  if (esp_sntp_enabled()) {
+    esp_sntp_stop();
+  }
+}
+
 bool HalClock::writeTimeToRTC(uint8_t hour, uint8_t minute, uint8_t second) {
   // DS3231 on this board only ever surfaces hour/minute back out (see getTime()) --
   // the date fields keep DateTime's harmless in-struct defaults (Rtc.h) rather than

--- a/lib/hal/HalClock.h
+++ b/lib/hal/HalClock.h
@@ -56,6 +56,12 @@ class HalClock {
   // whenever isSystemTimeValid() is false; a no-op if WiFi isn't connected yet.
   static bool quickSyncSystemTime();
 
+  // Stops the SNTP client in place, if running. A no-op otherwise. Used when tearing
+  // down the network stack without a full chip reset (touch devices skip the reset
+  // to keep externally powered peripherals from cycling) -- see
+  // finishWifiSessionWithoutRestart() in main.cpp.
+  static void stopSntp();
+
  private:
   bool writeTimeToRTC(uint8_t hour, uint8_t minute, uint8_t second);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,9 +27,6 @@
 #include <WiFi.h>
 #include <XteinkDetect.h>
 #include <builtinFonts/all.h>
-#if FREEINK_CAP_TOUCH
-#include <esp_sntp.h>
-#endif
 
 #include <cstring>
 
@@ -266,9 +263,7 @@ static bool finishWifiSessionWithoutRestart() {
 
   // A software reset does not cycle externally powered touch/frontlight rails.
   // Shut down the network stack in place so those peripherals retain state.
-  if (esp_sntp_enabled()) {
-    esp_sntp_stop();
-  }
+  HalClock::stopSntp();
   WiFi.mode(WIFI_OFF);
   delay(100);
   LOG_DBG("MAIN", "WiFi stopped without restart on touch device");


### PR DESCRIPTION
## Summary

- `finishWifiSessionWithoutRestart()` in `src/main.cpp` called `esp_sntp_enabled()`/`esp_sntp_stop()` directly, bypassing the HAL boundary the project's architecture guide requires ("Always use HAL classes, NOT SDK classes directly").
- Adds `HalClock::stopSntp()` (static, no instance state — matches the existing `isSystemTimeValid()`/`quickSyncSystemTime()` convention) and routes the touch-device WiFi-teardown path through it.
- Removes the now-unused `#include <esp_sntp.h>` (and its now-empty `#if FREEINK_CAP_TOUCH` guard) from `main.cpp`.

Closes #175.

## Test plan

- [x] `pio run -e default` — SUCCESS
- [x] `pio run -e sticky` (touch-capable env, exercises the changed `FREEINK_CAP_TOUCH` code path) — SUCCESS
- [x] `pio check -e default` (cppcheck) — No defects found
- [x] Host unit test suite (`ctest --test-dir build/test`) — 183/183 passed
- [x] `./bin/clang-format-fix -g` (against `llvm@21`, matching CI) — no changes needed
- [ ] On-device validation (flagged for human tester per project testing checklist — no behavior change to SNTP semantics, only the call-site owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)