### PR TITLE
fix: unblock desktop simulator builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -279,6 +279,11 @@ build_src_filter =
   -<network/OtaUpdater.cpp>
   -<network/WebDAVHandler.cpp>
   -<platform/skip_efuse_blk_check.c>
+  ; ESP-IDF bootloader-only (esp_secure_boot.h, __wrap_esp_secure_boot_init_checks
+  ; link-time wrap): PR #163's boot-time OTA-signing guard has no host equivalent
+  ; and was never added to this exclusion list, breaking every simulator build
+  ; since it landed.
+  -<OtaSigningBootGuard.cpp>
   ; No simulator-side counterpart for lib/hal/BlePeripheralManager (see
   ; docs/ble-module-tasks.md) -- unlike the network/ files above, this one has no
   ; host-backed shim to fall back to, since BLE peripheral advertising has no
@@ -320,6 +325,15 @@ extra_scripts =
   pre:scripts/build_html.py
 lib_deps =
   simulator=https://github.com/crosspoint-reader/crosspoint-simulator
+  ; Both required by src/components/UiAppHost.h/UiAppHelpers.h (FreeInkApp.h) --
+  ; upstream CrossPoint has the same dependency and documents both symlink
+  ; entries in the simulator library's own sample-platformio-*.ini, but they
+  ; were never carried over into this project's [env:simulator]/[env:simulator_x3].
+  ; Not a stale simulator pin (the fetched simulator commit already matches
+  ; crosspoint-reader/crosspoint-simulator's current HEAD) -- purely a missing
+  ; local lib_deps declaration.
+  FreeInkUI=symlink://freeink-sdk/libs/ui/FreeInkUI
+  Icons=symlink://freeink-sdk/libs/assets/Icons
   bblanchon/ArduinoJson @ 7.4.2
   ricmoo/QRCode @ ^0.0.1
   links2004/WebSockets @ 2.7.3
@@ -344,6 +358,11 @@ build_src_filter =
   -<network/OtaUpdater.cpp>
   -<network/WebDAVHandler.cpp>
   -<platform/skip_efuse_blk_check.c>
+  ; ESP-IDF bootloader-only (esp_secure_boot.h, __wrap_esp_secure_boot_init_checks
+  ; link-time wrap): PR #163's boot-time OTA-signing guard has no host equivalent
+  ; and was never added to this exclusion list, breaking every simulator build
+  ; since it landed.
+  -<OtaSigningBootGuard.cpp>
   ; No simulator-side counterpart for lib/hal/BlePeripheralManager (see
   ; docs/ble-module-tasks.md) -- unlike the network/ files above, this one has no
   ; host-backed shim to fall back to, since BLE peripheral advertising has no
@@ -386,6 +405,15 @@ extra_scripts =
   pre:scripts/build_html.py
 lib_deps =
   simulator=https://github.com/crosspoint-reader/crosspoint-simulator
+  ; Both required by src/components/UiAppHost.h/UiAppHelpers.h (FreeInkApp.h) --
+  ; upstream CrossPoint has the same dependency and documents both symlink
+  ; entries in the simulator library's own sample-platformio-*.ini, but they
+  ; were never carried over into this project's [env:simulator]/[env:simulator_x3].
+  ; Not a stale simulator pin (the fetched simulator commit already matches
+  ; crosspoint-reader/crosspoint-simulator's current HEAD) -- purely a missing
+  ; local lib_deps declaration.
+  FreeInkUI=symlink://freeink-sdk/libs/ui/FreeInkUI
+  Icons=symlink://freeink-sdk/libs/assets/Icons
   bblanchon/ArduinoJson @ 7.4.2
   ricmoo/QRCode @ ^0.0.1
   links2004/WebSockets @ 2.7.3


### PR DESCRIPTION
## Summary
Prerequisite tooling fix, split out per explicit instruction from the Apps-launcher redesign PR (#190) it was originally needed for. `pio run -e simulator` / `-e simulator_x3` currently fail to build at all, unrelated to any specific feature branch.

Root cause was NOT a stale simulator package pin — the fetched `crosspoint-simulator` commit already matches upstream's current HEAD (`8323320`, verified via `git ls-remote`). It's a local configuration gap:

1. `[env:simulator]`/`[env:simulator_x3]` never declared the `FreeInkUI`/`Icons` symlink `lib_deps` entries that `src/components/UiAppHost.h`/`UiAppHelpers.h` (`FreeInkApp.h`) need. Upstream CrossPoint has this exact dependency too, and the simulator library's own `sample-platformio-*.ini` documents both entries — they were simply never carried into this project's `platformio.ini`.
2. `OtaSigningBootGuard.cpp` (PR #163, ESP-IDF bootloader-only, `esp_secure_boot.h`) was never added to either env's `build_src_filter` exclusion list, unlike the other OTA-boot-related files already excluded right above it.

## Out of scope
Investigated the simulator's HAL-stub gaps this surfaced (`HalClock::isSystemTimeValid/stopSntp`, `esp_http_client_get_url/delete_header`, `HalSystem::noteHeap`, `HalDisplay::displayBuffer`'s `forceCleanBaseOnHalf` param) — all confirmed Midad-only additions with no upstream counterpart. Those live in the separately-versioned `crosspoint-reader/crosspoint-simulator` package, not this repo, so they're patched only in the local `.pio/libdeps` cache for verification purposes here and are candidates for a future upstream contribution to that repo, not part of this PR.

## Test plan
- [x] `pio run -e simulator` builds and links clean
- [x] `pio run -e simulator_x3` builds and links clean
- [x] Both verified end-to-end: navigated Home -> Apps via scripted input (`CROSSPOINT_SIM_INPUT_SCRIPT`) and captured screenshots (`CROSSPOINT_SIM_SCREENSHOTS`) — used to produce the Apps-redesign screenshots in #190
- [ ] CI green
- [ ] CodeRabbit review resolved

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>