### PR TITLE
fix: pin release/CI workflow GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -75,7 +75,9 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Read commit subject
         id: check
@@ -100,8 +102,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           submodules: recursive
           # Full history + tags: the next version is derived from existing tags,
           # which a shallow clone would not have.
@@ -133,12 +136,12 @@ jobs:
           sed -i "s/^version = .*/version = ${{ steps.version.outputs.next }}/" platformio.ini
           grep -m1 '^version = ' platformio.ini
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: false
@@ -147,11 +150,16 @@ jobs:
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
       - name: Cache PlatformIO packages
-        uses: actions/cache@v4
+        # Namespaced separately from ci.yml's `pio-*` cache: this job signs firmware
+        # with OTA_SIGNING_KEY, so it must never restore a cache entry that untrusted
+        # PR-triggered CI could have populated (cache poisoning). The prefixes never
+        # overlap, so a restore-keys prefix match can't cross between them in either
+        # direction.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.platformio
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-${{ runner.os }}-
+          key: signed-release-pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: signed-release-pio-${{ runner.os }}-
 
       - name: Build CrossPoint Release Candidate
         env:
@@ -172,7 +180,7 @@ jobs:
         run: ./scripts/sign_firmware.sh .pio/build/gh_release_rc/firmware.bin ota-signing-public-key.pem
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: CrossPoint-RC-${{ steps.version.outputs.next }}
           path: |
@@ -183,7 +191,7 @@ jobs:
             .pio/build/gh_release_rc/partitions.bin
 
       - name: Publish GitHub Pre-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           # firmware.bin only, matching release.yml, so ReleaseJsonParser and
           # OtaUpdater need no per-channel special-casing. Devices with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: false
@@ -97,7 +97,7 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
@@ -135,7 +135,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: false
@@ -152,7 +152,7 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
@@ -197,7 +197,7 @@ jobs:
           sudo apt-get install -y cmake ninja-build
 
       - name: Cache googletest source
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: build/test/_deps/googletest-src
           key: ${{ runner.os }}-googletest-${{ hashFiles('test/CMakeLists.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.13'
 
@@ -56,11 +56,11 @@ jobs:
   ota-signing-flags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.13'
 
@@ -70,12 +70,12 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.13'
 
@@ -125,12 +125,12 @@ jobs:
           - env: papermono
             asset: firmware-papermono.bin
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.13'
 
@@ -177,7 +177,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload firmware artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ matrix.asset }}
           path: .pio/build/${{ matrix.env }}/firmware.bin
@@ -186,7 +186,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
@@ -58,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -72,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
@@ -127,6 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
@@ -188,6 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           submodules: recursive
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -57,11 +58,16 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
+        # Namespaced separately from ci.yml's `pio-*` cache: this job signs firmware
+        # with OTA_SIGNING_KEY, so it must never restore a cache entry that untrusted
+        # PR-triggered CI could have populated (cache poisoning). The prefixes never
+        # overlap, so a restore-keys prefix match can't cross between them in either
+        # direction.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-${{ runner.os }}-
+          key: signed-release-pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: signed-release-pio-${{ runner.os }}-
 
       - name: Build CrossPoint
         run: pio run -e ${{ matrix.pio_env }} -j1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         run: ./scripts/sign_firmware.sh ".pio/build/${{ matrix.pio_env }}/${{ matrix.asset }}" ota-signing-public-key.pem
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.asset }}
           path: |
