### PR TITLE
chore: authorize the USB icon generated pair via reviewed-upstream-backport

### DIFF
--- a/scripts/reviewed-upstream-backports.tsv
+++ b/scripts/reviewed-upstream-backports.tsv
@@ -33,3 +33,36 @@
 # the path now. Removed per docs/upstream-sync-architecture.md's "Reviewed
 # upstream backport" section and the maintenance note in that same section
 # of CLAUDE.md's "Midad Thin-Fork Architecture".
+
+# --- Active records ---
+#
+# CrossPoint 218dc6aaf1fc8638d5434e6c071f2784ea2bb1da
+#   "feat: add usb mass storage mode for x4 pro (#3203)"
+#
+# Why these two paths, and why now: adopting CrossPoint's touch-capable
+# WifiSelectionActivity/OptionPopup for X4 Pro requires upstream's
+# UiAppHelpers.h byte-identical, which resolves UIIcon::Usb to icon_usb_24/32.
+# Those two icons live in the generated listIcons.h and its manifest, and were
+# added upstream by the commit above -- AFTER the 69dd947f sync baseline, so
+# both paths were clean relative to shared upstream history and an ordinary
+# adoption reads as new Midad-side divergence.
+#
+# The generated pair is recorded together deliberately: listIcons.h is
+# generated from listIcons.manifest (gen_icons.py), so authorizing the
+# generated output without its source would leave the two able to drift.
+#
+# Both paths satisfy the documented rules exactly:
+#   - single-parent commit (verified: rev-list --parents yields 2 words)
+#   - ancestor of live crosspoint-reader/develop
+#   - the commit touches both paths
+#   - Midad's base blob for each path is byte-identical to the commit's own
+#     parent blob, and the commit's post blob is still live upstream's blob
+#     today (nothing has touched either path since), so the isolated per-path
+#     patch reproduces the recorded head blob exactly.
+#
+# This authorizes exactly these two file states and nothing else. It
+# self-invalidates the moment a real CrossPoint sync merge absorbs 218dc6aa as
+# genuine ancestry, at which point ordinary HEAD==UPSTREAM convergence covers
+# both paths and these records must be removed.
+src/components/icons/listIcons.h	218dc6aaf1fc8638d5434e6c071f2784ea2bb1da	1b88c724ebd4e8a8fe9ad76ffeac5953a2d2baf4	30272589e4b1c4238f732ce7e2e8db5063e6eb2e	USB icon for UIIcon::Usb, required by upstream UiAppHelpers.h (X4 Pro touch Wi-Fi/popup adoption)
+src/components/icons/listIcons.manifest	218dc6aaf1fc8638d5434e6c071f2784ea2bb1da	0f4d875ea52cc0e71614c4a78a3cd1733eec5160	96f0354632a2484ce980c091837b524c5ca8f32e	Generator source for listIcons.h above; recorded together so the pair cannot drift


### PR DESCRIPTION
## Guard / security-boundary maintenance — requires the documented admin procedure

**This PR contains only two `scripts/reviewed-upstream-backports.tsv` records. No source changes.** One file, +33 lines (30 of which are the explanatory header).

`thin-fork-guard` **will fail this PR** with `security-boundary file modified`. That is by design and is exactly the case `docs/upstream-sync-architecture.md` → "Security-boundary file maintenance" describes: the TSV is in `SECURITY_BOUNDARY_FILES`, so no ordinary PR can modify it.

### Admin procedure required

1. Identify as guard maintenance, not an ordinary PR ✔ (this PR)
2. Temporarily relax the required check — ruleset `enforcement: disabled`, or drop `thin-fork-guard-trusted` from the required contexts
3. Merge this PR (its guard verdict will report the security-boundary FAIL; that's the deliberately relaxed gate)
4. **Immediately restore the ruleset**
5. Not applicable — this touches only the TSV, not the evaluator logic (`thin-fork-guard.sh`, `measure-conflicts.sh`, `check-workflow-permissions.rb`, `test-thin-fork-guard.sh`, or the trusted workflow), so the disposable-PR re-validation sequence is not triggered

### What it authorizes and why

CrossPoint `218dc6aaf1fc8638d5434e6c071f2784ea2bb1da` — *"feat: add usb mass storage mode for x4 pro"* (#3203) — added `icon_usb_24/32` to the generated `listIcons.h` and its manifest, **after** the `69dd947f` sync baseline.

Adopting upstream's `UiAppHelpers.h` byte-identical (needed for CrossPoint's touch-capable `WifiSelectionActivity`/`OptionPopup` on X4 Pro, which resolve `UIIcon::Usb`) requires those icons. Both paths were clean relative to shared upstream history, so a plain adoption correctly reads as new Midad-side divergence — the guard was right to stop it.

The **complete generated pair** is recorded — the `.h` *and* its `.manifest` generator source — so the two cannot drift.

### Verification (re-run independently against live git objects)

| Rule | `listIcons.h` | `listIcons.manifest` |
|---|---|---|
| 5 TSV fields | OK | OK |
| commit resolves | OK | OK |
| single-parent commit | OK | OK |
| ancestor of live `crosspoint-reader/develop` | OK | OK |
| commit touches the path | OK | OK |
| base blob == commit's own parent blob | OK `1b88c724…` | OK `0f4d875e…` |
| head blob == live upstream blob today | OK `30272589…` | OK `96f03546…` |

Because nothing has touched either path since `218dc6aa`, the isolated per-path patch reproduces the recorded head blob exactly — step 7 of `verify_reviewed_backport()`.

### Self-invalidation

These records stop doing any work the moment a real CrossPoint sync absorbs `218dc6aa` as genuine ancestry; ordinary `HEAD==UPSTREAM` convergence covers both paths then, and they must be removed — the same trigger that retired the previous `TxtReaderActivity.cpp` record.

**Guard logic untouched. No path exemption. No CI relaxation in the repo itself.**