@@ -98,7 +98,7 @@ jobs:
             .pio/build/${{ matrix.pio_env }}/partitions.bin
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           # OtaUpdater.cpp looks up releases/latest and matches an asset named
           # exactly "firmware.bin" (ReleaseJsonParser.cpp:47) for the primary C3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
           - pio_env: papermono-gh_release
             asset: firmware-papermono.bin
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: false
@@ -57,7 +57,7 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           submodules: recursive
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -48,11 +49,16 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
+        # Namespaced separately from ci.yml's `pio-*` cache: this job signs firmware
+        # with OTA_SIGNING_KEY, so it must never restore a cache entry that untrusted
+        # PR-triggered CI could have populated (cache poisoning). The prefixes never
+        # overlap, so a restore-keys prefix match can't cross between them in either
+        # direction.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-${{ runner.os }}-
+          key: signed-release-pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: signed-release-pio-${{ runner.os }}-
 
       - name: Extract env
         run: |

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -22,16 +22,16 @@ jobs:
           - pio_env: papermono-gh_release_rc
             asset: firmware-papermono.bin
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: false
@@ -48,7 +48,7 @@ jobs:
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
       - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.platformio
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./scripts/sign_firmware.sh ".pio/build/${{ matrix.pio_env }}/${{ matrix.asset }}" ota-signing-public-key.pem
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: CrossPoint-RC-${{ env.BRANCH_SUFFIX }}-${{ matrix.pio_env }}
           path: |
@@ -97,7 +97,7 @@ jobs:
             .pio/build/${{ matrix.pio_env }}/partitions.bin
 
       - name: Publish GitHub Pre-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           # Settings -> System -> Pre-release opts a device into checking GitHub's
           # full /releases list (includes pre-releases) instead of /releases/latest,


### PR DESCRIPTION
## Summary

Pins **every** mutable-tag `uses:` reference across **four** workflow files — `.github/workflows/ci.yml`, `release.yml`, `release_candidate.yml`, and `auto-release.yml` — to a reviewed, immutable 40-char commit SHA. Also disables checkout credential persistence on every checkout step, and isolates the three signed-release workflows' PlatformIO cache from the generic CI cache namespace. Based on `develop @ b0c1f519c7dc9d20e6ee57cb36f790d37aead0be`.

**Scope history**: started as #173 + #174's literal citations (checkout/setup-python in ci.yml, upload-artifact + action-gh-release in the two release workflows) → expanded to the remaining mutable references in the same three files (astral-sh/setup-uv, actions/cache, and the release workflows' own checkout/setup-python) → expanded again to add `auto-release.yml` (previously out of scope) once CodeRabbit's cache-poisoning finding was confirmed valid there too, plus `persist-credentials: false` across all four files for CodeRabbit's one surviving actionable finding.

## SHA provenance — tag-to-SHA mapping (independently verified)

Every SHA was looked up directly via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` against the action's own official repository.

| Action | Tag | Verified commit SHA | Note |
|---|---|---|---|
| `actions/checkout` | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | Lightweight tag → direct commit |
| `actions/setup-python` | `v7` | `5fda3b95a4ea91299a34e894583c3862153e4b97` | Lightweight tag → direct commit |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | Lightweight tag → direct commit |
| `actions/upload-artifact` | `v6` | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` | Lightweight tag → direct commit |
| `softprops/action-gh-release` | `v3` | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` | **Annotated** tag — dereferenced one hop further |
| `astral-sh/setup-uv` | `v7` | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` | **Annotated** tag — dereferenced one hop further |
| `actions/cache` | `v6` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | Lightweight tag → direct commit (ci.yml, release.yml, release_candidate.yml) |
| `actions/cache` | `v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` | Lightweight tag → direct commit (`auto-release.yml` only — resolved separately, **not** the v6 SHA above; auto-release.yml genuinely pins a different major version) |

## Full inventory — corrected counts, zero remaining unpinned

**Correcting an earlier report in this PR's history**: the original description undercounted `actions/setup-python@v7` as 5× when it is actually 6× (4 in ci.yml + 1 each in release.yml/release_candidate.yml), making the three-file total 27, not 26. With `auto-release.yml` now included, the grand total across all four files is **34**:

| Action | ci.yml | release.yml | release_candidate.yml | auto-release.yml | Total |
|---|---|---|---|---|---|
| `checkout@v7` | 5 | 1 | 1 | 2 | 9 |
| `setup-python@v7` | 4 | 1 | 1 | 1 | 7 |
| `setup-uv@v7` | 2 | 1 | 1 | 1 | 5 |
| `cache@v6` / `cache@v4` | 3 (v6) | 1 (v6) | 1 (v6) | 1 (v4) | 6 |
| `upload-artifact@v4` | — | 1 | 1 | 1 | 3 |
| `upload-artifact@v6` | 1 | — | — | — | 1 |
| `action-gh-release@v3` | — | 1 | 1 | 1 | 3 |
| **File total** | **15** | **6** | **6** | **7** | **34** |

```
$ grep -n "uses:" .github/workflows/{ci,release,release_candidate,auto-release}.yml | grep -vE '@[a-f0-9]{40} #'
(no output — 0 matches)
```

Python/PlatformIO dependency locking (issue #172) remains untouched — not in scope here.

## Checkout credential persistence — 9/9 disabled

`persist-credentials: false` added to all 9 `actions/checkout` steps (5 ci.yml, 1 release.yml, 1 release_candidate.yml, 2 auto-release.yml). CI runs repository-controlled code on `pull_request`; the three release workflows carry `contents: write` plus `OTA_SIGNING_KEY`. None of the 9 steps need an authenticated git config left behind for later steps. This was CodeRabbit's one actionable finding on this PR — fixed, replied to, and the review thread resolved.

## Signed-release cache isolation

`release.yml`, `release_candidate.yml`, and `auto-release.yml` now key their PlatformIO cache as `signed-release-pio-<os>-<hash>` (was `pio-<os>-<hash>`, identical to `ci.yml`'s own cache key). `ci.yml`'s cache is untouched — it's the generic, PR-writable namespace this isolation exists to keep separate. The two prefixes (`pio-` vs `signed-release-pio-`) never overlap, so a `restore-keys` prefix match can't cross between them in either direction: a cache entry an untrusted PR populated via `ci.yml` can no longer be restored into a job that signs firmware with `OTA_SIGNING_KEY`. Caching behavior is otherwise unchanged (same `actions/cache` version per file, same `path`, same hash-based key structure).

## Diff (3 commits total on this PR)

Commit 3 (this update): 4 files changed, 38 insertions(+), 13 deletions(-) — `persist-credentials: false` lines, cache-key/restore-key changes + explanatory comments, and `auto-release.yml`'s full pinning pass. Every trigger, permission, condition, job step ordering, and non-cache/non-checkout `with:` value is byte-identical to before across all three commits.

## Validation (re-run after this expansion)

- [x] YAML syntax: clean on all four files
- [x] `actionlint`: zero new findings. Pre-existing shellcheck notes on `release_candidate.yml`'s "Extract env" script (SC2086/SC2129) and `auto-release.yml`'s "Compute next version" script (SC2129) both reproduced identically against `origin/develop` before this PR touched either file, confirming both predate this work
- [x] `scripts/test-thin-fork-guard.sh` — 141/141 assertions pass

## CodeRabbit thread status

The one actionable finding (`persist-credentials: false`) has been replied to with the fix commit and **resolved**. 0 unresolved threads remain as of this update. A fresh CodeRabbit review will be triggered on this new head once CI settles.

## Expected thin-fork-guard failure — security-boundary file, admin merge required

`.github/workflows/ci.yml` is listed in `thin-fork-guard.sh`'s `SECURITY_BOUNDARY_FILES`. The `thin-fork-guard-trusted` **StatusContext** (the actual ruleset-enforced check, distinct from the Actions job of the same name which always exits 0 by design) fails by design on every commit in this PR — confirmed by reading the trusted evaluator's own run log directly. This is the guard functioning as designed.

Landing this requires the same human security-boundary maintenance procedure as PR #154/#171/#177: snapshot ruleset `20797779` → temporarily drop only `thin-fork-guard-trusted` from required status checks → merge with "Create a merge commit" → restore the check immediately → byte-diff the restored ruleset against the snapshot. I do not have tool permission to modify the ruleset myself; that step stays manual.

**This PR stays draft and unmerged pending explicit go-ahead.** The manual ruleset procedure has not been started, and issue #172 has not been started.

Closes #173.
Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)