### PR TITLE
ci: mandatory Update Survivability Gate on firmware update-path PRs

### DIFF
--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -119,6 +119,7 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
           set -euo pipefail
 
@@ -152,8 +153,23 @@ jobs:
           fi
           echo "Changed files: $file_count"
 
-          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/labels" \
-            --jq '.[].name' > labels.txt || true
+          # Labels come from the event payload, not the API. There is no
+          # `pulls/{n}/labels` route -- it 404s (verified against this repo:
+          # `pulls/214/labels` -> 404, `issues/214/labels` -> the list) -- and
+          # the original spelling swallowed that 404, producing a silently
+          # empty labels.txt. The label-driven UI escalation was therefore
+          # dead in production while the step still reported success.
+          #
+          # The issues endpoint would work but needs an `issues: read` scope
+          # this workflow deliberately does not hold. The payload carries the
+          # same list, already, for free, and stays correct on the `labeled`
+          # and `unlabeled` events that exist precisely to re-run this gate.
+          # Like PR_TITLE and PR_BODY it is untrusted data delivered through
+          # `env:`, never interpolated into this script.
+          if ! printf '%s' "$PR_LABELS" | jq -r '.[].name' > labels.txt; then
+            echo "::warning::could not parse PR labels; continuing without label-based escalation"
+            : > labels.txt
+          fi
 
           # Evidence = the PR body, plus the content of any hardware
           # validation report the PR adds or edits. Report content is read

--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -54,8 +54,9 @@ name: Update Survivability Gate
 # of scripts/update-survivability-gate.sh, so a PR could edit the gate to pass
 # itself. This workflow checks out the BASE branch and runs only its copy. It
 # never checks out, builds, or executes anything from PR HEAD -- the diff, the
-# labels, the title and the body all arrive as inert DATA through the GitHub
-# API and the event payload, and every one of them is routed through `env`
+# labels, the title, the body and the review list all arrive as inert DATA
+# through the GitHub API and the event payload, and every one of them is
+# routed through `env`
 # rather than `${{ }}` string interpolation (a PR title and body are
 # attacker-controlled free text; inline interpolation into a shell script is
 # the classic Actions injection vector).
@@ -69,12 +70,44 @@ name: Update Survivability Gate
 # actually establish is precisely the bug that bricked the device; applying
 # the opposite posture to the CI that guards it is the point.
 #
-# Permissions note: this workflow deliberately grants only `contents: read`
-# and `pull-requests: read`. It must never request `statuses: write`,
-# `checks: write` or `write-all` -- scripts/thin-fork-guard.sh's
-# workflow-permission audit (gate 7) fails any PR that introduces a second
-# workflow able to spoof the trusted required status, and this workflow is
-# audited by it like any other.
+# Design decision 4: the result is PUBLISHED against the PR head SHA
+# ------------------------------------------------------------------
+# Same mechanism as thin-fork-guard-trusted.yml's "property B". This job does
+# not rely on the ordinary GitHub Actions check run to carry the verdict to
+# branch protection. It explicitly PUBLISHES a commit status via the REST
+# Statuses API (POST /repos/{owner}/{repo}/statuses/{sha}) with
+# `sha: github.event.pull_request.head.sha` and
+# `context: update-survivability-gate`.
+#
+# The head SHA comes from the event payload, never from `GITHUB_SHA`: under
+# `pull_request_target`, `GITHUB_SHA` is a commit on the BASE branch, so a
+# result keyed to it would not be a result about this pull request's code at
+# all. The payload's `pull_request.head.sha` is the commit branch protection
+# evaluates, is correct for fork PRs as well as same-repo ones, and does not
+# depend on how GitHub happens to associate a workflow run's check suite.
+# Triggering on `synchronize` means every push re-runs this workflow and posts
+# a FRESH status against the NEW head SHA, so a required check keeps tracking
+# the PR as it moves.
+#
+# The status is posted on EVERY outcome -- pass, block, and the fail-closed
+# "could not determine a verdict" path -- from a step that runs `if: always()`.
+# A gate that only posts on success leaves a required check pending forever,
+# which is just a slower way of not being a gate.
+#
+# The JOB is named `update-survivability-gate`, the same string as the status
+# context, deliberately: a ruleset entry naming that context then matches both
+# the posted commit status and this job's own check run, so the required check
+# does not depend on which of the two GitHub resolves it against.
+#
+# Permissions note: `statuses: write` is required for the publish above, and is
+# the reason this workflow appears on scripts/thin-fork-guard.sh's gate-7
+# allowlist alongside thin-fork-guard-trusted.yml. That allowlist stays
+# exhaustive: any OTHER workflow acquiring `statuses: write`, `checks: write`
+# or `write-all` still fails the thin-fork guard, because the invariant it
+# protects is that only known, reviewed evaluators can write a required status.
+# `contents: read` and `pull-requests: read` cover the rest: the base-branch
+# checkout, the changed-file listing, the report content, and the review list
+# that clears a gate self-modification.
 #
 # Because `pull_request_target` runs the BASE branch's copy of a workflow,
 # this gate only applies to PRs whose target branch already contains this
@@ -90,10 +123,13 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 jobs:
   update-survivability-gate:
-    name: Update Survivability Gate
+    # Same string as the published status context, on purpose -- see
+    # "Design decision 4" above.
+    name: update-survivability-gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch (trusted scripts only -- never PR HEAD)
@@ -199,27 +235,90 @@ jobs:
 
           printf '%s' "$PR_TITLE" > pr-title.txt
 
+          # Reviews clear the gate-self-modification classification. Only
+          # GitHub can say who has write access, so authorization is read from
+          # `author_association` (which GitHub computes from the reviewer's
+          # permission on this repository) and from `commit_id`, which pins an
+          # approval to the commit it was given against. Nothing the PR author
+          # writes -- body, title, label -- is accepted for this, because the
+          # author controls all three.
+          #
+          # `pulls/{n}/reviews` needs only the `pull-requests: read` scope this
+          # workflow already holds. A run with no reviews yields an empty file,
+          # which the evaluator reads as "nobody has approved", not as an
+          # undetermined input.
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '.[] | [.state, .author_association, (.commit_id // "")] | @tsv' \
+            > reviews.txt
+          echo "Reviews: $(wc -l < reviews.txt)"
+
+          printf '%s' "$PR_HEAD_SHA" > pr-head-sha.txt
+
       - name: Evaluate the gate
+        id: evaluate
+        # Sets `state` and `description` for the publish step below on every
+        # path, then exits non-zero for a blocking verdict so the run itself is
+        # red in the Actions tab too. Outputs written before a non-zero exit are
+        # still read by the runner, and the publish step runs `if: always()`, so
+        # the commit status is posted either way.
         run: |
           set -uo pipefail
           title="$(cat pr-title.txt)"
+          head_sha="$(cat pr-head-sha.txt)"
           set +e
           scripts/update-survivability-gate.sh \
             changed-files.txt evidence.txt labels.txt "$title" \
+            reviews.txt "$head_sha" \
             | tee -a "$GITHUB_STEP_SUMMARY"
           verdict=${PIPESTATUS[0]}
           set -e
 
           case "$verdict" in
             0)
+              echo "state=success" >>"$GITHUB_OUTPUT"
+              echo "description=update survivability gate passed" >>"$GITHUB_OUTPUT"
               echo "Update Survivability Gate: pass"
               ;;
             1)
-              echo "::error::Update Survivability Gate: this PR changes the firmware update path without a complete hardware validation report. Builds, host tests, cppcheck, CodeQL and CodeRabbit all passed on the change that left the only X4 Pro update-locked -- none of them runs on hardware or exercises an install cycle, so none of them can substitute. See docs/update-survivability-gate.md and the job summary for the exact files and missing rows."
+              echo "state=failure" >>"$GITHUB_OUTPUT"
+              echo "description=blocked: hardware validation report and/or maintainer approval missing" >>"$GITHUB_OUTPUT"
+              echo "::error::Update Survivability Gate: blocked. Either this PR changes the firmware update path without a complete hardware validation report, or it modifies the gate itself without an approving maintainer review on the current head SHA. Builds, host tests, cppcheck, CodeQL and CodeRabbit all passed on the change that left the only X4 Pro update-locked -- none of them runs on hardware or exercises an install cycle, so none of them can substitute. See docs/update-survivability-gate.md and the job summary."
               exit 1
               ;;
             *)
+              echo "state=error" >>"$GITHUB_OUTPUT"
+              echo "description=undetermined verdict -- failing closed (see run summary)" >>"$GITHUB_OUTPUT"
               echo "::error::Update Survivability Gate: could not determine a verdict (script exit $verdict) and is failing closed. An undetermined result is never a pass -- that fail-open reading is the same mistake that caused the incident this gate guards. See docs/update-survivability-gate.md."
               exit 1
               ;;
           esac
+
+      - name: Publish the result against the PR head SHA
+        # `if: always()` so a required check is never left pending: if any step
+        # above failed outright -- a truncated file listing, a failed API call,
+        # a runner fault -- the `|| 'error'` fallback publishes a blocking
+        # status rather than nothing at all.
+        #
+        # Every value reaches the shell through `env`, never `${{ }}` inside
+        # the script: this job holds `statuses: write`, so inline interpolation
+        # of any payload-derived string would be the highest-value script
+        # injection target in this repository.
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STATUS_STATE: ${{ steps.evaluate.outputs.state || 'error' }}
+          STATUS_DESCRIPTION: ${{ steps.evaluate.outputs.description || 'gate did not run to completion -- failing closed' }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$REPO/statuses/$PR_HEAD_SHA" \
+            -f "state=$STATUS_STATE" \
+            -f "context=update-survivability-gate" \
+            -f "description=$STATUS_DESCRIPTION" \
+            -f "target_url=$TARGET_URL"

--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -1,0 +1,189 @@
+name: Update Survivability Gate
+
+# Blocks a pull request that changes the firmware update path -- flasher, OTA
+# client, boot-slot switch, image validators, partition table, release or
+# signing machinery -- unless it carries a hardware validation report proving
+# the device can still install a SECOND update afterwards.
+#
+# The incident this exists for
+# ----------------------------
+# A UI/touch hardware-test RC also moved the firmware installation path and
+# shipped without a two-slot update test. It installed once; the device could
+# then never install again, because firmware_flash::runningPartitionChipId()
+# (src/network/FirmwareFlasher.cpp) misreads chip identity from the running
+# slot and both install paths fail closed on it -- validateImageFile() returns
+# BAD_CHIP, and OtaUpdater::installUpdate() aborts the transfer. The only X4
+# Pro in the field became update-locked with no working recovery channel.
+#
+# Four board builds, 512 host tests, cppcheck, CodeQL and a full CodeRabbit
+# review all passed on that change. None of them runs on hardware, and none of
+# them exercises an install CYCLE. Adding more of the same would not have
+# caught it; only a designated test device completing the matrix in
+# docs/update-survivability-gate.md would have.
+#
+# Design decision 1: classification is DIFF-DERIVED, not metadata-derived
+# ----------------------------------------------------------------------
+# "Is this a UI PR reaching into the updater?" is answered from the changed
+# FILE LIST, never from a label or a title convention. A label can be removed,
+# never applied, or renamed; a title convention can be written any way the
+# author likes. Both are opt-in metadata, and a gate that keys off opt-in
+# metadata is off by default.
+#
+# Label and title ARE read, but only to ESCALATE: when a PR that touches these
+# files also presents as UI work, the failure message says so in the loudest
+# terms available, because that is the exact shape of the incident. Stripping
+# the label changes the wording and nothing else. There is no state in which
+# touching a protected path does not require the report.
+#
+# Failure mode of this choice (stated deliberately, not hidden): the protected
+# list is a hand-maintained inventory, so a dangerous file that matches NONE of
+# its patterns is invisible until a human adds it. That is mitigated, not
+# eliminated, by the broad trailing patterns in the script
+# (src/network/Firmware*, src/network/Ota*, src/Ota*, scripts/*sign*, ...),
+# which cover the naming conventions the update path actually uses so a newly
+# written src/network/FirmwareSignature.cpp is caught on day one. A file that
+# affects updating while matching neither the named nor the broad patterns --
+# say a bootloader change routed through platformio.ini build flags -- still
+# gets through. Reviewers own that residue; the gate covers the shape that
+# actually bit us.
+#
+# Design decision 2: pull_request_target, base-branch scripts only
+# ---------------------------------------------------------------
+# Same reasoning as thin-fork-guard-trusted.yml: on the ordinary
+# `pull_request` event the job would check out and execute the PR's OWN copy
+# of scripts/update-survivability-gate.sh, so a PR could edit the gate to pass
+# itself. This workflow checks out the BASE branch and runs only its copy. It
+# never checks out, builds, or executes anything from PR HEAD -- the diff, the
+# labels, the title and the body all arrive as inert DATA through the GitHub
+# API and the event payload, and every one of them is routed through `env`
+# rather than `${{ }}` string interpolation (a PR title and body are
+# attacker-controlled free text; inline interpolation into a shell script is
+# the classic Actions injection vector).
+#
+# Design decision 3: fail closed
+# ------------------------------
+# The gate script exits 2 when it cannot DETERMINE a verdict -- unreadable
+# inputs, an empty changed-file list -- and this workflow treats exit 2 as a
+# failure, never as a pass. A truncated file listing or a failed API call must
+# not read as "nothing to check." Fail-open on a value the code could not
+# actually establish is precisely the bug that bricked the device; applying
+# the opposite posture to the CI that guards it is the point.
+#
+# Permissions note: this workflow deliberately grants only `contents: read`
+# and `pull-requests: read`. It must never request `statuses: write`,
+# `checks: write` or `write-all` -- scripts/thin-fork-guard.sh's
+# workflow-permission audit (gate 7) fails any PR that introduces a second
+# workflow able to spoof the trusted required status, and this workflow is
+# audited by it like any other.
+#
+# Because `pull_request_target` runs the BASE branch's copy of a workflow,
+# this gate only applies to PRs whose target branch already contains this
+# file. Merge it into develop and into every live release branch.
+
+on:
+  pull_request_target:
+    # `edited` and the label events matter here: the hardware validation
+    # report normally lives in the PR description, so editing the body must
+    # re-run the gate rather than leaving a stale red check.
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-survivability-gate:
+    name: Update Survivability Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch (trusted scripts only -- never PR HEAD)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Self-test the gate script
+        # A gate whose own matching logic has never been exercised is not
+        # evidence. Synthetic fixtures, no dependency on this repo's history --
+        # same pattern as thin-fork-guard.yml's self-test step.
+        run: |
+          set -euo pipefail
+          chmod +x scripts/update-survivability-gate.sh scripts/test-update-survivability-gate.sh
+          scripts/test-update-survivability-gate.sh
+
+      - name: Collect PR facts (API data only, never executed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Changed files. `--paginate` walks every page; GitHub caps this
+          # endpoint at 3000 files, so a listing at the cap is a TRUNCATED
+          # listing and must fail closed rather than be judged as complete.
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' > changed-files.txt
+          file_count="$(wc -l < changed-files.txt)"
+          if [ "$file_count" -ge 3000 ]; then
+            echo "::error::PR file listing hit the API's 3000-file cap and is truncated; the gate cannot judge it. Failing closed."
+            exit 1
+          fi
+          echo "Changed files: $file_count"
+
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/labels" \
+            --jq '.[].name' > labels.txt || true
+
+          # Evidence = the PR body, plus the content of any hardware
+          # validation report the PR adds or edits. Report content is read
+          # from PR HEAD through the contents API and is only ever scanned as
+          # text -- nothing from HEAD is checked out or run. Paths are
+          # filtered to a strict charset before being used in a URL.
+          printf '%s\n' "$PR_BODY" > evidence.txt
+          while IFS= read -r hv; do
+            case "$hv" in
+              docs/hardware-validation/*.md) ;;
+              *) continue ;;
+            esac
+            if ! printf '%s' "$hv" | grep -qE '^docs/hardware-validation/[A-Za-z0-9._/-]+\.md$'; then
+              echo "::warning::skipping report path with unexpected characters: $hv"
+              continue
+            fi
+            echo "Reading hardware validation report: $hv"
+            {
+              echo
+              echo "----- $hv -----"
+              gh api "repos/$REPO/contents/$hv?ref=$PR_HEAD_SHA" --jq '.content' \
+                | tr -d '\n' | base64 -d
+            } >> evidence.txt
+          done < changed-files.txt
+
+          printf '%s' "$PR_TITLE" > pr-title.txt
+
+      - name: Evaluate the gate
+        run: |
+          set -uo pipefail
+          title="$(cat pr-title.txt)"
+          set +e
+          scripts/update-survivability-gate.sh \
+            changed-files.txt evidence.txt labels.txt "$title" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          verdict=${PIPESTATUS[0]}
+          set -e
+
+          case "$verdict" in
+            0)
+              echo "Update Survivability Gate: pass"
+              ;;
+            1)
+              echo "::error::Update Survivability Gate: this PR changes the firmware update path without a complete hardware validation report. Builds, host tests, cppcheck, CodeQL and CodeRabbit all passed on the change that left the only X4 Pro update-locked -- none of them runs on hardware or exercises an install cycle, so none of them can substitute. See docs/update-survivability-gate.md and the job summary for the exact files and missing rows."
+              exit 1
+              ;;
+            *)
+              echo "::error::Update Survivability Gate: could not determine a verdict (script exit $verdict) and is failing closed. An undetermined result is never a pass -- that fail-open reading is the same mistake that caused the incident this gate guards. See docs/update-survivability-gate.md."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -127,6 +127,24 @@ on:
     # re-run the gate rather than leaving a stale red check.
     types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
+# One gate run per PR at a time, newest wins.
+#
+# `edited`, `labeled` and `unlabeled` all start a run WITHOUT changing the head
+# SHA, so several runs can be in flight against the same commit. Branch
+# protection reads the latest check run for this name on that commit, and
+# "latest" is decided by when a run finishes -- so a stale run that started
+# before a blocking edit could finish afterwards and become the result of
+# record, reporting a verdict about evidence that no longer exists.
+#
+# Cancelling supersedes it: a cancelled run's check run is `cancelled`, which is
+# not success, so the fail-closed posture holds while the replacement run
+# produces the real verdict. (This workflow publishes no commit status -- see
+# design decision 4 -- so there is no status context to overwrite; the race that
+# remains is purely about which check run is newest.)
+concurrency:
+  group: update-survivability-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -125,8 +125,26 @@ jobs:
           # Changed files. `--paginate` walks every page; GitHub caps this
           # endpoint at 3000 files, so a listing at the cap is a TRUNCATED
           # listing and must fail closed rather than be judged as complete.
+          #
+          # One line per API RECORD, as `filename<TAB>previous_filename`.
+          # `previous_filename` is present ONLY on a rename, where it holds
+          # the SOURCE path while `filename` holds the destination; `// ""`
+          # turns its absence on every other record into an empty second
+          # field. Writing `.filename` alone -- the obvious spelling -- is a
+          # total bypass of this gate: renaming src/network/OtaUpdater.cpp to
+          # src/network/Updater.cpp and rewriting it in the same commit yields
+          # a list matching no protected pattern, so the gate says "Not
+          # applicable" and the updater ships unvalidated. This step only
+          # TRANSPORTS the pair; scripts/update-survivability-gate.sh does all
+          # of the classification and is self-tested against both rename
+          # directions, so the matching logic never lives in un-runnable
+          # inline YAML.
+          #
+          # Still one line per changed file, so the 3000-file cap check below
+          # continues to count API records rather than paths.
           gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --jq '.[].filename' > changed-files.txt
+            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' \
+            > changed-files.txt
           file_count="$(wc -l < changed-files.txt)"
           if [ "$file_count" -ge 3000 ]; then
             echo "::error::PR file listing hit the API's 3000-file cap and is truncated; the gate cannot judge it. Failing closed."
@@ -142,8 +160,10 @@ jobs:
           # from PR HEAD through the contents API and is only ever scanned as
           # text -- nothing from HEAD is checked out or run. Paths are
           # filtered to a strict charset before being used in a URL.
+          # Field 1 of each record is `filename` -- for a rename, the path the
+          # report lives at on PR HEAD, which is the one to read content from.
           printf '%s\n' "$PR_BODY" > evidence.txt
-          while IFS= read -r hv; do
+          while IFS=$'\t' read -r hv _; do
             case "$hv" in
               docs/hardware-validation/*.md) ;;
               *) continue ;;

--- a/.github/workflows/update-survivability-gate.yml
+++ b/.github/workflows/update-survivability-gate.yml
@@ -70,44 +70,51 @@ name: Update Survivability Gate
 # actually establish is precisely the bug that bricked the device; applying
 # the opposite posture to the CI that guards it is the point.
 #
-# Design decision 4: the result is PUBLISHED against the PR head SHA
+# Design decision 4: the required result is THIS JOB'S OWN CHECK RUN
 # ------------------------------------------------------------------
-# Same mechanism as thin-fork-guard-trusted.yml's "property B". This job does
-# not rely on the ordinary GitHub Actions check run to carry the verdict to
-# branch protection. It explicitly PUBLISHES a commit status via the REST
-# Statuses API (POST /repos/{owner}/{repo}/statuses/{sha}) with
-# `sha: github.event.pull_request.head.sha` and
-# `context: update-survivability-gate`.
+# The verdict reaches branch protection as the ordinary GitHub Actions check
+# run produced by this job. The job is therefore named exactly
+# `update-survivability-gate`, and that string is the context a ruleset must
+# require.
 #
-# The head SHA comes from the event payload, never from `GITHUB_SHA`: under
-# `pull_request_target`, `GITHUB_SHA` is a commit on the BASE branch, so a
-# result keyed to it would not be a result about this pull request's code at
-# all. The payload's `pull_request.head.sha` is the commit branch protection
-# evaluates, is correct for fork PRs as well as same-repo ones, and does not
-# depend on how GitHub happens to associate a workflow run's check suite.
-# Triggering on `synchronize` means every push re-runs this workflow and posts
-# a FRESH status against the NEW head SHA, so a required check keeps tracking
-# the PR as it moves.
+# This deliberately does NOT post a commit status via the Statuses API, the
+# way thin-fork-guard-trusted.yml does. Posting one needs `statuses: write`,
+# and the only place to authorise that is the gate-7 allowlist inside
+# scripts/thin-fork-guard.sh -- a SECURITY_BOUNDARY_FILES entry, as is
+# scripts/check-workflow-permissions.rb. Editing either is blocked for an
+# ordinary PR by design, so shipping a status writer here would have required
+# temporarily relaxing branch protection to merge this very workflow, and
+# would have added a second workflow able to write a required status,
+# weakening the invariant that only one known evaluator can. Not worth it for
+# a property the check run already provides.
 #
-# The status is posted on EVERY outcome -- pass, block, and the fail-closed
-# "could not determine a verdict" path -- from a step that runs `if: always()`.
-# A gate that only posts on success leaves a required check pending forever,
-# which is just a slower way of not being a gate.
+# The measured fact this rests on, checked on this repository rather than
+# assumed:
 #
-# The JOB is named `update-survivability-gate`, the same string as the status
-# context, deliberately: a ruleset entry naming that context then matches both
-# the posted commit status and this job's own check run, so the required check
-# does not depend on which of the two GitHub resolves it against.
+#   For `pull_request_target`, `GITHUB_SHA` inside the job IS a commit on the
+#   BASE branch -- but the workflow RUN and its CHECK SUITE are associated
+#   with the PR HEAD SHA. Verified against thin-fork-guard-trusted.yml (also
+#   `pull_request_target`) on PR #216: run head_sha, check-suite head_sha and
+#   the PR head SHA were all b186c1e8, while the base was 42802346.
 #
-# Permissions note: `statuses: write` is required for the publish above, and is
-# the reason this workflow appears on scripts/thin-fork-guard.sh's gate-7
-# allowlist alongside thin-fork-guard-trusted.yml. That allowlist stays
-# exhaustive: any OTHER workflow acquiring `statuses: write`, `checks: write`
-# or `write-all` still fails the thin-fork guard, because the invariant it
-# protects is that only known, reviewed evaluators can write a required status.
-# `contents: read` and `pull-requests: read` cover the rest: the base-branch
-# checkout, the changed-file listing, the report content, and the review list
-# that clears a gate self-modification.
+# So the check run lands on the commit branch protection actually evaluates,
+# and `synchronize` re-runs it on every push. Nothing in this workflow reads
+# `GITHUB_SHA`; where the head SHA is genuinely needed (clearing a gate
+# self-modification requires an approval on the CURRENT head) it comes from
+# `github.event.pull_request.head.sha` via `env:`.
+#
+# The limit of that measurement, stated plainly: it was taken on a SAME-REPO
+# pull request. It has not been verified for a pull request opened from a
+# FORK. Confirm the context appears on a fork PR's head SHA before making this
+# a required check -- if it does not, a required check that never reports
+# blocks every fork PR, and the status-writer route above becomes necessary
+# after all.
+#
+# Permissions: `contents: read` and `pull-requests: read` only -- the
+# base-branch checkout, the changed-file listing, the report content, and the
+# review list that clears a gate self-modification. No write scope of any
+# kind, so this workflow stays off scripts/thin-fork-guard.sh's gate-7
+# allowlist and that allowlist stays exhaustive at one entry.
 #
 # Because `pull_request_target` runs the BASE branch's copy of a workflow,
 # this gate only applies to PRs whose target branch already contains this
@@ -123,7 +130,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  statuses: write
 
 jobs:
   update-survivability-gate:
@@ -256,11 +262,11 @@ jobs:
 
       - name: Evaluate the gate
         id: evaluate
-        # Sets `state` and `description` for the publish step below on every
-        # path, then exits non-zero for a blocking verdict so the run itself is
-        # red in the Actions tab too. Outputs written before a non-zero exit are
-        # still read by the runner, and the publish step runs `if: always()`, so
-        # the commit status is posted either way.
+        # Exits non-zero for a blocking verdict, which turns this job's check
+        # run red. That check run IS the required status -- see "Design
+        # decision 4" in the header. `state`/`description` outputs are also
+        # written on every path so the verdict is machine-readable from the run
+        # without re-parsing the summary.
         run: |
           set -uo pipefail
           title="$(cat pr-title.txt)"
@@ -292,33 +298,3 @@ jobs:
               exit 1
               ;;
           esac
-
-      - name: Publish the result against the PR head SHA
-        # `if: always()` so a required check is never left pending: if any step
-        # above failed outright -- a truncated file listing, a failed API call,
-        # a runner fault -- the `|| 'error'` fallback publishes a blocking
-        # status rather than nothing at all.
-        #
-        # Every value reaches the shell through `env`, never `${{ }}` inside
-        # the script: this job holds `statuses: write`, so inline interpolation
-        # of any payload-derived string would be the highest-value script
-        # injection target in this repository.
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          STATUS_STATE: ${{ steps.evaluate.outputs.state || 'error' }}
-          STATUS_DESCRIPTION: ${{ steps.evaluate.outputs.description || 'gate did not run to completion -- failing closed' }}
-          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/$REPO/statuses/$PR_HEAD_SHA" \
-            -f "state=$STATUS_STATE" \
-            -f "context=update-survivability-gate" \
-            -f "description=$STATUS_DESCRIPTION" \
-            -f "target_url=$TARGET_URL"

--- a/docs/update-survivability-gate.md
+++ b/docs/update-survivability-gate.md
@@ -311,6 +311,24 @@ false positive, because a gate that hard-blocks work it has nothing to say
 about is a gate people learn to route around. Any new exclusion must clear the
 same bar.
 
+Renaming a protected file does not get you out of the gate. Both the **source**
+and the **destination** path of every rename are matched against the list
+above, so all three of these block:
+
+- `src/network/OtaUpdater.cpp` → `src/network/Updater.cpp` — the file that was
+  the updater still is the updater; matching only the destination would report
+  this PR as "Not applicable" while the install path was rewritten under a new
+  name.
+- `src/network/Updater.cpp` → `src/network/OtaUpdater.cpp` — whatever content
+  lands at a protected pathname *is* the update path from that commit on.
+- A rename through the `release-fonts.yml` carve-out in either direction — the
+  exclusion is evaluated per path, not per rename.
+
+A rename that changes not one byte is classified identically to a rewrite; the
+gate reads paths, never patch size. When a rename is what triggered the gate,
+the failure message names both paths and which side matched, because the
+blocking path will not be in the diff you are looking at.
+
 The gate is triggered by the **diff**, not by a label. A PR cannot opt out of
 it by omitting or removing a label — see the workflow header for that decision
 and its residual failure mode.

--- a/docs/update-survivability-gate.md
+++ b/docs/update-survivability-gate.md
@@ -137,43 +137,63 @@ SHA-256**, and **boot result**.
 | **US-2** | **B** running from `app1` → install **C** into `app0` | Install succeeds; device boots C from `app0`. **This is the hop the incident failed.** |
 | **US-3** | **C** running from `app0` → install **B** into `app1` | Install succeeds; device boots B from `app1`. Proves the cycle closes, not just that two hops work |
 | **US-4** | Self-reinstall, where supported | Installing the currently running version again either succeeds cleanly or is refused with a clear message — never leaves the device unbootable. Mark `N/A` if the build refuses same-version installs by design (see `isUpdateNewer()` in [`OtaUpdater.cpp`](../src/network/OtaUpdater.cpp)) |
-| **US-5** | Wrong-**chip** image offered | Rejected, **and neither slot is erased**. The running slot still boots and the inactive slot still holds its previous image |
-| **US-6** | Wrong-**board** image offered (same chip family, different board tag — see [`FirmwareBoardTag.h`](../src/network/FirmwareBoardTag.h)) | Rejected, **and never selected as bootable**. Partial bytes may land in the inactive slot; `esp_ota_set_boot_partition()` must not be reached |
-| **US-7** | Corrupted / truncated image offered | Rejected **before erase**. Truncate a valid image mid-file and offer it via SD; the fallback slot must be intact afterwards |
-| **US-8** | HTTP failure **before** the download starts (unreachable host, DNS failure, TLS rejection) | Update aborts; **the fallback slot is not erased** |
-| **US-9** | HTTP failure **during** the download (connection dropped mid-stream) | Update aborts; **the fallback slot is not erased** |
+| **US-5** | Wrong-**chip** image offered | **SD:** rejected *before* any erase or write, so **neither slot is erased** — `validateImageFile()` compares `chip_id` and returns `BAD_CHIP` ([`FirmwareFlasher.cpp:149-153`](../src/network/FirmwareFlasher.cpp)) and `flashFromSdPath()` validates at [`:292`](../src/network/FirmwareFlasher.cpp) before its first `esp_partition_erase_range()` at [`:330`](../src/network/FirmwareFlasher.cpp). **OTA:** the **running slot stays bootable and stays the boot target**; the target slot is never selected — `esp_ota_abort()` runs at [`OtaUpdater.cpp:290`](../src/network/OtaUpdater.cpp) and `esp_ota_set_boot_partition()` at [`:306`](../src/network/OtaUpdater.cpp) is never reached. The inactive slot **may** be erased or partly written; do **not** require it intact (see "Erase ordering" below) |
+| **US-6** | Wrong-**board** image offered (same chip family, different board tag — see [`FirmwareBoardTag.h`](../src/network/FirmwareBoardTag.h)) | **SD:** rejected before erase — `validateImageFile()` returns `WRONG_BOARD` at [`FirmwareFlasher.cpp:211-216`](../src/network/FirmwareFlasher.cpp). **OTA:** rejected mid-stream and **never selected as bootable**; partial bytes may land in the inactive slot, `esp_ota_set_boot_partition()` must not be reached |
+| **US-7** | Corrupted / truncated image offered | **SD:** rejected **before erase** — header, segment table, XOR checksum and the SHA-256 trailer are all verified against the card ([`FirmwareFlasher.cpp:113-273`](../src/network/FirmwareFlasher.cpp)) before any partition write, so the fallback slot must be intact afterwards. Truncate a valid image mid-file and offer it via SD. **OTA:** `esp_ota_end()` ([`OtaUpdater.cpp:300`](../src/network/OtaUpdater.cpp)) must reject the image and the boot target must not change; the target slot may hold the partial write |
+| **US-8** | HTTP failure **before** the download starts (unreachable host, DNS failure, TLS rejection) — **OTA only** | Update aborts; the **running slot still boots and is still the boot target**. The inactive slot may already be blank — that is the current, documented behaviour (see "Erase ordering"), and this case must **not** require it intact |
+| **US-9** | HTTP failure **during** the download (connection dropped mid-stream) — **OTA only** | Update aborts; the **running slot still boots and is still the boot target**. The inactive slot holds a partial image; that is expected, not a failure of this case |
 | **US-10** | Power loss at each documented safe stage (§6) | Device boots afterwards, from either slot |
 | **US-11** | After **every** failure case above | Confirm the previous slot still boots before moving on |
 
-### Why US-8 and US-9 are required cases, grounded in the code
+### Erase ordering: the required invariant, and where the firmware deviates
 
-[`OtaUpdater::installUpdate()`](../src/network/OtaUpdater.cpp) calls:
+**Required invariant.** Chip/header validation and HTTP acceptance must happen
+**before `esp_ota_begin()`**. Nothing that can be rejected on the strength of
+the image header or the connection alone should cost the device its fallback
+image.
 
-```cpp
-esp_err_t esp_err = esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle);
-```
+> **The current firmware does not satisfy that invariant.** In
+> [`OtaUpdater::installUpdate()`](../src/network/OtaUpdater.cpp),
+> `esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle)` is called at
+> **line 221**, *before* `HttpDownloader::fetchUrlVerified` is invoked at
+> **line 245** and before the chip-id check, which runs inside the streaming
+> callback on the first 14 bytes at **lines 250-258**. `esp_ota_begin` with
+> `OTA_SIZE_UNKNOWN` erases the **entire** target partition up front, because
+> it cannot know how much of it the incoming image will use. The firmware's own
+> comment at **lines 241-243** states the consequence: "The wrong image may
+> partially land in the inactive OTA slot, but `esp_ota_abort()` below means it
+> never becomes the boot target."
+>
+> This deviation is recorded, not fixed here: the firmware is frozen for this
+> change. It is the reason US-5, US-8 and US-9 **cannot** require an intact
+> fallback slot on the OTA channel today, and it is why they require the
+> weaker — but actually achievable — property instead: the running slot stays
+> bootable and stays the boot target, and the target slot is never selected
+> until a complete image has passed validation (`esp_ota_end()` at line 300,
+> then `esp_ota_set_boot_partition()` at line 306; `esp_ota_abort()` at lines
+> 290 and 296 on every rejection path).
 
-and only *then* starts the HTTP fetch (`HttpDownloader::fetchUrlVerified`).
+So on the OTA channel the real ordering is:
 
-`esp_ota_begin` with `OTA_SIZE_UNKNOWN` erases the **entire** target partition
-up front, because it cannot know how much of it the incoming image will use.
-So the ordering is:
-
-1. erase the whole fallback slot
+1. erase the whole target slot (`esp_ota_begin`)
 2. open the network connection
-3. download
+3. download, validating the header on the first bytes
 
 The fallback image is destroyed **before the first byte arrives**. Any network
 failure at step 2 or step 3 therefore happens with one slot already blank —
 which is survivable only if the *running* slot is still good. US-8 and US-9
-exist to prove that this erase-before-fetch ordering never costs the device its
-only bootable image. They are not hypothetical robustness checks; they are a
-direct consequence of that one line.
+exist to prove exactly that, and nothing stronger. They are not hypothetical
+robustness checks; they are a direct consequence of that ordering.
 
-The same ordering is why US-7 says "rejected **before** erase": the SD path
-(`validateImageFile()`) validates the whole file from the card *before* any
-partition write, and that property must be preserved. Reordering validation
-after erase would turn a rejected image into a bricked device.
+**The SD channel is different, and its stronger guarantee must be preserved.**
+`validateImageFile()` verifies the whole file from the card — header, chip id,
+board tag, segment table, XOR checksum, SHA-256 trailer — *before*
+`flashFromSdPath()` writes or erases anything
+([`FirmwareFlasher.cpp:292`](../src/network/FirmwareFlasher.cpp) validates;
+[`:330`](../src/network/FirmwareFlasher.cpp) is the first erase). That is why
+US-5 (SD half) and US-7 say "rejected **before** erase" and require both slots
+intact. Reordering validation after erase on the SD path would turn a rejected
+image into a bricked device, and would be a regression this matrix must catch.
 
 ### Why US-5 and US-6 are separate cases
 
@@ -190,9 +210,27 @@ test cases.
 
 ## 5. Results table (fill this in)
 
-Copy this block into the PR description. CI reads it: every `US-` row must
-carry a `PASS`, `FAIL` or `N/A` verdict, `Test device:` must name a unit, and
-`Build SHAs:` must contain real commit hashes.
+Copy this block into the PR description and fill it in. **This template and
+[`scripts/update-survivability-gate.sh`](../scripts/update-survivability-gate.sh)'s
+parser are locked to each other** by a test in
+[`scripts/test-update-survivability-gate.sh`](../scripts/test-update-survivability-gate.sh)
+that extracts this exact block from this document, fills it in with plausible
+PASS values, and asserts the gate accepts it — and asserts that the block left
+as issued is rejected. Change one side without the other and that test fails.
+
+What CI requires of the filled-in block:
+
+- **Every `US-` row is a table row**, not a sentence. Its first cell is the case
+  id, and it records **running slot**, **target slot**, **image SHA-256**,
+  **boot result** and a **verdict**, in the column order printed below. Write
+  `-` in any cell that genuinely does not apply; a blank cell or `TBD` is an
+  unfilled template, not a result.
+- **`N/A` is accepted for US-4 only.** Every other row must record a real
+  outcome.
+- **`Test device:`** must name an actual unit — a `<placeholder>` does not count.
+- **`Build SHAs:`** must give **A**, **B** and **C**, each 7-40 hex characters,
+  and all three must be **different** (§4: C exists so the `app1 → app0` hop
+  uses an image that is not already resident).
 
 ```markdown
 ## Hardware validation
@@ -222,8 +260,10 @@ Firmware channel(s) exercised: <SD | OTA | both>
 ```
 
 `N/A` is acceptable only for **US-4**, and only where the build refuses
-same-version installs by design. `FAIL` or `BLOCKED` on any row blocks the RC;
-so does a row left without a verdict. Both are CI failures, not warnings.
+same-version installs by design; on any other row it is rejected outright.
+`FAIL` or `BLOCKED` on any row blocks the RC; so does a row left without a
+verdict, and so does a row missing any of its four transition fields. All of
+those are CI failures, not warnings.
 
 A recorded `FAIL` is a *good* outcome for the process — it is the gate working.
 Fix the firmware, re-run the matrix, update the report.
@@ -278,8 +318,9 @@ Verdict: <RELEASABLE | BLOCKED>
 ## 8. What CI checks, and what it does not
 
 The workflow verifies the report was **written down**: that a protected file
-was touched, that a test device is named, that build SHAs are real hashes and
-not `TBD`, that every matrix row carries a verdict, and that no row failed.
+was touched, that a test device is named, that build SHAs are three real,
+distinct hashes and not `TBD`, that every matrix row is a complete row with a
+permitted verdict, and that no row failed.
 
 It cannot verify the results are **true**. Nobody can automate that — the whole
 premise of this gate is that no CI job runs on hardware. The reviewer owns
@@ -333,6 +374,73 @@ The gate is triggered by the **diff**, not by a label. A PR cannot opt out of
 it by omitting or removing a label — see the workflow header for that decision
 and its residual failure mode.
 
+### How the result reaches branch protection
+
+The job publishes a **commit status** with the context
+**`update-survivability-gate`** against
+`github.event.pull_request.head.sha`, via
+`POST /repos/{owner}/{repo}/statuses/{sha}` — the same mechanism
+[`thin-fork-guard-trusted.yml`](../.github/workflows/thin-fork-guard-trusted.yml)
+uses. The head SHA comes from the event payload and never from `GITHUB_SHA`,
+which under `pull_request_target` is a commit on the *base* branch: a result
+keyed to that would not be a result about the pull request's code. Every push
+re-runs the workflow and posts a fresh status against the new head SHA, and the
+status is posted on **every** outcome — pass, block, and the fail-closed
+"could not determine a verdict" path — so a required check is never left
+pending. The job is named `update-survivability-gate` too, so a ruleset entry
+naming that context matches both the posted status and the job's own check run.
+
+Publishing that status is why this workflow holds `statuses: write`, and why it
+is the second (and only other) entry on
+[`scripts/thin-fork-guard.sh`](../scripts/thin-fork-guard.sh)'s gate-7
+allowlist. That list stays exhaustive: any other workflow acquiring
+`statuses: write`, `checks: write` or `write-all` still fails the thin-fork
+guard.
+
+### The gate protects itself: gate self-modification
+
+A PR that changes only the gate's own files matches no protected firmware path.
+Left at that, it would be reported as "Not applicable" and an edit weakening the
+evaluator for every *future* PR would merge behind a green check.
+
+So a change to any of these is a **second, independent classification**:
+
+- `.github/workflows/update-survivability-gate.yml`
+- `scripts/update-survivability-gate.sh`
+- `scripts/test-update-survivability-gate.sh`
+- `docs/update-survivability-gate.md`
+
+Both sides of a rename count, for the same reason they do for the protected
+paths: renaming the evaluator away is functionally a rewrite of it, and renaming
+something *into* its pathname is what the workflow will execute from the next
+merge onward.
+
+**A hardware matrix does not clear it.** Running US-0..US-11 on a device says
+nothing about a change to a CI workflow or a shell script, and demanding one for
+a typo fix would make this gate something people route around — the failure mode
+the carve-out policy above exists to avoid.
+
+**Nothing the PR author writes clears it either.** A line in the description, a
+title convention and a label are all text the author controls, so none of them
+is authorization. Note also that labels may only ever *escalate* a message in
+this gate, never suppress one; a label-based opt-out would contradict that
+principle directly.
+
+**What clears it is an APPROVED GitHub review** whose `author_association` is
+`OWNER`, `MEMBER` or `COLLABORATOR` — a value GitHub computes from the
+reviewer's permission on this repository, not something a PR can set — and whose
+`commit_id` is the PR's **current head SHA**. Pushing another commit after
+approval invalidates it and re-blocks the gate, so an approval can never be
+carried across a change. Reading `pulls/{n}/reviews` needs only the
+`pull-requests: read` scope the workflow already holds.
+
+**This is a visibility control, not a prevention control.** Because the gate
+runs on `pull_request_target`, the **base branch's** copy of the workflow and
+evaluator is what judges the PR — nothing a PR changes here can weaken the
+verdict on that same PR. What that property does not do is make such a change
+*noticeable*. This classification is what makes it impossible for a change to
+the gate to be invisible.
+
 ### Branches that do not carry this workflow
 
 The gate runs on `pull_request_target`, so GitHub executes the **base branch's**
@@ -358,7 +466,16 @@ attached before it merges.** Run
 [`scripts/update-survivability-gate.sh`](../scripts/update-survivability-gate.sh)
 from a commit on a protected branch — never from the PR's own head, which the
 PR author controls — against that PR's exact base and head SHAs, and attach the
-complete output as a comment. To count as trusted, the comment must state:
+complete output as a comment. Its invocation is:
+
+```text
+update-survivability-gate.sh CHANGED_FILES EVIDENCE LABELS PR_TITLE REVIEWS HEAD_SHA
+```
+
+where `REVIEWS` is a file of `state<TAB>author_association<TAB>commit_id` lines
+(`gh api --paginate "repos/{owner}/{repo}/pulls/{n}/reviews" --jq '.[] |
+[.state, .author_association, (.commit_id // "")] | @tsv'`) and `HEAD_SHA` is
+the PR's current head commit. To count as trusted, the comment must state:
 
 - the branch and commit the gate script itself came from;
 - the PR's base SHA and head SHA, verbatim;

--- a/docs/update-survivability-gate.md
+++ b/docs/update-survivability-gate.md
@@ -1,0 +1,316 @@
+# Update Survivability Gate
+
+**Status: mandatory.** No X4 Pro release candidate may be handed to the owner
+until a designated test device has completed every case in the matrix below and
+the results are recorded and signed off.
+
+Enforced in CI by [`.github/workflows/update-survivability-gate.yml`](../.github/workflows/update-survivability-gate.yml)
+via [`scripts/update-survivability-gate.sh`](../scripts/update-survivability-gate.sh).
+
+---
+
+## 1. Why this gate exists
+
+A UI/touch hardware-test RC also changed the firmware **installation path**.
+It shipped without a two-slot update test. It installed **once**, successfully,
+onto the owner's X4 Pro — and after that the device could never install again.
+
+The mechanism:
+
+- [`firmware_flash::runningPartitionChipId()`](../src/network/FirmwareFlasher.cpp)
+  reads `chip_id` from offset 12 of the **running partition's** image header,
+  caches it in a function-local static, and returns `0xFFFF` on any read
+  failure.
+- The SD install path (`validateImageFile()` in
+  [`src/network/FirmwareFlasher.cpp`](../src/network/FirmwareFlasher.cpp))
+  compares the candidate image's `chip_id` against that value and returns
+  `Result::BAD_CHIP` on mismatch.
+- The OTA path (`OtaUpdater::installUpdate()` in
+  [`src/network/OtaUpdater.cpp`](../src/network/OtaUpdater.cpp)) buffers the
+  first 14 bytes of the stream, does the same comparison, and aborts the
+  transfer with `wrongChip = true`.
+
+Both **fail closed on the same misread value**. Once the device was running
+from a slot whose header the function misreads, every subsequent install — SD
+*and* OTA — was rejected. The owner's only X4 Pro is update-locked with no
+working recovery channel.
+
+### What did not catch it
+
+| Check | Ran | Result |
+|---|---|---|
+| Four board builds (`default`, `sticky`, `x4pro`, `papermono`) | yes | pass |
+| 512 host tests | yes | pass |
+| `cppcheck` (`pio check`) | yes | pass |
+| CodeQL | yes | pass |
+| CodeRabbit review | yes | pass |
+
+**None of them runs on hardware. None of them exercises an install *cycle*.**
+Adding more of the same class of check cannot close this gap. Only a real
+device installing a second time can.
+
+> ### The single most important rule on this page
+>
+> **A single successful installation is NOT sufficient evidence.**
+>
+> That is exactly what passed here. The bricking change installed cleanly the
+> first time; the defect only appears on the *next* install, from the slot the
+> first install landed in. Any validation that stops after one successful
+> flash proves nothing about survivability.
+
+---
+
+## 2. Recovery precondition (do this before flashing anything)
+
+Before an RC image is written to any device, **at least one recovery method
+must be *proven*, not assumed.** Proven means demonstrated on that specific
+device, in that specific state, before the risky flash — not "should work in
+theory."
+
+Accept exactly one of:
+
+1. **ROM-loader USB connection proven.** The device enumerates in download
+   mode and `esptool` can read the chip ID / flash ID over that connection.
+   Demonstrate this *before* the RC is written, and record the `esptool`
+   output.
+2. **Rollback to the previous slot tested.** The device has been shown to boot
+   the other OTA slot on demand (see
+   [`src/network/OtaBootSwitch.cpp`](../src/network/OtaBootSwitch.cpp) and
+   [`src/OtaRollbackRecoveryPlan.cpp`](../src/OtaRollbackRecoveryPlan.cpp)),
+   and that path was exercised at least once in this session.
+3. **Designated sacrificial unit.** The device under test is expendable, is
+   not anyone's working reader, and professional flash recovery (external
+   programmer / chip-off reflash) is available and arranged.
+
+If none of the three holds, **stop.** Do not flash. This precondition is
+case **US-0** in the matrix and it is not waivable.
+
+### The device rule
+
+> The test device must **never** be the owner's only working unit.
+
+This is not a preference. The incident happened because the only X4 Pro in
+existence was also the test device. See
+[`docs/fix-bricked-xteink.md`](fix-bricked-xteink.md) for what recovery costs
+once that rule is broken.
+
+---
+
+## 3. Flash geometry
+
+From [`partitions.csv`](../partitions.csv):
+
+| Name | Type | SubType | Offset | Size |
+|---|---|---|---|---|
+| `otadata` | data | ota | `0xe000` | `0x2000` |
+| `app0` | app | ota_0 | `0x10000` | `0x640000` |
+| `app1` | app | ota_1 | `0x650000` | `0x640000` |
+
+Two application slots. `esp_ota_get_next_update_partition()` alternates between
+them, so a healthy device ping-pongs `app0 → app1 → app0 → app1`. **The whole
+point of this matrix is that each direction of that ping-pong is a distinct
+code path and must be tested separately.** The bricking change passed the first
+hop and failed the second.
+
+---
+
+## 4. The survivability matrix
+
+Build three distinct, individually identifiable images before starting:
+
+- **A** — the known-good baseline currently shipping.
+- **B** — the release candidate under test.
+- **C** — any third build distinguishable from B (a trivial version-string
+  bump on top of B is fine). C exists so the `app1 → app0` hop can be tested
+  with an image that is not already resident.
+
+Record the **SHA-256 of every image file** before flashing it, and again as
+read back from the device where the path allows it.
+
+For **every transition**, record: **running slot**, **target slot**, **image
+SHA-256**, and **boot result**.
+
+| ID | Case | What must happen |
+|---|---|---|
+| **US-0** | Recovery precondition proven (§2) | One of the three recovery methods demonstrated on this device *before* the first RC flash |
+| **US-1** | Known-good **A** running from `app0` → install **B** into `app1` | Install succeeds; device boots B from `app1` |
+| **US-2** | **B** running from `app1` → install **C** into `app0` | Install succeeds; device boots C from `app0`. **This is the hop the incident failed.** |
+| **US-3** | **C** running from `app0` → install **B** into `app1` | Install succeeds; device boots B from `app1`. Proves the cycle closes, not just that two hops work |
+| **US-4** | Self-reinstall, where supported | Installing the currently running version again either succeeds cleanly or is refused with a clear message — never leaves the device unbootable. Mark `N/A` if the build refuses same-version installs by design (see `isUpdateNewer()` in [`OtaUpdater.cpp`](../src/network/OtaUpdater.cpp)) |
+| **US-5** | Wrong-**chip** image offered | Rejected, **and neither slot is erased**. The running slot still boots and the inactive slot still holds its previous image |
+| **US-6** | Wrong-**board** image offered (same chip family, different board tag — see [`FirmwareBoardTag.h`](../src/network/FirmwareBoardTag.h)) | Rejected, **and never selected as bootable**. Partial bytes may land in the inactive slot; `esp_ota_set_boot_partition()` must not be reached |
+| **US-7** | Corrupted / truncated image offered | Rejected **before erase**. Truncate a valid image mid-file and offer it via SD; the fallback slot must be intact afterwards |
+| **US-8** | HTTP failure **before** the download starts (unreachable host, DNS failure, TLS rejection) | Update aborts; **the fallback slot is not erased** |
+| **US-9** | HTTP failure **during** the download (connection dropped mid-stream) | Update aborts; **the fallback slot is not erased** |
+| **US-10** | Power loss at each documented safe stage (§6) | Device boots afterwards, from either slot |
+| **US-11** | After **every** failure case above | Confirm the previous slot still boots before moving on |
+
+### Why US-8 and US-9 are required cases, grounded in the code
+
+[`OtaUpdater::installUpdate()`](../src/network/OtaUpdater.cpp) calls:
+
+```cpp
+esp_err_t esp_err = esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle);
+```
+
+and only *then* starts the HTTP fetch (`HttpDownloader::fetchUrlVerified`).
+
+`esp_ota_begin` with `OTA_SIZE_UNKNOWN` erases the **entire** target partition
+up front, because it cannot know how much of it the incoming image will use.
+So the ordering is:
+
+1. erase the whole fallback slot
+2. open the network connection
+3. download
+
+The fallback image is destroyed **before the first byte arrives**. Any network
+failure at step 2 or step 3 therefore happens with one slot already blank —
+which is survivable only if the *running* slot is still good. US-8 and US-9
+exist to prove that this erase-before-fetch ordering never costs the device its
+only bootable image. They are not hypothetical robustness checks; they are a
+direct consequence of that one line.
+
+The same ordering is why US-7 says "rejected **before** erase": the SD path
+(`validateImageFile()`) validates the whole file from the card *before* any
+partition write, and that property must be preserved. Reordering validation
+after erase would turn a rejected image into a bricked device.
+
+### Why US-5 and US-6 are separate cases
+
+`chip_id` cannot distinguish S3 boards from each other — `sticky`, `x4pro` and
+`papermono` all share it. That is why
+[`FirmwareBoardTag.h`](../src/network/FirmwareBoardTag.h) exists and why the
+board check has different semantics from the chip check: the chip check runs
+against the *header* and rejects before any write; the board check runs against
+the *stream* and may abort mid-write, relying on `esp_ota_abort()` so the
+partial image is never made bootable. Two different guarantees, two different
+test cases.
+
+---
+
+## 5. Results table (fill this in)
+
+Copy this block into the PR description. CI reads it: every `US-` row must
+carry a `PASS`, `FAIL` or `N/A` verdict, `Test device:` must name a unit, and
+`Build SHAs:` must contain real commit hashes.
+
+```markdown
+## Hardware validation
+
+Test device: <model, serial/MAC, and why it is NOT the only working unit>
+Recovery method proven: <ROM loader | tested rollback | sacrificial unit + recovery arranged>
+Build SHAs: A=<commit> B=<commit> C=<commit>
+Image SHA-256: A=<sha256> B=<sha256> C=<sha256>
+Firmware channel(s) exercised: <SD | OTA | both>
+
+### Survivability matrix
+
+| ID    | Running slot | Target slot | Image SHA-256 | Boot result | Verdict | Notes |
+|-------|--------------|-------------|---------------|-------------|---------|-------|
+| US-0  |              |             |               |             |         |       |
+| US-1  | app0         | app1        |               |             |         |       |
+| US-2  | app1         | app0        |               |             |         |       |
+| US-3  | app0         | app1        |               |             |         |       |
+| US-4  |              |             |               |             |         |       |
+| US-5  |              |             |               |             |         |       |
+| US-6  |              |             |               |             |         |       |
+| US-7  |              |             |               |             |         |       |
+| US-8  |              |             |               |             |         |       |
+| US-9  |              |             |               |             |         |       |
+| US-10 |              |             |               |             |         |       |
+| US-11 |              |             |               |             |         |       |
+```
+
+`N/A` is acceptable only for **US-4**, and only where the build refuses
+same-version installs by design. `FAIL` or `BLOCKED` on any row blocks the RC;
+so does a row left without a verdict. Both are CI failures, not warnings.
+
+A recorded `FAIL` is a *good* outcome for the process — it is the gate working.
+Fix the firmware, re-run the matrix, update the report.
+
+---
+
+## 6. Power-loss stages (US-10)
+
+Cut power at each of these points, then confirm the device boots afterwards:
+
+| Stage | Where | Expectation |
+|---|---|---|
+| P1 | After `esp_ota_begin()` erase, before any write | Running slot still boots; inactive slot blank |
+| P2 | Mid-write, roughly 50% through | Running slot still boots; `otadata` still points at it |
+| P3 | After the last `esp_ota_write()`, before `esp_ota_end()` | Running slot still boots; the incomplete image is never selected |
+| P4 | After `esp_ota_end()`, before `esp_ota_set_boot_partition()` | Running slot still boots |
+| P5 | Immediately after `esp_ota_set_boot_partition()`, before reboot | Device boots the NEW slot; if it does not, rollback recovery engages (see [`src/OtaRollbackDetection.cpp`](../src/OtaRollbackDetection.cpp)) |
+
+P5 is the only stage where the boot target legitimately changes. Any *other*
+stage that changes the boot target is a defect.
+
+---
+
+## 7. Sign-off
+
+An RC is not releasable until this block is complete. It goes in the PR
+description alongside the results table, or in a report file under
+`docs/hardware-validation/`.
+
+```markdown
+## Update survivability sign-off
+
+- [ ] The test device is NOT the owner's only working unit (§2, device rule)
+- [ ] US-0 recovery precondition was proven BEFORE the first RC flash
+- [ ] Every matrix row US-0..US-11 has a recorded verdict
+- [ ] Running slot, target slot, image SHA-256 and boot result are recorded
+      for every transition — not just the successful ones
+- [ ] At least THREE consecutive successful installs across BOTH slots were
+      observed (US-1, US-2, US-3), not one
+- [ ] After each failure case, the previous slot was confirmed bootable (US-11)
+- [ ] Both install channels in scope for this RC were exercised (SD and/or OTA)
+
+Tested by: <name>
+Date: <YYYY-MM-DD>
+Firmware under test: <build SHA>
+Baseline it replaces: <build SHA>
+Verdict: <RELEASABLE | BLOCKED>
+```
+
+---
+
+## 8. What CI checks, and what it does not
+
+The workflow verifies the report was **written down**: that a protected file
+was touched, that a test device is named, that build SHAs are real hashes and
+not `TBD`, that every matrix row carries a verdict, and that no row failed.
+
+It cannot verify the results are **true**. Nobody can automate that — the whole
+premise of this gate is that no CI job runs on hardware. The reviewer owns
+judging whether the recorded slots, hashes and boot results describe a test
+that actually happened.
+
+Protected paths, from
+[`scripts/update-survivability-gate.sh`](../scripts/update-survivability-gate.sh):
+
+- `src/network/FirmwareFlasher.*`, `src/network/OtaUpdater.*`,
+  `src/network/OtaBootSwitch.*`, `src/network/FirmwareBoardTag.*`,
+  `src/network/FirmwareImageIdentity.h`, `src/network/FirmwareUpdatePolicy.h`
+- `src/OtaRollback*`
+- `src/activities/settings/SdFirmwareUpdateActivity.*`,
+  `src/activities/settings/OtaUpdateActivity.*`
+- `partitions.csv`
+- `.github/workflows/release*.yml`
+- Broad conventions so newly added files are caught without a list update:
+  `src/network/Firmware*`, `src/network/Ota*`, `src/Ota*`,
+  `src/activities/settings/Ota*`, `src/activities/settings/SdFirmware*`,
+  and any `scripts/*sign*`, `scripts/*hash*`, `scripts/*checksum*`,
+  `scripts/*digest*`
+
+One documented carve-out: `.github/workflows/release-fonts.yml` matches
+`release*.yml` by name but publishes SD-card font packs — it touches no
+firmware image, partition or boot slot, so no install testing could say
+anything about a change to it. It is excluded explicitly rather than left as a
+false positive, because a gate that hard-blocks work it has nothing to say
+about is a gate people learn to route around. Any new exclusion must clear the
+same bar.
+
+The gate is triggered by the **diff**, not by a label. A PR cannot opt out of
+it by omitting or removing a label — see the workflow header for that decision
+and its residual failure mode.

--- a/docs/update-survivability-gate.md
+++ b/docs/update-survivability-gate.md
@@ -376,26 +376,44 @@ and its residual failure mode.
 
 ### How the result reaches branch protection
 
-The job publishes a **commit status** with the context
-**`update-survivability-gate`** against
-`github.event.pull_request.head.sha`, via
-`POST /repos/{owner}/{repo}/statuses/{sha}` — the same mechanism
-[`thin-fork-guard-trusted.yml`](../.github/workflows/thin-fork-guard-trusted.yml)
-uses. The head SHA comes from the event payload and never from `GITHUB_SHA`,
-which under `pull_request_target` is a commit on the *base* branch: a result
-keyed to that would not be a result about the pull request's code. Every push
-re-runs the workflow and posts a fresh status against the new head SHA, and the
-status is posted on **every** outcome — pass, block, and the fail-closed
-"could not determine a verdict" path — so a required check is never left
-pending. The job is named `update-survivability-gate` too, so a ruleset entry
-naming that context matches both the posted status and the job's own check run.
+The verdict reaches branch protection as this job's own **GitHub Actions check
+run**. The job is named exactly **`update-survivability-gate`**, and that string
+is the context a ruleset must require.
 
-Publishing that status is why this workflow holds `statuses: write`, and why it
-is the second (and only other) entry on
-[`scripts/thin-fork-guard.sh`](../scripts/thin-fork-guard.sh)'s gate-7
-allowlist. That list stays exhaustive: any other workflow acquiring
-`statuses: write`, `checks: write` or `write-all` still fails the thin-fork
-guard.
+The gate deliberately does **not** publish a commit status via the Statuses API,
+the way [`thin-fork-guard-trusted.yml`](../.github/workflows/thin-fork-guard-trusted.yml)
+does. Doing so needs `statuses: write`, and the only place to authorise that is
+the gate-7 allowlist inside
+[`scripts/thin-fork-guard.sh`](../scripts/thin-fork-guard.sh) — a
+`SECURITY_BOUNDARY_FILES` entry, as is `scripts/check-workflow-permissions.rb`.
+An ordinary PR cannot edit either, by design, so shipping a status writer here
+would have meant temporarily relaxing branch protection in order to merge the
+very workflow that tightens it, and would have left the repository with a second
+workflow able to write a required status — weakening the invariant that only one
+known evaluator can. The check run already provides the property, so this
+workflow holds **no write scope of any kind** and the gate-7 allowlist stays
+exhaustive at one entry.
+
+That choice rests on a fact measured on this repository rather than assumed:
+
+> For `pull_request_target`, `GITHUB_SHA` inside the job **is** a commit on the
+> base branch — but the workflow **run** and its **check suite** are associated
+> with the **PR head SHA**. Verified against `thin-fork-guard-trusted.yml`
+> (also `pull_request_target`) on PR #216: the run's `head_sha`, the check
+> suite's `head_sha` and the PR head SHA were all `b186c1e8`, while the base was
+> `42802346`.
+
+So the check run lands on the commit branch protection actually evaluates, and
+`synchronize` re-runs it on every push. Nothing in the workflow reads
+`GITHUB_SHA`; where the head SHA is genuinely needed — clearing a gate
+self-modification requires an approving review on the *current* head — it comes
+from `github.event.pull_request.head.sha` through `env:`.
+
+**The limit of that measurement, stated plainly:** it was taken on a *same-repo*
+pull request. It has not been verified for a pull request opened from a **fork**.
+Confirm the context appears on a fork PR's head SHA before making this a required
+check. If it does not, a required check that never reports blocks every fork PR,
+and the status-writer route above becomes necessary after all.
 
 ### The gate protects itself: gate self-modification
 

--- a/docs/update-survivability-gate.md
+++ b/docs/update-survivability-gate.md
@@ -332,3 +332,43 @@ blocking path will not be in the diff you are looking at.
 The gate is triggered by the **diff**, not by a label. A PR cannot opt out of
 it by omitting or removing a label — see the workflow header for that decision
 and its residual failure mode.
+
+### Branches that do not carry this workflow
+
+The gate runs on `pull_request_target`, so GitHub executes the **base branch's**
+copy of the workflow, not the pull request's. A pull request opened against a
+branch that predates this file therefore gets no gate run at all — and it gets
+none *silently*. There is no red check, no skipped check, and nothing in the
+PR's check list to notice; the absence looks exactly like a clean sheet. That
+is the same shape of failure the gate exists to prevent, so it is called out
+here rather than left to be discovered.
+
+Two rules follow.
+
+**Create every future `release/*` and `sync/*` branch from `develop` once
+`develop` carries this workflow.** A branch cut from protected `develop` carries
+the gate with it, and every PR into it is checked automatically. Existing
+release and sync branches are deliberately **not** retrofitted: rewriting the
+history of a branch that has already produced a tested artifact would cost the
+provenance of that artifact for no gain the manual route below does not
+already provide.
+
+**A PR into a branch without the workflow needs a trusted manual gate result
+attached before it merges.** Run
+[`scripts/update-survivability-gate.sh`](../scripts/update-survivability-gate.sh)
+from a commit on a protected branch — never from the PR's own head, which the
+PR author controls — against that PR's exact base and head SHAs, and attach the
+complete output as a comment. To count as trusted, the comment must state:
+
+- the branch and commit the gate script itself came from;
+- the PR's base SHA and head SHA, verbatim;
+- the changed-record count, and whether the API's 3000-file cap was hit;
+- the gate's **complete** output, untruncated;
+- the exit code and its meaning — and note that exit 2 means the gate could not
+  determine an answer, which is a failure, never a pass;
+- that the gate's own self-test suite was run and passed.
+
+A manual result is weaker evidence than an automatic one, because a human chose
+when to run it and against what. Attaching one is a reviewer-facing obligation,
+not a formality — the reviewer is the enforcement mechanism, and should refuse a
+PR that lacks it exactly as CI would.

--- a/scripts/test-update-survivability-gate.sh
+++ b/scripts/test-update-survivability-gate.sh
@@ -379,6 +379,30 @@ expect_output "the message explains that a mention is not a row" \
   "$(complete_report | sed 's/^| US-6 .*/US-6 was fine: PASS/')" "" "fix: ota"
 
 echo
+echo "== exactly one row per case: a duplicate must never let PASS hide FAIL =="
+# The reported hazard, precisely: evidence is the PR body concatenated with the
+# hardware report, so an author can present a PASS row for a case in the body
+# while the attached report records FAIL for the same case. Taking the first
+# match would report the RC as validated.
+run_case "an earlier PASS cannot hide a later FAIL for the same case" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report)
+| US-2  | app1    | app0   | 3c4d5e6f      | ok   | FAIL |" "" "fix: ota"
+run_case "a later PASS cannot hide an earlier FAIL for the same case" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 \(.*\)PASS |/| US-2 \1FAIL |/')
+| US-2  | app1    | app0   | 3c4d5e6f      | ok   | PASS |" "" "fix: ota"
+run_case "two identical PASS rows for one case are still ambiguous" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report)
+| US-2  | app1    | app0   | 3c4d5e6f      | ok   | PASS |" "" "fix: ota"
+expect_output "the message says exactly one row is required" \
+  'exactly one is required' \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report)
+| US-2  | app1    | app0   | 3c4d5e6f      | ok   | FAIL |" "" "fix: ota"
+
+echo
 echo "== N/A is permitted only for US-4 =="
 run_case "N/A on US-4 is accepted" 0 \
   "src/network/OtaUpdater.cpp" "$(complete_report)" "" "fix: ota"

--- a/scripts/test-update-survivability-gate.sh
+++ b/scripts/test-update-survivability-gate.sh
@@ -14,12 +14,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GATE="$SCRIPT_DIR/update-survivability-gate.sh"
+GATE_DOC_FILE="$SCRIPT_DIR/../docs/update-survivability-gate.md"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 PASSED=0
 FAILED=0
+
+# The PR head SHA every fixture is judged against. A maintainer approval only
+# clears a gate self-modification when it was recorded against THIS commit.
+HEAD_SHA="cafebabecafebabecafebabecafebabecafebabe"
+OLD_HEAD_SHA="0ff5e70ff5e70ff5e70ff5e70ff5e70ff5e70ff5"
+
+# Review fixtures, one `state<TAB>author_association<TAB>commit_id` per line --
+# the shape the workflow produces from the GitHub pull-reviews API.
+REVIEW_NONE=""
+REVIEW_OWNER_CURRENT="APPROVED\tOWNER\t$HEAD_SHA"
+REVIEW_MEMBER_CURRENT="APPROVED\tMEMBER\t$HEAD_SHA"
+REVIEW_COLLABORATOR_CURRENT="APPROVED\tCOLLABORATOR\t$HEAD_SHA"
+REVIEW_OWNER_STALE="APPROVED\tOWNER\t$OLD_HEAD_SHA"
+REVIEW_OUTSIDER_CURRENT="APPROVED\tCONTRIBUTOR\t$HEAD_SHA"
+REVIEW_OWNER_COMMENTED="COMMENTED\tOWNER\t$HEAD_SHA"
 
 # A complete, well-formed report. Individual tests mutate copies of it.
 complete_report() {
@@ -48,17 +64,26 @@ Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=9f8e7d6
 REPORT
 }
 
-# run_case <name> <expected-exit> <changed-files> <evidence> <labels> <title>
+# write_fixtures <changed> <evidence> <labels> <reviews>
+write_fixtures() {
+  printf '%s\n' "$1" >"$TMP/changed"
+  printf '%s\n' "$2" >"$TMP/evidence"
+  printf '%s' "$3" >"$TMP/labels"
+  printf '%b\n' "$4" >"$TMP/reviews"
+}
+
+# run_case <name> <expected-exit> <changed-files> <evidence> <labels> <title> \
+#          [reviews] [head-sha]
 run_case() {
   local name="$1" want="$2" changed="$3" evidence="$4" labels="$5" title="$6"
-  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out" got=0
+  local reviews="${7-}" head="${8-$HEAD_SHA}"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" rv="$TMP/reviews"
+  local out="$TMP/out" got=0
 
-  printf '%s\n' "$changed" >"$cf"
-  printf '%s\n' "$evidence" >"$ev"
-  printf '%s' "$labels" >"$lb"
+  write_fixtures "$changed" "$evidence" "$labels" "$reviews"
 
   set +e
-  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  "$GATE" "$cf" "$ev" "$lb" "$title" "$rv" "$head" >"$out" 2>&1
   got=$?
   set -e
 
@@ -72,17 +97,18 @@ run_case() {
   fi
 }
 
-# expect_output <name> <grep-ere> <changed-files> <evidence> <labels> <title>
+# expect_output <name> <grep-ere> <changed-files> <evidence> <labels> <title> \
+#               [reviews] [head-sha]
 expect_output() {
   local name="$1" pattern="$2" changed="$3" evidence="$4" labels="$5" title="$6"
-  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out"
+  local reviews="${7-}" head="${8-$HEAD_SHA}"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" rv="$TMP/reviews"
+  local out="$TMP/out"
 
-  printf '%s\n' "$changed" >"$cf"
-  printf '%s\n' "$evidence" >"$ev"
-  printf '%s' "$labels" >"$lb"
+  write_fixtures "$changed" "$evidence" "$labels" "$reviews"
 
   set +e
-  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  "$GATE" "$cf" "$ev" "$lb" "$title" "$rv" "$head" >"$out" 2>&1
   set -e
 
   if grep -qE "$pattern" "$out"; then
@@ -95,17 +121,18 @@ expect_output() {
   fi
 }
 
-# expect_absent <name> <grep-ere> <changed-files> <evidence> <labels> <title>
+# expect_absent <name> <grep-ere> <changed-files> <evidence> <labels> <title> \
+#               [reviews] [head-sha]
 expect_absent() {
   local name="$1" pattern="$2" changed="$3" evidence="$4" labels="$5" title="$6"
-  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out"
+  local reviews="${7-}" head="${8-$HEAD_SHA}"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" rv="$TMP/reviews"
+  local out="$TMP/out"
 
-  printf '%s\n' "$changed" >"$cf"
-  printf '%s\n' "$evidence" >"$ev"
-  printf '%s' "$labels" >"$lb"
+  write_fixtures "$changed" "$evidence" "$labels" "$reviews"
 
   set +e
-  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  "$GATE" "$cf" "$ev" "$lb" "$title" "$rv" "$head" >"$out" 2>&1
   set -e
 
   if grep -qE "$pattern" "$out"; then
@@ -269,29 +296,38 @@ echo "== fail-closed: undetermined inputs must be exit 2, never exit 0 =="
 run_case "empty changed-file list" 2 "" "irrelevant" "" "chore: nothing"
 run_case "whitespace-only changed-file list" 2 "   " "irrelevant" "" "chore: nothing"
 
-set +e
-"$GATE" "$TMP/does-not-exist" "$TMP/evidence" "$TMP/labels" "t" >"$TMP/out" 2>&1
-rc=$?
-set -e
-if [ "$rc" -eq 2 ]; then
-  echo "  ok   unreadable changed-file list (exit 2)"
-  PASSED=$((PASSED + 1))
-else
-  echo "  FAIL unreadable changed-file list: expected exit 2, got $rc"
-  FAILED=$((FAILED + 1))
-fi
+# expect_exit <name> <expected-exit> <argv...>
+expect_exit() {
+  local name="$1" want="$2"
+  shift 2
+  local rc=0
+  set +e
+  "$GATE" "$@" >"$TMP/out" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq "$want" ]; then
+    echo "  ok   $name (exit $rc)"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL $name: expected exit $want, got $rc"
+    sed 's/^/       | /' "$TMP/out"
+    FAILED=$((FAILED + 1))
+  fi
+}
 
-set +e
-"$GATE" "$TMP/changed" "$TMP/evidence" >"$TMP/out" 2>&1
-rc=$?
-set -e
-if [ "$rc" -eq 2 ]; then
-  echo "  ok   wrong argument count (exit 2)"
-  PASSED=$((PASSED + 1))
-else
-  echo "  FAIL wrong argument count: expected exit 2, got $rc"
-  FAILED=$((FAILED + 1))
-fi
+expect_exit "unreadable changed-file list" 2 \
+  "$TMP/does-not-exist" "$TMP/evidence" "$TMP/labels" "t" "$TMP/reviews" "$HEAD_SHA"
+# An unreadable REVIEWS file is undetermined, not "nobody approved": the
+# difference decides whether a gate self-modification is judged at all.
+expect_exit "unreadable reviews list" 2 \
+  "$TMP/changed" "$TMP/evidence" "$TMP/labels" "t" "$TMP/does-not-exist" "$HEAD_SHA"
+# Without a head SHA an approval cannot be bound to a commit, so a stale
+# approval would be indistinguishable from a current one.
+expect_exit "empty head SHA" 2 \
+  "$TMP/changed" "$TMP/evidence" "$TMP/labels" "t" "$TMP/reviews" ""
+expect_exit "wrong argument count (2)" 2 "$TMP/changed" "$TMP/evidence"
+expect_exit "wrong argument count (4 -- the pre-review signature)" 2 \
+  "$TMP/changed" "$TMP/evidence" "$TMP/labels" "t"
 
 echo
 echo "== message quality =="
@@ -307,6 +343,265 @@ expect_output "UI escalation fires on a title scope" 'detected via: title' \
   "src/network/OtaUpdater.cpp" "no report" "" "feat(ui): install screen"
 expect_output "UI escalation fires on diff shape alone" 'detected via: diff-shape' \
   "$UI_PLUS_UPDATER_DIFF" "no report" "" "chore: unlabelled work"
+
+echo
+echo "== evidence parsing: a result is a structured ROW, not a mention =="
+# The looser "any line carrying the id and any verdict word" rule accepted a
+# sentence in the PR body as a completed hardware test, and accepted a row with
+# no recorded slots, image hash or boot result at all.
+run_case "a prose mention of a case id is not a matrix row" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-6 .*/US-6 wrong-board image was rejected: PASS/')" "" "fix: ota"
+run_case "row missing the running-slot cell" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 .*/| US-2  |         | app0   | 3c4d...       | ok   | PASS |/')" "" "fix: ota"
+run_case "row missing the target-slot cell" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 .*/| US-2  | app1    |        | 3c4d...       | ok   | PASS |/')" "" "fix: ota"
+run_case "row missing the image SHA-256 cell" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 .*/| US-2  | app1    | app0   |               | ok   | PASS |/')" "" "fix: ota"
+run_case "row missing the boot-result cell" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 .*/| US-2  | app1    | app0   | 3c4d...       |      | PASS |/')" "" "fix: ota"
+run_case "row whose cells are still TBD is not a filled-in row" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-2 .*/| US-2  | TBD     | TBD    | TBD           | TBD  | PASS |/')" "" "fix: ota"
+run_case "row with too few cells to carry a verdict" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-9 .*/| US-9  | app1 | PASS |/')" "" "fix: ota"
+run_case "the verdict must be in the Verdict cell, not loose on the line" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-3 .*/| US-3  | app0    | app1   | 5e6f...       | PASS |      |/')" "" "fix: ota"
+expect_output "the message explains that a mention is not a row" \
+  'must be a full matrix row' \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-6 .*/US-6 was fine: PASS/')" "" "fix: ota"
+
+echo
+echo "== N/A is permitted only for US-4 =="
+run_case "N/A on US-4 is accepted" 0 \
+  "src/network/OtaUpdater.cpp" "$(complete_report)" "" "fix: ota"
+run_case "N/A on US-5 is rejected" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-5 \(.*\)PASS |/| US-5 \1N\/A  |/')" "" "fix: ota"
+run_case "N/A on US-11 is rejected" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-11 \(.*\)PASS |/| US-11 \1N\/A  |/')" "" "fix: ota"
+run_case "N/A on US-0 (the recovery precondition) is rejected" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-0 \(.*\)PASS |/| US-0 \1N\/A  |/')" "" "fix: ota"
+expect_output "the rejection says N/A is not permitted for that case" \
+  'N/A is not permitted for this case' \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^| US-5 \(.*\)PASS |/| US-5 \1N\/A  |/')" "" "fix: ota"
+
+echo
+echo "== build SHAs: three real, DISTINCT hashes =="
+run_case "a single build SHA is not three" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: 3321f1e1/')" "" "fix: ota"
+run_case "A and B present, C absent" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=a1b2c3d4e5f/')" "" "fix: ota"
+run_case "C is a placeholder, not a hash" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=TBD/')" "" "fix: ota"
+run_case "a hash shorter than 7 hex is not a commit id" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=9f8e/')" "" "fix: ota"
+run_case "A, B and C all identical" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=3321f1e1 C=3321f1e1/')" "" "fix: ota"
+run_case "B and C identical (C must be distinguishable from B)" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=a1b2c3d4e5f/')" "" "fix: ota"
+run_case "case differences do not make two SHAs distinct" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=A1B2C3D4E5F C=a1b2c3d4e5f/')" "" "fix: ota"
+run_case "three distinct hashes are accepted" 0 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=deadbee1 B=deadbee2 C=deadbee3/')" "" "fix: ota"
+expect_output "the message asks for three DISTINCT builds" 'THREE DISTINCT' \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: A=3321f1e1 B=3321f1e1 C=3321f1e1/')" "" "fix: ota"
+run_case "a placeholder test device is not a named unit" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(complete_report | sed 's/^Test device:.*/Test device: <model, serial\/MAC>/')" "" "fix: ota"
+
+echo
+echo "== gate self-modification: a separate, fail-closed classification =="
+# A PR that changes ONLY the gate's own workflow or evaluator matches no
+# protected firmware path. Without this classification it reports "Not
+# applicable" and an edit weakening the evaluator for every future PR merges
+# behind a green check.
+GATE_WORKFLOW=".github/workflows/update-survivability-gate.yml"
+GATE_SCRIPT="scripts/update-survivability-gate.sh"
+GATE_SELFTEST="scripts/test-update-survivability-gate.sh"
+GATE_DOC_PATH="docs/update-survivability-gate.md"
+
+run_case "the gate workflow alone blocks" 1 \
+  "$GATE_WORKFLOW" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+run_case "the evaluator script alone blocks" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+run_case "the gate self-test suite alone blocks" 1 \
+  "$GATE_SELFTEST" "Add a test." "" "test: gate" "$REVIEW_NONE"
+run_case "the gate document alone blocks" 1 \
+  "$GATE_DOC_PATH" "Fix a typo." "" "docs: gate typo" "$REVIEW_NONE"
+expect_absent "a gate self-modification is never reported as Not applicable" \
+  ':white_check_mark: \*\*Not applicable' \
+  "$GATE_WORKFLOW" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+expect_output "the failure names the gate file that was touched" \
+  '\.github/workflows/update-survivability-gate\.yml' \
+  "$GATE_WORKFLOW" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+expect_output "the failure says a hardware matrix does not clear it" \
+  'says nothing about a change to a CI workflow or a shell script' \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+expect_output "the failure states it is a visibility control, not prevention" \
+  'visibility control, not a prevention control' \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+expect_output "the failure names no approving maintainer review" \
+  'no approving maintainer review' \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+
+run_case "an APPROVED OWNER review on the current head clears it" 0 \
+  "$GATE_WORKFLOW" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OWNER_CURRENT"
+run_case "an APPROVED MEMBER review on the current head clears it" 0 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_MEMBER_CURRENT"
+run_case "an APPROVED COLLABORATOR review on the current head clears it" 0 \
+  "$GATE_DOC_PATH" "Fix a typo." "" "docs: gate typo" "$REVIEW_COLLABORATOR_CURRENT"
+run_case "an approval recorded against an EARLIER commit does not clear it" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OWNER_STALE"
+expect_output "a stale approval is reported as given against an earlier commit" \
+  'earlier commit' \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OWNER_STALE"
+run_case "an approval from a non-maintainer association does not clear it" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OUTSIDER_CURRENT"
+expect_output "a non-maintainer approval is reported as an association problem" \
+  'author_association' \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OUTSIDER_CURRENT"
+run_case "a COMMENTED review from the owner is not an approval" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_OWNER_COMMENTED"
+run_case "no review at all blocks" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "" "ci: gate tweak" "$REVIEW_NONE"
+
+# The clearing mechanism must not be anything the PR author writes: the same
+# person who wrote the change writes the body, the title and the labels.
+run_case "an acknowledgement line in the PR body does NOT clear it" 1 \
+  "$GATE_SCRIPT" "Gate-self-modification: tightening the parser, reviewed by me." \
+  "" "ci: gate tweak" "$REVIEW_NONE"
+run_case "a label does NOT clear it" 1 \
+  "$GATE_SCRIPT" "Tighten the gate." "gate-self-modification" "ci: gate tweak" "$REVIEW_NONE"
+
+run_case "renaming the evaluator away is still a gate self-modification" 1 \
+  "scripts/us-gate.sh${TAB}${GATE_SCRIPT}" "Rename." "" "refactor: shorter name" "$REVIEW_NONE"
+run_case "renaming something INTO the evaluator path is a gate self-modification" 1 \
+  "${GATE_SCRIPT}${TAB}scripts/us-gate.sh" "Rename." "" "refactor: longer name" "$REVIEW_NONE"
+
+# Both classifications can apply at once, and both must then be satisfied.
+GATE_PLUS_UPDATER_DIFF="$GATE_WORKFLOW
+src/network/OtaUpdater.cpp"
+run_case "gate file + protected path: a complete report alone is not enough" 1 \
+  "$GATE_PLUS_UPDATER_DIFF" "$(complete_report)" "" "fix: ota and gate" "$REVIEW_NONE"
+run_case "gate file + protected path: an approval alone is not enough" 1 \
+  "$GATE_PLUS_UPDATER_DIFF" "No report." "" "fix: ota and gate" "$REVIEW_OWNER_CURRENT"
+run_case "gate file + protected path: report AND approval passes" 0 \
+  "$GATE_PLUS_UPDATER_DIFF" "$(complete_report)" "" "fix: ota and gate" "$REVIEW_OWNER_CURRENT"
+run_case "an ordinary PR is unaffected by the reviews input" 0 \
+  "docs/troubleshooting.md" "Typo." "" "docs: typo" "$REVIEW_NONE"
+
+echo
+echo "== lockstep: the document's own §5 template must satisfy this parser =="
+# The single most important test here. Tightening the parser without updating
+# the published template would reject every real hardware report a human fills
+# in, which makes the gate unusable and therefore routed around. These two
+# cases pin the template and the parser to each other: the REAL template, read
+# out of docs/update-survivability-gate.md, must pass when filled in and must
+# fail when left as issued.
+
+# The fenced markdown block inside "## 5. Results table".
+doc_results_template() {
+  # The fence is toggled BEFORE the section-end test: the template itself
+  # contains `## Hardware validation`, which would otherwise be read as the
+  # start of the next document section.
+  awk '
+    /^## 5\./ { in5 = 1; next }
+    in5 && /^```/ { fence = 1 - fence; next }
+    in5 && !fence && /^## / { in5 = 0 }
+    in5 && fence { print }
+  ' "$GATE_DOC_FILE"
+}
+
+# Fill that template in the way a tester would: every placeholder line gets a
+# plausible value, and every EMPTY matrix cell is filled according to its own
+# column heading -- so reordering, renaming or adding a column in the document
+# changes what this produces and breaks the test rather than silently drifting.
+fill_doc_template() {
+  doc_results_template | awk '
+    function trim(v) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); return v }
+    /^Test device:/ { print "Test device: X4 Pro #2 (designated test unit, MAC 38:44:be:e1:d8:41)"; next }
+    /^Recovery method proven:/ { print "Recovery method proven: tested rollback"; next }
+    /^Build SHAs:/ { print "Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=9f8e7d6"; next }
+    /^Image SHA-256:/ { print "Image SHA-256: A=aa11bb22cc33 B=dd44ee55ff66 C=1122334455aa"; next }
+    /^Firmware channel/ { print "Firmware channel(s) exercised: both"; next }
+    /^[[:space:]]*\|/ {
+      n = split($0, c, "|")
+      id = trim(c[2])
+      if (tolower(id) == "id") {
+        for (i = 2; i < n; i++) hdr[i] = tolower(trim(c[i]))
+        print
+        next
+      }
+      if (id ~ /^-+$/) { print; next }
+      if (id ~ /^US-/) {
+        out = ""
+        for (i = 2; i < n; i++) {
+          v = trim(c[i])
+          if (v == "" && i > 2) {
+            h = hdr[i]
+            if (h ~ /running/) v = "app0"
+            else if (h ~ /target/) v = "app1"
+            else if (h ~ /sha/) v = "1a2b3c4d5e6f7a8b"
+            else if (h ~ /boot/) v = "booted ok"
+            else if (h ~ /verdict/) v = "PASS"
+            else if (h ~ /note/) v = ""
+            else v = "-"
+          }
+          out = out "| " v " "
+        }
+        print out "|"
+        next
+      }
+      print
+      next
+    }
+    { print }
+  '
+}
+
+DOC_TEMPLATE_RAW="$(doc_results_template)"
+DOC_TEMPLATE_FILLED="$(fill_doc_template)"
+
+if [ -n "$DOC_TEMPLATE_RAW" ] && grep -q 'US-11' <<<"$DOC_TEMPLATE_RAW"; then
+  echo "  ok   the §5 results template was found in $GATE_DOC_FILE"
+  PASSED=$((PASSED + 1))
+else
+  echo "  FAIL could not extract the §5 results template from $GATE_DOC_FILE"
+  FAILED=$((FAILED + 1))
+fi
+
+run_case "the document's own §5 template, filled in, PASSES this parser" 0 \
+  "src/network/OtaUpdater.cpp" "$DOC_TEMPLATE_FILLED" "" "fix: ota"
+run_case "the same template left as issued (blank / <placeholder>) FAILS" 1 \
+  "src/network/OtaUpdater.cpp" "$DOC_TEMPLATE_RAW" "" "fix: ota"
+run_case "the filled template with an unauthorized N/A still FAILS" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(printf '%s\n' "$DOC_TEMPLATE_FILLED" | sed 's/^| US-7 \(.*\)| PASS |/| US-7 \1| N\/A  |/')" \
+  "" "fix: ota"
+run_case "the filled template with TBD build SHAs still FAILS" 1 \
+  "src/network/OtaUpdater.cpp" \
+  "$(printf '%s\n' "$DOC_TEMPLATE_FILLED" | sed 's/^Build SHAs:.*/Build SHAs: TBD/')" \
+  "" "fix: ota"
 
 echo
 echo "-------------------------------------------"

--- a/scripts/test-update-survivability-gate.sh
+++ b/scripts/test-update-survivability-gate.sh
@@ -95,6 +95,29 @@ expect_output() {
   fi
 }
 
+# expect_absent <name> <grep-ere> <changed-files> <evidence> <labels> <title>
+expect_absent() {
+  local name="$1" pattern="$2" changed="$3" evidence="$4" labels="$5" title="$6"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out"
+
+  printf '%s\n' "$changed" >"$cf"
+  printf '%s\n' "$evidence" >"$ev"
+  printf '%s' "$labels" >"$lb"
+
+  set +e
+  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  set -e
+
+  if grep -qE "$pattern" "$out"; then
+    echo "  FAIL $name: output unexpectedly matched /$pattern/"
+    sed 's/^/       | /' "$out"
+    FAILED=$((FAILED + 1))
+  else
+    echo "  ok   $name"
+    PASSED=$((PASSED + 1))
+  fi
+}
+
 UI_ONLY_DIFF='src/activities/settings/DisplaySettingsActivity.cpp
 lib/UITheme/UITheme.cpp
 lib/I18n/translations/english.yaml'
@@ -134,6 +157,90 @@ run_case "broad pattern catches a NEW updater file the named list predates" 1 \
   "src/network/FirmwareSignature.cpp" "New signature verifier." "" "feat: verify signatures"
 run_case "signing script" 1 \
   "scripts/sign_firmware.py" "New signer." "" "feat: sign images"
+
+echo
+echo "== renames: BOTH sides of every rename are classified =="
+# The GitHub pull-files API reports a rename's destination in `filename` and
+# its source in `previous_filename`; the gate's changed-file records carry them
+# as `destination<TAB>source`. Matching the destination alone was a total
+# bypass: rename src/network/OtaUpdater.cpp to src/network/Updater.cpp, rewrite
+# it in the same commit, and the resulting list matches no protected pattern,
+# so the gate reports "Not applicable" and the updater ships with no hardware
+# validation. Every case below fails loudly if that regresses.
+TAB=$'\t'
+
+# Protected SOURCE -> unprotected destination. Contents changed in the same
+# commit. This is the reported bypass; it must block.
+RENAME_AWAY_DIFF="src/network/Updater.cpp${TAB}src/network/OtaUpdater.cpp
+src/network/Updater.h${TAB}src/network/OtaUpdater.h
+src/activities/settings/DisplaySettingsActivity.cpp"
+
+# Unprotected source -> protected DESTINATION. Whatever now lives at the
+# protected pathname is the update path from this commit on.
+RENAME_INTO_DIFF="src/network/OtaUpdater.cpp${TAB}src/network/Updater.cpp
+lib/UITheme/UITheme.cpp"
+
+run_case "protected source renamed to unprotected destination, contents changed" 1 \
+  "$RENAME_AWAY_DIFF" "Renames the updater while reworking the install screen." "ui" \
+  "feat(ui): touch install screen"
+run_case "unprotected source renamed INTO a protected path" 1 \
+  "$RENAME_INTO_DIFF" "Moves the download helper." "" "refactor: rename Updater to OtaUpdater"
+run_case "unprotected renamed to unprotected" 0 \
+  "src/network/HttpClient.cpp${TAB}src/network/HttpDownloader.cpp" "Rename only." "" \
+  "refactor: rename the downloader"
+# The gate has no diff-size, patch or similarity-score input at all: a pure
+# 100%-similarity rename that changes not one byte is classified exactly like a
+# rewrite, because the question is which paths moved, never how much moved.
+run_case "pure rename, no content change, is still classified by path" 1 \
+  "src/network/Updater.cpp${TAB}src/network/OtaUpdater.cpp" \
+  "Pure rename, zero content change." "" "refactor: shorter filename"
+run_case "renamed protected path WITH a complete report" 0 \
+  "$RENAME_AWAY_DIFF" "$(complete_report)" "ui" "feat(ui): touch install screen"
+run_case "both sides protected (OtaUpdater -> FirmwareFlasher-ish)" 1 \
+  "src/network/OtaBootSwitch.cpp${TAB}src/network/OtaUpdater.cpp" "Split." "" "refactor: split ota"
+
+# Exclusions are evaluated per PATH, not per record, so the one documented
+# carve-out cannot be used as a laundering route in either direction.
+run_case "carve-out source renamed INTO real release machinery" 1 \
+  ".github/workflows/release-firmware.yml${TAB}.github/workflows/release-fonts.yml" \
+  "Repurpose the font workflow." "" "chore: reuse the workflow"
+run_case "carve-out renamed to something unprotected" 0 \
+  "docs/font-packs.md${TAB}.github/workflows/release-fonts.yml" "Retire the workflow." "" \
+  "chore: drop the font workflow"
+run_case "protected path laundered through the carve-out name" 1 \
+  ".github/workflows/release-fonts.yml${TAB}.github/workflows/release.yml" "Rename." "" \
+  "chore: rename release workflow"
+
+# A record with an empty second field is an ordinary non-rename change, so a
+# plain one-path-per-line list (every other test above) stays valid input.
+run_case "empty rename field is a plain change (protected)" 1 \
+  "src/network/OtaUpdater.cpp${TAB}" "No report." "" "fix: ota"
+run_case "empty rename field is a plain change (unprotected)" 0 \
+  "docs/troubleshooting.md${TAB}" "Typo." "" "docs: typo"
+
+echo
+echo "== rename message quality: name BOTH paths and the direction =="
+expect_output "rename-away failure names the source path the author no longer has" \
+  'src/network/OtaUpdater\.cpp -> src/network/Updater\.cpp' \
+  "$RENAME_AWAY_DIFF" "no report" "" "refactor: rename the updater"
+expect_output "rename-away failure says it matched on the SOURCE path" \
+  'RENAMED AWAY from a protected path' \
+  "$RENAME_AWAY_DIFF" "no report" "" "refactor: rename the updater"
+expect_output "rename-into failure names both paths" \
+  'src/network/Updater\.cpp -> src/network/OtaUpdater\.cpp' \
+  "$RENAME_INTO_DIFF" "no report" "" "refactor: rename Updater to OtaUpdater"
+expect_output "rename-into failure says it matched on the DESTINATION path" \
+  'RENAMED INTO a protected path' \
+  "$RENAME_INTO_DIFF" "no report" "" "refactor: rename Updater to OtaUpdater"
+expect_output "the failure explains why a path not in the diff is blocking" \
+  'A rename is what put a protected path in this list' \
+  "$RENAME_AWAY_DIFF" "no report" "" "refactor: rename the updater"
+expect_absent "a non-rename failure carries no rename explanation" \
+  'RENAMED|A rename is what put' \
+  "src/network/OtaUpdater.cpp" "no report" "" "fix: ota"
+expect_absent "an unprotected rename is not reported as touching a protected path" \
+  'Blocked|Protected files touched' \
+  "src/network/HttpClient.cpp${TAB}src/network/HttpDownloader.cpp" "no report" "" "refactor: rename"
 
 echo
 echo "== report completeness =="

--- a/scripts/test-update-survivability-gate.sh
+++ b/scripts/test-update-survivability-gate.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# test-update-survivability-gate.sh
+#
+# Self-test for scripts/update-survivability-gate.sh, run by
+# .github/workflows/update-survivability-gate.yml BEFORE the gate's verdict on
+# a real PR is trusted. Synthetic fixtures only -- no dependency on this
+# repository's real history, so the test means the same thing on every branch.
+#
+# Mirrors scripts/test-thin-fork-guard.sh's role for the thin-fork guard: a
+# gate whose own matching logic has never been exercised is not evidence.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/update-survivability-gate.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASSED=0
+FAILED=0
+
+# A complete, well-formed report. Individual tests mutate copies of it.
+complete_report() {
+  cat <<'REPORT'
+## Hardware validation
+
+Test device: X4 Pro #2 (designated test unit, MAC 38:44:be:e1:d8:41)
+Build SHAs: A=3321f1e1 B=a1b2c3d4e5f C=9f8e7d6
+
+### Survivability matrix
+
+| Case  | Running | Target | Image SHA-256 | Boot | Verdict |
+|-------|---------|--------|---------------|------|---------|
+| US-0  | app0    | -      | -             | -    | PASS |
+| US-1  | app0    | app1   | 1a2b...       | ok   | PASS |
+| US-2  | app1    | app0   | 3c4d...       | ok   | PASS |
+| US-3  | app0    | app1   | 5e6f...       | ok   | PASS |
+| US-4  | app1    | app1   | -             | -    | N/A  |
+| US-5  | app1    | -      | 7a8b...       | ok   | PASS |
+| US-6  | app1    | -      | 9c0d...       | ok   | PASS |
+| US-7  | app1    | -      | e1f2...       | ok   | PASS |
+| US-8  | app1    | -      | -             | ok   | PASS |
+| US-9  | app1    | -      | -             | ok   | PASS |
+| US-10 | app1    | app0   | 3344...       | ok   | PASS |
+| US-11 | app1    | -      | -             | ok   | PASS |
+REPORT
+}
+
+# run_case <name> <expected-exit> <changed-files> <evidence> <labels> <title>
+run_case() {
+  local name="$1" want="$2" changed="$3" evidence="$4" labels="$5" title="$6"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out" got=0
+
+  printf '%s\n' "$changed" >"$cf"
+  printf '%s\n' "$evidence" >"$ev"
+  printf '%s' "$labels" >"$lb"
+
+  set +e
+  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  got=$?
+  set -e
+
+  if [ "$got" -eq "$want" ]; then
+    echo "  ok   $name (exit $got)"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL $name: expected exit $want, got $got"
+    sed 's/^/       | /' "$out"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# expect_output <name> <grep-ere> <changed-files> <evidence> <labels> <title>
+expect_output() {
+  local name="$1" pattern="$2" changed="$3" evidence="$4" labels="$5" title="$6"
+  local cf="$TMP/changed" ev="$TMP/evidence" lb="$TMP/labels" out="$TMP/out"
+
+  printf '%s\n' "$changed" >"$cf"
+  printf '%s\n' "$evidence" >"$ev"
+  printf '%s' "$labels" >"$lb"
+
+  set +e
+  "$GATE" "$cf" "$ev" "$lb" "$title" >"$out" 2>&1
+  set -e
+
+  if grep -qE "$pattern" "$out"; then
+    echo "  ok   $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL $name: output did not match /$pattern/"
+    sed 's/^/       | /' "$out"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+UI_ONLY_DIFF='src/activities/settings/DisplaySettingsActivity.cpp
+lib/UITheme/UITheme.cpp
+lib/I18n/translations/english.yaml'
+
+UI_PLUS_UPDATER_DIFF='src/activities/settings/DisplaySettingsActivity.cpp
+lib/UITheme/UITheme.cpp
+src/network/OtaUpdater.cpp
+src/network/FirmwareFlasher.cpp'
+
+echo "== negative path: PRs the gate must let through =="
+run_case "UI-only diff, UI label, no report" 0 \
+  "$UI_ONLY_DIFF" "Adds a touch target to the display settings list." "ui" "feat(ui): bigger touch targets"
+run_case "docs-only diff" 0 \
+  "docs/troubleshooting.md" "Typo fix." "" "docs: fix typo"
+run_case "similarly-named but unprotected file" 0 \
+  "src/network/HttpDownloader.cpp" "Retry tweak." "" "fix: retry once on a truncated read"
+run_case "carve-out: release-fonts.yml is not firmware release machinery" 0 \
+  ".github/workflows/release-fonts.yml" "Bump the font pack." "" "chore: new font pack"
+run_case "the carve-out is exact, not a prefix (release.yml still blocks)" 1 \
+  ".github/workflows/release.yml" "Bump asset name." "" "chore: rename asset"
+run_case "protected path touched WITH a complete report" 0 \
+  "$UI_PLUS_UPDATER_DIFF" "$(complete_report)" "ui" "feat(ui): touch install screen"
+
+echo
+echo "== positive path: PRs the gate must block =="
+run_case "UI PR touching the updater, no report" 1 \
+  "$UI_PLUS_UPDATER_DIFF" "Reworks the install screen for touch." "ui" "feat(ui): touch install screen"
+run_case "non-UI PR touching the updater, no report (label is irrelevant)" 1 \
+  "src/network/OtaUpdater.cpp" "Refactor." "" "refactor: tidy installUpdate"
+run_case "partitions.csv" 1 \
+  "partitions.csv" "Grow spiffs." "" "chore: repartition"
+run_case "release workflow" 1 \
+  ".github/workflows/release.yml" "Bump artifact name." "" "chore: rename asset"
+run_case "rollback source" 1 \
+  "src/OtaRollbackDetection.cpp" "Tidy." "" "refactor: rollback"
+run_case "broad pattern catches a NEW updater file the named list predates" 1 \
+  "src/network/FirmwareSignature.cpp" "New signature verifier." "" "feat: verify signatures"
+run_case "signing script" 1 \
+  "scripts/sign_firmware.py" "New signer." "" "feat: sign images"
+
+echo
+echo "== report completeness =="
+run_case "matrix row missing (US-11 deleted)" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | grep -v 'US-11')" "" "fix: ota"
+run_case "matrix row recorded as FAIL" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | sed 's/| US-7 .*|.*| PASS |/| US-7  | app1 | - | e1f2 | ok | FAIL |/')" "" "fix: ota"
+run_case "matrix row with no verdict at all" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | sed 's/| US-5 \(.*\)PASS |/| US-5 \1|/')" "" "fix: ota"
+run_case "test device not named" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | grep -v '^Test device:')" "" "fix: ota"
+run_case "build SHAs are a TBD placeholder, not hex" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | sed 's/^Build SHAs:.*/Build SHAs: TBD/')" "" "fix: ota"
+run_case "matrix block not labelled as such" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | sed 's/Survivability matrix/Results/')" "" "fix: ota"
+
+echo
+echo "== id anchoring: US-1 must not be satisfied by US-10 or US-11 =="
+run_case "US-1 removed but US-10/US-11 present" 1 \
+  "src/network/OtaUpdater.cpp" "$(complete_report | grep -v '| US-1  ')" "" "fix: ota"
+expect_output "the missing-row list names US-1 specifically" '^US-1$' \
+  "src/network/OtaUpdater.cpp" "$(complete_report | grep -v '| US-1  ')" "" "fix: ota"
+
+echo
+echo "== fail-closed: undetermined inputs must be exit 2, never exit 0 =="
+run_case "empty changed-file list" 2 "" "irrelevant" "" "chore: nothing"
+run_case "whitespace-only changed-file list" 2 "   " "irrelevant" "" "chore: nothing"
+
+set +e
+"$GATE" "$TMP/does-not-exist" "$TMP/evidence" "$TMP/labels" "t" >"$TMP/out" 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 2 ]; then
+  echo "  ok   unreadable changed-file list (exit 2)"
+  PASSED=$((PASSED + 1))
+else
+  echo "  FAIL unreadable changed-file list: expected exit 2, got $rc"
+  FAILED=$((FAILED + 1))
+fi
+
+set +e
+"$GATE" "$TMP/changed" "$TMP/evidence" >"$TMP/out" 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 2 ]; then
+  echo "  ok   wrong argument count (exit 2)"
+  PASSED=$((PASSED + 1))
+else
+  echo "  FAIL wrong argument count: expected exit 2, got $rc"
+  FAILED=$((FAILED + 1))
+fi
+
+echo
+echo "== message quality =="
+expect_output "failure names the offending files" 'src/network/OtaUpdater\.cpp' \
+  "$UI_PLUS_UPDATER_DIFF" "no report here" "ui" "feat(ui): touch install screen"
+expect_output "failure points at the gate document" 'docs/update-survivability-gate\.md' \
+  "$UI_PLUS_UPDATER_DIFF" "no report here" "ui" "feat(ui): touch install screen"
+expect_output "failure says builds/tests/CodeRabbit are not substitutes" 'CodeRabbit' \
+  "$UI_PLUS_UPDATER_DIFF" "no report here" "ui" "feat(ui): touch install screen"
+expect_output "UI escalation fires on a label" 'detected via: label' \
+  "src/network/OtaUpdater.cpp" "no report" "ui" "chore: bump"
+expect_output "UI escalation fires on a title scope" 'detected via: title' \
+  "src/network/OtaUpdater.cpp" "no report" "" "feat(ui): install screen"
+expect_output "UI escalation fires on diff shape alone" 'detected via: diff-shape' \
+  "$UI_PLUS_UPDATER_DIFF" "no report" "" "chore: unlabelled work"
+
+echo
+echo "-------------------------------------------"
+echo "passed: $PASSED   failed: $FAILED"
+if [ "$FAILED" -ne 0 ]; then
+  echo "test-update-survivability-gate.sh: FAILED"
+  exit 1
+fi
+echo "test-update-survivability-gate.sh: OK"

--- a/scripts/thin-fork-guard.sh
+++ b/scripts/thin-fork-guard.sh
@@ -47,11 +47,9 @@
 #      "Security-boundary file maintenance" in
 #      docs/upstream-sync-architecture.md for the explicit human procedure
 #      required to change one legitimately.
-#   5. INTRODUCE another status/check-writing workflow (section 7) --
-#      `.github/workflows/*.yml` at HEAD other than the two allowlisted
-#      trusted evaluators (thin-fork-guard-trusted.yml and
-#      update-survivability-gate.yml, both of which publish a required
-#      commit status against the PR head SHA) must never SEMANTICALLY grant
+#   5. INTRODUCE a second status/check-writing workflow (section 7) --
+#      `.github/workflows/*.yml` at HEAD other than
+#      thin-fork-guard-trusted.yml itself must never SEMANTICALLY grant
 #      `statuses: write`, `checks: write`, or the `write-all` shorthand.
 #      One invariant: no ordinary PR may create another workflow capable of
 #      spoofing the trusted required status. Each workflow file is parsed
@@ -790,30 +788,6 @@ done < <(git diff --name-status --diff-filter=R "$BASE_REF...$HEAD_REF")
 # backwards for a security gate -- WORKFLOW_AUDIT_ERROR captures any such
 # failure and aborts the whole script immediately (see below), the same
 # fail-closed posture COMMON_REF and measure-conflicts.sh already use.
-# The workflows allowed to hold status/check-write permissions. Both are
-# `pull_request_target` evaluators that publish a REQUIRED commit status
-# against the PR's head SHA, which is the one thing that genuinely cannot be
-# done without `statuses: write`:
-#   thin-fork-guard-trusted.yml  -> context `thin-fork-guard-trusted`
-#   update-survivability-gate.yml -> context `update-survivability-gate`
-# This list is EXHAUSTIVE by design and must stay short. The invariant is not
-# "status-writing is fine"; it is that only these known, reviewed evaluators
-# can write a required status, so no ordinary PR can introduce a workflow that
-# spoofs one. Adding an entry here is a security-boundary change and follows
-# the same procedure as any other (see docs/upstream-sync-architecture.md).
-STATUS_WRITE_ALLOWED_WORKFLOWS=(
-  ".github/workflows/thin-fork-guard-trusted.yml"
-  ".github/workflows/update-survivability-gate.yml"
-)
-
-is_status_write_allowed_workflow() {
-  local candidate="$1" allowed
-  for allowed in "${STATUS_WRITE_ALLOWED_WORKFLOWS[@]}"; do
-    [ "$candidate" = "$allowed" ] && return 0
-  done
-  return 1
-}
-
 CHECK_PERMS_SCRIPT="$SCRIPT_DIR/check-workflow-permissions.rb"
 WORKFLOW_PERMISSION_VIOLATIONS=""
 WORKFLOW_AUDIT_ERROR=""
@@ -839,7 +813,7 @@ fi
 if [ -z "$WORKFLOW_AUDIT_ERROR" ]; then
   while IFS= read -r path; do
     [ -z "$path" ] && continue
-    is_status_write_allowed_workflow "$path" && continue
+    [ "$path" = ".github/workflows/thin-fork-guard-trusted.yml" ] && continue
 
     if ! content="$(git show "$HEAD_REF:$path" 2>&1)"; then
       WORKFLOW_AUDIT_ERROR="${WORKFLOW_AUDIT_ERROR}failed to read '$path' at '$HEAD_REF': $content"$'\n'
@@ -1062,7 +1036,7 @@ fi
 
   if [ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ]; then
     echo "### Workflow files with forbidden status/check-write permissions (gates this PR)"
-    echo "Only \`thin-fork-guard-trusted.yml\` and \`update-survivability-gate.yml\` may hold these permissions:"
+    echo "Only \`thin-fork-guard-trusted.yml\` may hold these permissions:"
     echo '```'
     echo "$WORKFLOW_PERMISSION_VIOLATIONS"
     echo '```'
@@ -1075,7 +1049,7 @@ FAIL_REASONS=()
 [ -n "$MIDAD_NEW_DIVERGED" ] && FAIL_REASONS+=("introduces new Midad-side divergence in a file that was clean relative to the shared upstream history")
 [ -n "$RENAME_NEW_DIVERGED" ] && FAIL_REASONS+=("renames a Midad-clean shared file away from tracking upstream")
 [ -n "$SECURITY_BOUNDARY_TOUCHED" ] && FAIL_REASONS+=("security-boundary file modified -- explicit guard-maintenance procedure required")
-[ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ] && FAIL_REASONS+=("introduces a workflow with status/check-write permissions outside thin-fork-guard-trusted.yml and update-survivability-gate.yml, the only allowlisted trusted evaluators")
+[ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ] && FAIL_REASONS+=("introduces a workflow with status/check-write permissions outside thin-fork-guard-trusted.yml")
 
 if [ "${#FAIL_REASONS[@]}" -gt 0 ]; then
   echo "FAIL: this PR:"

--- a/scripts/thin-fork-guard.sh
+++ b/scripts/thin-fork-guard.sh
@@ -47,9 +47,11 @@
 #      "Security-boundary file maintenance" in
 #      docs/upstream-sync-architecture.md for the explicit human procedure
 #      required to change one legitimately.
-#   5. INTRODUCE a second status/check-writing workflow (section 7) --
-#      `.github/workflows/*.yml` at HEAD other than
-#      thin-fork-guard-trusted.yml itself must never SEMANTICALLY grant
+#   5. INTRODUCE another status/check-writing workflow (section 7) --
+#      `.github/workflows/*.yml` at HEAD other than the two allowlisted
+#      trusted evaluators (thin-fork-guard-trusted.yml and
+#      update-survivability-gate.yml, both of which publish a required
+#      commit status against the PR head SHA) must never SEMANTICALLY grant
 #      `statuses: write`, `checks: write`, or the `write-all` shorthand.
 #      One invariant: no ordinary PR may create another workflow capable of
 #      spoofing the trusted required status. Each workflow file is parsed
@@ -788,6 +790,30 @@ done < <(git diff --name-status --diff-filter=R "$BASE_REF...$HEAD_REF")
 # backwards for a security gate -- WORKFLOW_AUDIT_ERROR captures any such
 # failure and aborts the whole script immediately (see below), the same
 # fail-closed posture COMMON_REF and measure-conflicts.sh already use.
+# The workflows allowed to hold status/check-write permissions. Both are
+# `pull_request_target` evaluators that publish a REQUIRED commit status
+# against the PR's head SHA, which is the one thing that genuinely cannot be
+# done without `statuses: write`:
+#   thin-fork-guard-trusted.yml  -> context `thin-fork-guard-trusted`
+#   update-survivability-gate.yml -> context `update-survivability-gate`
+# This list is EXHAUSTIVE by design and must stay short. The invariant is not
+# "status-writing is fine"; it is that only these known, reviewed evaluators
+# can write a required status, so no ordinary PR can introduce a workflow that
+# spoofs one. Adding an entry here is a security-boundary change and follows
+# the same procedure as any other (see docs/upstream-sync-architecture.md).
+STATUS_WRITE_ALLOWED_WORKFLOWS=(
+  ".github/workflows/thin-fork-guard-trusted.yml"
+  ".github/workflows/update-survivability-gate.yml"
+)
+
+is_status_write_allowed_workflow() {
+  local candidate="$1" allowed
+  for allowed in "${STATUS_WRITE_ALLOWED_WORKFLOWS[@]}"; do
+    [ "$candidate" = "$allowed" ] && return 0
+  done
+  return 1
+}
+
 CHECK_PERMS_SCRIPT="$SCRIPT_DIR/check-workflow-permissions.rb"
 WORKFLOW_PERMISSION_VIOLATIONS=""
 WORKFLOW_AUDIT_ERROR=""
@@ -813,7 +839,7 @@ fi
 if [ -z "$WORKFLOW_AUDIT_ERROR" ]; then
   while IFS= read -r path; do
     [ -z "$path" ] && continue
-    [ "$path" = ".github/workflows/thin-fork-guard-trusted.yml" ] && continue
+    is_status_write_allowed_workflow "$path" && continue
 
     if ! content="$(git show "$HEAD_REF:$path" 2>&1)"; then
       WORKFLOW_AUDIT_ERROR="${WORKFLOW_AUDIT_ERROR}failed to read '$path' at '$HEAD_REF': $content"$'\n'
@@ -1036,7 +1062,7 @@ fi
 
   if [ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ]; then
     echo "### Workflow files with forbidden status/check-write permissions (gates this PR)"
-    echo "Only \`thin-fork-guard-trusted.yml\` may hold these permissions:"
+    echo "Only \`thin-fork-guard-trusted.yml\` and \`update-survivability-gate.yml\` may hold these permissions:"
     echo '```'
     echo "$WORKFLOW_PERMISSION_VIOLATIONS"
     echo '```'
@@ -1049,7 +1075,7 @@ FAIL_REASONS=()
 [ -n "$MIDAD_NEW_DIVERGED" ] && FAIL_REASONS+=("introduces new Midad-side divergence in a file that was clean relative to the shared upstream history")
 [ -n "$RENAME_NEW_DIVERGED" ] && FAIL_REASONS+=("renames a Midad-clean shared file away from tracking upstream")
 [ -n "$SECURITY_BOUNDARY_TOUCHED" ] && FAIL_REASONS+=("security-boundary file modified -- explicit guard-maintenance procedure required")
-[ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ] && FAIL_REASONS+=("introduces a workflow with status/check-write permissions outside thin-fork-guard-trusted.yml")
+[ -n "$WORKFLOW_PERMISSION_VIOLATIONS" ] && FAIL_REASONS+=("introduces a workflow with status/check-write permissions outside thin-fork-guard-trusted.yml and update-survivability-gate.yml, the only allowlisted trusted evaluators")
 
 if [ "${#FAIL_REASONS[@]}" -gt 0 ]; then
   echo "FAIL: this PR:"

--- a/scripts/update-survivability-gate.sh
+++ b/scripts/update-survivability-gate.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+#
+# update-survivability-gate.sh
+#
+# Fails a pull request that touches the firmware update path -- the flasher,
+# the OTA client, the boot-slot switch, the image validators, the partition
+# table, or the release/signing machinery -- unless it carries a hardware
+# validation report proving the device can still install a SECOND update after
+# the change.
+#
+# Why this exists
+# ---------------
+# A UI/touch hardware-test RC also changed the firmware installation path and
+# shipped without a two-slot update test. It installed once; the device could
+# then never install again, because runningPartitionChipId() (see
+# src/network/FirmwareFlasher.cpp) misreads chip identity from the running
+# slot, and BOTH install paths fail closed on that value:
+# src/network/FirmwareFlasher.cpp's validateImageFile() returns BAD_CHIP, and
+# src/network/OtaUpdater.cpp's installUpdate() aborts the transfer. The only
+# X4 Pro in the field became update-locked with no working recovery channel.
+#
+# Four board builds, 512 host tests, cppcheck, CodeQL and a full CodeRabbit
+# review all passed. None of them runs on hardware, and none of them exercises
+# an install CYCLE. This gate is the check that would have caught it, and the
+# only evidence it accepts is a real device completing the matrix in
+# docs/update-survivability-gate.md.
+#
+# Classification is DIFF-DERIVED, not metadata-derived
+# ----------------------------------------------------
+# The gate triggers on the changed-file list alone. A PR label, a title
+# convention, or a "this is only UI work" claim in the description cannot turn
+# it off -- there is nothing to remove, mislabel, or forget. Label and title
+# signals are read (see ui_presentation below), but they can only ESCALATE the
+# message, never suppress the gate. See the workflow file's header for the
+# residual failure mode this choice leaves open.
+#
+# Fail-closed contract
+# --------------------
+# Exit 0: no protected path touched, OR a complete hardware validation report
+#         is present and every matrix row passed.
+# Exit 1: a protected path was touched and the report is missing, incomplete,
+#         or records a FAIL/BLOCKED row.
+# Exit 2: the gate could not DETERMINE the answer -- an unreadable or empty
+#         changed-file list, an unreadable evidence file. The caller MUST
+#         treat exit 2 as a failure, never as a pass. Reading a missing input
+#         as "nothing to check" is the identical fail-open mistake that
+#         produced the incident this gate exists to prevent.
+#
+# Usage:
+#   update-survivability-gate.sh CHANGED_FILES EVIDENCE LABELS PR_TITLE
+#
+#   CHANGED_FILES  file, one repo-relative changed path per line
+#   EVIDENCE       file, the PR body concatenated with the content of any
+#                  docs/hardware-validation/*.md the PR adds or edits
+#   LABELS         file, one PR label per line (may be empty)
+#   PR_TITLE       the PR title, as a single argument
+#
+# Report is written to stdout as GitHub-flavoured Markdown, suitable for
+# $GITHUB_STEP_SUMMARY.
+
+set -euo pipefail
+
+GATE_DOC="docs/update-survivability-gate.md"
+
+# --- Protected paths ---------------------------------------------------------
+# Bash glob patterns, matched against each changed path with [[ == ]].
+#
+# The explicitly-named entries are the current update path. The trailing
+# broad patterns exist because the named list is a hand-maintained inventory
+# of danger and a NEW file is invisible to it until someone remembers to add
+# it -- exactly the class of omission this gate is about. The broad patterns
+# cover the naming conventions the update path actually uses, so a future
+# src/network/FirmwareSignature.cpp is caught on the day it is written.
+PROTECTED_PATTERNS=(
+  # -- named: image install and validation --
+  "src/network/FirmwareFlasher.*"
+  "src/network/OtaUpdater.*"
+  "src/network/OtaBootSwitch.*"
+  "src/network/FirmwareBoardTag.*"
+  "src/network/FirmwareImageIdentity.h"
+  "src/network/FirmwareUpdatePolicy.h"
+  # -- named: rollback / recovery --
+  "src/OtaRollback*"
+  # -- named: the two user-facing install activities --
+  "src/activities/settings/SdFirmwareUpdateActivity.*"
+  "src/activities/settings/OtaUpdateActivity.*"
+  # -- named: flash geometry and release machinery --
+  "partitions.csv"
+  ".github/workflows/release*.yml"
+  # -- broad: catch newly added files following the same conventions --
+  "src/network/Firmware*"
+  "src/network/Ota*"
+  "src/Ota*"
+  "src/activities/settings/Ota*"
+  "src/activities/settings/SdFirmware*"
+  "scripts/*sign*"
+  "scripts/*hash*"
+  "scripts/*checksum*"
+  "scripts/*digest*"
+)
+
+# --- Documented carve-outs ---------------------------------------------------
+# Checked BEFORE the protected list, and deliberately kept tiny. A gate that
+# hard-blocks work it has nothing to say about is a gate people learn to route
+# around, and a routed-around gate protects nothing -- so a genuine false
+# positive gets an explicit, reviewable exclusion here rather than a habit of
+# merging past a red check.
+#
+# release-fonts.yml publishes SD-card font packs. It matches
+# `.github/workflows/release*.yml` by name only; it touches no firmware image,
+# no partition and no boot slot, so no amount of two-slot install testing
+# could say anything about a change to it. Any NEW exclusion must clear the
+# same bar: the file cannot influence what image is built, validated, written
+# to a slot, or selected as bootable.
+EXCLUDED_PATTERNS=(
+  ".github/workflows/release-fonts.yml"
+)
+
+# --- Required matrix rows ----------------------------------------------------
+# Case IDs from docs/update-survivability-gate.md. Every one must appear in the
+# evidence with a verdict. Keep in sync with that document's table.
+REQUIRED_CASES=(
+  "US-0"   # recovery precondition proven before flashing
+  "US-1"   # A @ app0 -> install B -> app1
+  "US-2"   # B @ app1 -> install C -> app0
+  "US-3"   # C @ app0 -> install B -> app1
+  "US-4"   # self-reinstall (or N/A where unsupported)
+  "US-5"   # wrong-chip image rejected, neither slot erased
+  "US-6"   # wrong-board image rejected, never selected bootable
+  "US-7"   # corrupted / truncated image rejected before erase
+  "US-8"   # HTTP failure BEFORE download, fallback intact
+  "US-9"   # HTTP failure DURING download, fallback intact
+  "US-10"  # power-loss simulation at documented safe stages
+  "US-11"  # after every failure, the previous slot still boots
+)
+
+die_undetermined() {
+  echo "update-survivability-gate.sh: cannot determine verdict -- failing closed: $1" >&2
+  exit 2
+}
+
+# --- Inputs ------------------------------------------------------------------
+if [ "$#" -ne 4 ]; then
+  die_undetermined "expected 4 arguments (CHANGED_FILES EVIDENCE LABELS PR_TITLE), got $#"
+fi
+
+CHANGED_FILES_PATH="$1"
+EVIDENCE_PATH="$2"
+LABELS_PATH="$3"
+PR_TITLE="$4"
+
+[ -r "$CHANGED_FILES_PATH" ] || die_undetermined "changed-file list '$CHANGED_FILES_PATH' is not readable"
+[ -r "$EVIDENCE_PATH" ] || die_undetermined "evidence file '$EVIDENCE_PATH' is not readable"
+[ -r "$LABELS_PATH" ] || die_undetermined "labels file '$LABELS_PATH' is not readable"
+
+CHANGED_FILES="$(cat "$CHANGED_FILES_PATH")"
+# A pull request with an empty changed-file list is not a pass, it is a failed
+# enumeration -- the API call returned nothing, was truncated, or paginated
+# past its cap. Refusing to judge it is the whole point of exit 2.
+if [ -z "${CHANGED_FILES//[[:space:]]/}" ]; then
+  die_undetermined "changed-file list is empty (a PR always changes at least one file; treat as a failed enumeration, not a clean diff)"
+fi
+
+EVIDENCE="$(cat "$EVIDENCE_PATH")"
+LABELS="$(cat "$LABELS_PATH")"
+
+# --- 1. Which protected paths does this PR touch? ----------------------------
+TOUCHED=""
+while IFS= read -r changed; do
+  [ -z "$changed" ] && continue
+  excluded=false
+  for pattern in "${EXCLUDED_PATTERNS[@]}"; do
+    # shellcheck disable=SC2053  # deliberate glob match, not a string compare
+    if [[ "$changed" == $pattern ]]; then
+      excluded=true
+      break
+    fi
+  done
+  [ "$excluded" = true ] && continue
+  for pattern in "${PROTECTED_PATTERNS[@]}"; do
+    # shellcheck disable=SC2053  # deliberate glob match, not a string compare
+    if [[ "$changed" == $pattern ]]; then
+      TOUCHED="${TOUCHED}${changed}"$'\n'
+      break
+    fi
+  done
+done <<<"$CHANGED_FILES"
+TOUCHED="$(printf '%s' "$TOUCHED" | sed '/^$/d')"
+
+# --- 2. Does the PR present itself as UI work? -------------------------------
+# Informational only. Used to escalate the failure message for the scope-creep
+# shape that caused the incident (a UI RC that quietly moved the install path);
+# it never changes the verdict.
+ui_presentation() {
+  local title_lc
+  title_lc="$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]')"
+  case "$title_lc" in
+    *"(ui)"*|*"(ux)"*|*"(touch)"*|*touch*|*ui/*) echo "title"; return 0 ;;
+  esac
+
+  local label label_lc
+  while IFS= read -r label; do
+    [ -z "$label" ] && continue
+    label_lc="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
+    case "$label_lc" in
+      ui|ux|touch|frontend|"ui/ux"|ui:*|"ui/"*|hardware-test) echo "label"; return 0 ;;
+    esac
+  done <<<"$LABELS"
+
+  # Path heuristic: at least half the diff is UI surface.
+  local total=0 ui=0 changed
+  while IFS= read -r changed; do
+    [ -z "$changed" ] && continue
+    total=$((total + 1))
+    case "$changed" in
+      src/activities/*|lib/UITheme/*|lib/GfxRenderer/*|lib/I18n/*|lib/EpdFont/*) ui=$((ui + 1)) ;;
+    esac
+  done <<<"$CHANGED_FILES"
+  if [ "$total" -gt 0 ] && [ $((ui * 2)) -ge "$total" ]; then
+    echo "diff-shape"
+    return 0
+  fi
+
+  echo ""
+}
+UI_SIGNAL="$(ui_presentation)"
+
+# --- 3. Report evaluation ----------------------------------------------------
+# Only reached when a protected path is touched. Every REQUIRED_CASES id must
+# appear in the evidence on a line carrying a verdict; PASS and N/A are
+# accepted, FAIL and BLOCKED are not, and a missing id is not.
+MISSING_CASES=""
+FAILED_CASES=""
+evaluate_matrix() {
+  local id line verdict
+  for id in "${REQUIRED_CASES[@]}"; do
+    # Anchor on the id followed by a non-alphanumeric, so US-1 never matches
+    # US-10 or US-11.
+    line="$(grep -E "(^|[^A-Za-z0-9-])${id}([^0-9]|$)" <<<"$EVIDENCE" | head -n 1 || true)"
+    if [ -z "$line" ]; then
+      MISSING_CASES="${MISSING_CASES}${id}"$'\n'
+      continue
+    fi
+    verdict="$(grep -oiE '\b(PASS|FAIL|BLOCKED|N/A)\b' <<<"$line" | tail -n 1 | tr '[:lower:]' '[:upper:]' || true)"
+    case "$verdict" in
+      PASS|"N/A") : ;;
+      FAIL|BLOCKED) FAILED_CASES="${FAILED_CASES}${id}: ${verdict}"$'\n' ;;
+      *) MISSING_CASES="${MISSING_CASES}${id} (no PASS / FAIL / N/A verdict on its row)"$'\n' ;;
+    esac
+  done
+}
+
+MISSING_FIELDS=""
+evaluate_fields() {
+  # Test device: must be named, and must not be blank.
+  if ! grep -qiE '^[[:space:]>|*-]*test[ -]device[[:space:]]*[:|][[:space:]]*[^[:space:]|]' <<<"$EVIDENCE"; then
+    MISSING_FIELDS="${MISSING_FIELDS}Test device: <designated unit, never the only working device>"$'\n'
+  fi
+  # Build SHAs: the line must exist AND carry at least one 7+ hex commit id, so
+  # a placeholder like "Build SHAs: TBD" does not satisfy it.
+  if ! grep -iE '^[[:space:]>|*-]*build[ -]sha' <<<"$EVIDENCE" | grep -qE '\b[0-9a-fA-F]{7,40}\b'; then
+    MISSING_FIELDS="${MISSING_FIELDS}Build SHAs: <A> <B> <C> (7-40 hex each)"$'\n'
+  fi
+  # The matrix block itself must be labelled, so the ids below are demonstrably
+  # a transcribed result table and not incidental prose.
+  if ! grep -qiE 'survivability[ -]matrix' <<<"$EVIDENCE"; then
+    MISSING_FIELDS="${MISSING_FIELDS}Survivability matrix: <the US-0..US-11 result rows>"$'\n'
+  fi
+}
+
+# --- 4. Verdict --------------------------------------------------------------
+if [ -z "$TOUCHED" ]; then
+  {
+    echo "## Update Survivability Gate"
+    echo
+    echo ":white_check_mark: **Not applicable.** This PR touches no firmware update path, boot slot, partition or release file."
+    echo
+    echo "Gate definition: \`$GATE_DOC\`"
+  }
+  exit 0
+fi
+
+evaluate_fields
+evaluate_matrix
+
+if [ -z "$MISSING_FIELDS" ] && [ -z "$MISSING_CASES" ] && [ -z "$FAILED_CASES" ]; then
+  {
+    echo "## Update Survivability Gate"
+    echo
+    echo ":white_check_mark: **Passed.** This PR touches the firmware update path and carries a complete hardware validation report."
+    echo
+    echo "### Protected files touched"
+    echo '```'
+    echo "$TOUCHED"
+    echo '```'
+    echo
+    echo "All ${#REQUIRED_CASES[@]} rows of the survivability matrix are recorded with a PASS or N/A verdict. The reviewer still owns judging whether the recorded slots, image SHA-256 values and boot results are real -- this job checks that they were WRITTEN DOWN, not that they are true."
+    echo
+    echo "Gate definition: \`$GATE_DOC\`"
+  }
+  exit 0
+fi
+
+{
+  echo "## Update Survivability Gate"
+  echo
+  echo ":x: **Blocked.** This PR changes the firmware update path and has no complete hardware validation report."
+  echo
+  echo "### Protected files touched"
+  echo '```'
+  echo "$TOUCHED"
+  echo '```'
+  echo
+
+  if [ -n "$UI_SIGNAL" ]; then
+    echo "### :rotating_light: This PR presents as UI work (detected via: $UI_SIGNAL)"
+    echo
+    echo "That is the exact shape of the incident this gate exists for: a UI/touch RC that also moved the firmware installation path, shipped after a single successful install, and left the only X4 Pro update-locked. A UI PR that reaches into these files is not a UI PR."
+    echo
+    echo "If the update-path edits are not essential to the UI change, **split them out** -- that is the cheapest way through this gate."
+    echo
+  fi
+
+  if [ -n "$MISSING_FIELDS" ]; then
+    echo "### Missing report fields"
+    echo
+    echo "Add these to the PR description (or to a \`docs/hardware-validation/*.md\` added by this PR):"
+    echo '```'
+    printf '%s' "$MISSING_FIELDS"
+    echo '```'
+    echo
+  fi
+
+  if [ -n "$MISSING_CASES" ]; then
+    echo "### Missing matrix rows"
+    echo
+    echo "Each row needs a \`PASS\`, \`FAIL\` or \`N/A\` verdict:"
+    echo '```'
+    printf '%s' "$MISSING_CASES"
+    echo '```'
+    echo
+  fi
+
+  if [ -n "$FAILED_CASES" ]; then
+    echo "### Rows that did not pass"
+    echo '```'
+    printf '%s' "$FAILED_CASES"
+    echo '```'
+    echo
+    echo "A recorded FAIL or BLOCKED row is a correct, useful result -- it just is not shippable. Fix the firmware, re-run the matrix, update the report."
+    echo
+  fi
+
+  echo "### What this gate will NOT accept as a substitute"
+  echo
+  echo "- A green build on all four board environments"
+  echo "- A passing host test suite, however large"
+  echo "- \`cppcheck\`, CodeQL, or a clean CodeRabbit review"
+  echo "- A single successful installation on real hardware"
+  echo
+  echo "All of those passed on the change that bricked the device. None of them runs on hardware AND exercises an install *cycle*. Only a designated test unit completing the two-slot matrix does."
+  echo
+  echo "### How to unblock"
+  echo
+  echo "1. Read **\`$GATE_DOC\`** and run the matrix on a designated test device -- never the only working unit."
+  echo "2. Record running slot, target slot, image SHA-256 and boot result for every transition."
+  echo "3. Paste the filled-in results block from that document into this PR's description, or add the report under \`docs/hardware-validation/\`."
+  echo
+  echo "Gate definition: \`$GATE_DOC\`"
+}
+exit 1

--- a/scripts/update-survivability-gate.sh
+++ b/scripts/update-survivability-gate.sh
@@ -34,17 +34,36 @@
 # message, never suppress the gate. See the workflow file's header for the
 # residual failure mode this choice leaves open.
 #
+# Two independent classifications
+# -------------------------------
+# 1. FIRMWARE UPDATE PATH (PROTECTED_PATTERNS below). Cleared by a hardware
+#    validation report: the US-0..US-11 matrix, run on a designated device.
+# 2. GATE SELF-MODIFICATION (GATE_SELF_PATHS below) -- a separate, fail-closed
+#    security-boundary classification for a PR that changes the gate's own
+#    workflow, evaluator, self-test suite or specification. It is NOT cleared
+#    by a hardware matrix (running US-0..US-11 on a device says nothing about
+#    a change to a CI script) and it is NOT cleared by anything the PR author
+#    writes: a body line, a title convention or a label is text the author
+#    controls, so it authorizes nothing. It is cleared ONLY by an APPROVED
+#    GitHub review from OWNER / MEMBER / COLLABORATOR whose commit_id is the
+#    PR's CURRENT head SHA -- authorization that comes from GitHub's own
+#    permission model, and that a later push invalidates.
+#
+# Both classifications can apply to one PR; both must then be satisfied.
+#
 # Fail-closed contract
 # --------------------
-# Exit 0: no protected path touched, OR a complete hardware validation report
-#         is present and every matrix row passed.
+# Exit 0: neither classification applies, OR every classification that applies
+#         is satisfied.
 # Exit 1: a protected path was touched and the report is missing, incomplete,
-#         or records a FAIL/BLOCKED row.
+#         or records a FAIL/BLOCKED row; and/or a gate file was touched with
+#         no qualifying maintainer approval on the current head SHA.
 # Exit 2: the gate could not DETERMINE the answer -- an unreadable or empty
-#         changed-file list, an unreadable evidence file. The caller MUST
-#         treat exit 2 as a failure, never as a pass. Reading a missing input
-#         as "nothing to check" is the identical fail-open mistake that
-#         produced the incident this gate exists to prevent.
+#         changed-file list, an unreadable evidence/labels/reviews file, a
+#         missing head SHA. The caller MUST treat exit 2 as a failure, never
+#         as a pass. Reading a missing input as "nothing to check" is the
+#         identical fail-open mistake that produced the incident this gate
+#         exists to prevent.
 #
 # Renames are a first-class hazard, not a detail
 # ----------------------------------------------
@@ -58,7 +77,8 @@
 # its security-boundary files, and for the same reason.
 #
 # Usage:
-#   update-survivability-gate.sh CHANGED_FILES EVIDENCE LABELS PR_TITLE
+#   update-survivability-gate.sh CHANGED_FILES EVIDENCE LABELS PR_TITLE \
+#                                REVIEWS HEAD_SHA
 #
 #   CHANGED_FILES  file, one CHANGED RECORD per line. A record is either a
 #                  bare repo-relative path, or a rename written as
@@ -72,6 +92,14 @@
 #                  docs/hardware-validation/*.md the PR adds or edits
 #   LABELS         file, one PR label per line (may be empty)
 #   PR_TITLE       the PR title, as a single argument
+#   REVIEWS        file, one PR REVIEW per line as
+#                  `state<TAB>author_association<TAB>commit_id` -- the fields
+#                  of the GitHub pull-reviews API. May be empty (no reviews);
+#                  an empty file is a determinate "nobody has approved yet",
+#                  not an undetermined input.
+#   HEAD_SHA       the PR's current head SHA, as a single argument. An
+#                  approval is only honoured when it was given against THIS
+#                  commit, so a push after approval re-blocks the gate.
 #
 # Report is written to stdout as GitHub-flavoured Markdown, suitable for
 # $GITHUB_STEP_SUMMARY.
@@ -134,23 +162,80 @@ EXCLUDED_PATTERNS=(
   ".github/workflows/release-fonts.yml"
 )
 
+# --- The gate's own files (second, independent classification) ---------------
+# A PR that changes the gate's workflow, its evaluator, its self-test suite or
+# its specification matches NONE of the protected firmware patterns above. With
+# only one classification the gate would report "Not applicable" on such a PR
+# and a weakening of the evaluator would merge behind a green check -- the gate
+# would not protect itself.
+#
+# These are deliberately NOT added to PROTECTED_PATTERNS. Demanding a
+# US-0..US-11 hardware matrix for a change to a CI script is both meaningless
+# (no device transition can say anything about a shell script) and
+# disproportionate enough to make the gate something people route around --
+# which this file's own carve-out comment warns against. They get their own
+# clearing mechanism instead; see maintainer_approval_state().
+#
+# The self-test suite is included for the same reason scripts/thin-fork-guard.sh
+# treats scripts/test-thin-fork-guard.sh as a security-boundary file: the
+# workflow EXECUTES the self-test from the base checkout before it trusts the
+# evaluator's verdict, so it is trusted executable code, not documentation. The
+# specification is included because it is the contract the parser is held to --
+# §5's results template and this script's row parser are locked together by a
+# test, and a silent edit to one side of that lock is exactly the invisible
+# change this classification exists to prevent.
+GATE_SELF_PATHS=(
+  ".github/workflows/update-survivability-gate.yml"
+  "scripts/update-survivability-gate.sh"
+  "scripts/test-update-survivability-gate.sh"
+  "docs/update-survivability-gate.md"
+)
+
+# Author associations that count as maintainer authority on this repository.
+# GitHub computes author_association itself from the actor's permission on the
+# repo; it is not settable by the PR author.
+MAINTAINER_ASSOCIATIONS=(OWNER MEMBER COLLABORATOR)
+
 # --- Required matrix rows ----------------------------------------------------
 # Case IDs from docs/update-survivability-gate.md. Every one must appear in the
 # evidence with a verdict. Keep in sync with that document's table.
+# Erase expectations are CHANNEL-SPECIFIC; see the matrix in that document for
+# which half of each case applies to SD and which to streaming OTA.
 REQUIRED_CASES=(
   "US-0"   # recovery precondition proven before flashing
   "US-1"   # A @ app0 -> install B -> app1
   "US-2"   # B @ app1 -> install C -> app0
   "US-3"   # C @ app0 -> install B -> app1
-  "US-4"   # self-reinstall (or N/A where unsupported)
-  "US-5"   # wrong-chip image rejected, neither slot erased
+  "US-4"   # self-reinstall (or N/A where unsupported) -- the ONLY N/A case
+  "US-5"   # wrong-chip image rejected: SD before erase; OTA never made bootable
   "US-6"   # wrong-board image rejected, never selected bootable
-  "US-7"   # corrupted / truncated image rejected before erase
-  "US-8"   # HTTP failure BEFORE download, fallback intact
-  "US-9"   # HTTP failure DURING download, fallback intact
+  "US-7"   # corrupted / truncated image rejected: SD before erase
+  "US-8"   # HTTP failure BEFORE download; running slot still boots
+  "US-9"   # HTTP failure DURING download; running slot still boots
   "US-10"  # power-loss simulation at documented safe stages
   "US-11"  # after every failure, the previous slot still boots
 )
+
+# The one case where `N/A` is a legitimate verdict, per §5 of the gate
+# document. Every other row must record a real result.
+NA_PERMITTED_CASES=(
+  "US-4"
+)
+
+# Matrix rows are markdown table rows with these cells, in this order. The
+# parser reads them BY POSITION and §5 of the gate document publishes exactly
+# this column order; scripts/test-update-survivability-gate.sh fills in the
+# document's own template and asserts this parser accepts it, so the two can
+# never drift apart silently.
+#
+#   | ID | Running slot | Target slot | Image SHA-256 | Boot result | Verdict | Notes |
+#      2        3              4              5             6           7        8
+# (cell 2, the ID, is matched textually when the row is located.)
+ROW_CELL_RUNNING=3
+ROW_CELL_TARGET=4
+ROW_CELL_SHA=5
+ROW_CELL_BOOT=6
+ROW_CELL_VERDICT=7
 
 die_undetermined() {
   echo "update-survivability-gate.sh: cannot determine verdict -- failing closed: $1" >&2
@@ -158,18 +243,28 @@ die_undetermined() {
 }
 
 # --- Inputs ------------------------------------------------------------------
-if [ "$#" -ne 4 ]; then
-  die_undetermined "expected 4 arguments (CHANGED_FILES EVIDENCE LABELS PR_TITLE), got $#"
+if [ "$#" -ne 6 ]; then
+  die_undetermined "expected 6 arguments (CHANGED_FILES EVIDENCE LABELS PR_TITLE REVIEWS HEAD_SHA), got $#"
 fi
 
 CHANGED_FILES_PATH="$1"
 EVIDENCE_PATH="$2"
 LABELS_PATH="$3"
 PR_TITLE="$4"
+REVIEWS_PATH="$5"
+HEAD_SHA="$6"
 
 [ -r "$CHANGED_FILES_PATH" ] || die_undetermined "changed-file list '$CHANGED_FILES_PATH' is not readable"
 [ -r "$EVIDENCE_PATH" ] || die_undetermined "evidence file '$EVIDENCE_PATH' is not readable"
 [ -r "$LABELS_PATH" ] || die_undetermined "labels file '$LABELS_PATH' is not readable"
+# An unreadable reviews file is an undetermined input, not "nobody approved":
+# the difference decides whether a gate-self-modification PR is judged at all.
+[ -r "$REVIEWS_PATH" ] || die_undetermined "reviews file '$REVIEWS_PATH' is not readable"
+# Without the head SHA an approval cannot be bound to a commit, so an approval
+# from before the last push would be indistinguishable from a current one.
+if [ -z "${HEAD_SHA//[[:space:]]/}" ]; then
+  die_undetermined "head SHA is empty (an approval must be bound to the commit it was given against)"
+fi
 
 CHANGED_FILES="$(cat "$CHANGED_FILES_PATH")"
 # A pull request with an empty changed-file list is not a pass, it is a failed
@@ -181,6 +276,7 @@ fi
 
 EVIDENCE="$(cat "$EVIDENCE_PATH")"
 LABELS="$(cat "$LABELS_PATH")"
+REVIEWS="$(cat "$REVIEWS_PATH")"
 
 # --- 1. Which protected paths does this PR touch? ----------------------------
 # One path in isolation: protected when it matches PROTECTED_PATTERNS and is
@@ -252,6 +348,75 @@ while IFS=$'\t' read -r new_path old_path; do
 done <<<"$CHANGED_FILES"
 TOUCHED="$(printf '%s' "$TOUCHED" | sed '/^$/d' | awk '!seen[$0]++')"
 
+# --- 1b. Does this PR modify the gate itself? --------------------------------
+# Exact-path membership (not a glob) on BOTH sides of every rename, for the
+# same reason the protected list checks both: renaming the evaluator out of the
+# way is functionally a rewrite of it, and renaming something INTO the
+# evaluator's pathname is what the workflow will execute from the next merge
+# onward.
+is_gate_self_path() {
+  local candidate="$1" gate_path
+  [ -z "$candidate" ] && return 1
+  for gate_path in "${GATE_SELF_PATHS[@]}"; do
+    [ "$candidate" = "$gate_path" ] && return 0
+  done
+  return 1
+}
+
+GATE_SELF_TOUCHED=""
+while IFS=$'\t' read -r new_path old_path; do
+  old_path="${old_path:-}"
+  [ -z "$new_path" ] && [ -z "$old_path" ] && continue
+
+  if is_gate_self_path "$new_path"; then
+    if [ -n "$old_path" ] && [ "$old_path" != "$new_path" ]; then
+      GATE_SELF_TOUCHED="${GATE_SELF_TOUCHED}${old_path} -> ${new_path}  (RENAMED INTO the gate's own files)"$'\n'
+    else
+      GATE_SELF_TOUCHED="${GATE_SELF_TOUCHED}${new_path}"$'\n'
+    fi
+    continue
+  fi
+  if is_gate_self_path "$old_path"; then
+    GATE_SELF_TOUCHED="${GATE_SELF_TOUCHED}${old_path} -> ${new_path}  (RENAMED AWAY from the gate's own files)"$'\n'
+  fi
+done <<<"$CHANGED_FILES"
+GATE_SELF_TOUCHED="$(printf '%s' "$GATE_SELF_TOUCHED" | sed '/^$/d' | awk '!seen[$0]++')"
+
+# Clearing a gate self-modification requires authorization GitHub itself
+# computes, never text the PR author supplies. An APPROVED review whose
+# author_association is OWNER / MEMBER / COLLABORATOR is a permission fact; a
+# body line, a title convention or a label is not, because the same person who
+# wrote the change writes all three. Binding the approval to the current head
+# SHA means a push after approval re-blocks the gate rather than inheriting it.
+#
+# Echoes one of: approved / stale / unauthorized / none.
+maintainer_approval_state() {
+  local state assoc commit assoc_uc state_uc allowed a best="none"
+  while IFS=$'\t' read -r state assoc commit; do
+    [ -z "$state" ] && continue
+    state_uc="$(printf '%s' "$state" | tr '[:lower:]' '[:upper:]')"
+    [ "$state_uc" = "APPROVED" ] || continue
+
+    assoc_uc="$(printf '%s' "$assoc" | tr '[:lower:]' '[:upper:]')"
+    allowed=false
+    for a in "${MAINTAINER_ASSOCIATIONS[@]}"; do
+      [ "$assoc_uc" = "$a" ] && allowed=true && break
+    done
+    if [ "$allowed" = false ]; then
+      [ "$best" = "none" ] && best="unauthorized"
+      continue
+    fi
+
+    if [ "$commit" != "$HEAD_SHA" ]; then
+      [ "$best" != "approved" ] && best="stale"
+      continue
+    fi
+    echo "approved"
+    return 0
+  done <<<"$REVIEWS"
+  echo "$best"
+}
+
 # --- 2. Does the PR present itself as UI work? -------------------------------
 # Informational only. Used to escalate the failure message for the scope-creep
 # shape that caused the incident (a UI RC that quietly moved the install path);
@@ -300,41 +465,136 @@ ui_presentation() {
 UI_SIGNAL="$(ui_presentation)"
 
 # --- 3. Report evaluation ----------------------------------------------------
-# Only reached when a protected path is touched. Every REQUIRED_CASES id must
-# appear in the evidence on a line carrying a verdict; PASS and N/A are
-# accepted, FAIL and BLOCKED are not, and a missing id is not.
+# Only reached when a protected path is touched.
+#
+# A result is a STRUCTURED ROW, not a mention. The earlier "any line containing
+# the id and any verdict word" rule accepted a sentence in the PR body -- and
+# accepted `N/A` for every case, although §5 permits it for US-4 alone. A row
+# must be a markdown table row whose first cell is exactly the case id and
+# which records all four documented transition fields (running slot, target
+# slot, image SHA-256, boot result) plus a verdict. Write `-` where a field
+# genuinely does not apply; a blank or `TBD` cell is an unfilled template.
+
+# Trimmed cell N of a markdown table row. Cell 1 is whatever precedes the
+# leading pipe (empty, or a blockquote marker), so the ID is cell 2.
+row_cell() {
+  awk -F'|' -v n="$2" '{
+    v = (n <= NF) ? $n : ""
+    gsub(/^[[:space:]`*]+|[[:space:]`*]+$/, "", v)
+    print v
+  }' <<<"$1"
+}
+
+# A cell is filled when it carries something other than whitespace and is not a
+# leftover template placeholder.
+cell_is_filled() {
+  local v_uc
+  [ -z "$1" ] && return 1
+  v_uc="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
+  case "$v_uc" in
+    TBD|TODO|"?"|"<>") return 1 ;;
+  esac
+  case "$1" in
+    "<"*">") return 1 ;;
+  esac
+  return 0
+}
+
+na_permitted_for() {
+  local id
+  for id in "${NA_PERMITTED_CASES[@]}"; do
+    [ "$1" = "$id" ] && return 0
+  done
+  return 1
+}
+
 MISSING_CASES=""
 FAILED_CASES=""
 evaluate_matrix() {
-  local id line verdict
+  local id row verdict running target sha boot missing_fields
   for id in "${REQUIRED_CASES[@]}"; do
-    # Anchor on the id followed by a non-alphanumeric, so US-1 never matches
-    # US-10 or US-11.
-    line="$(grep -E "(^|[^A-Za-z0-9-])${id}([^0-9]|$)" <<<"$EVIDENCE" | head -n 1 || true)"
-    if [ -z "$line" ]; then
+    # The first cell must be EXACTLY the id, so US-1 can never be satisfied by
+    # US-10 or US-11 and prose mentioning an id is never mistaken for a result.
+    row="$(grep -E "^[[:space:]>]*\|[[:space:]]*${id}[[:space:]]*\|" <<<"$EVIDENCE" | head -n 1 || true)"
+    if [ -z "$row" ]; then
       MISSING_CASES="${MISSING_CASES}${id}"$'\n'
       continue
     fi
-    verdict="$(grep -oiE '\b(PASS|FAIL|BLOCKED|N/A)\b' <<<"$line" | tail -n 1 | tr '[:lower:]' '[:upper:]' || true)"
+
+    verdict="$(row_cell "$row" "$ROW_CELL_VERDICT" | tr '[:lower:]' '[:upper:]')"
     case "$verdict" in
-      PASS|"N/A") : ;;
-      FAIL|BLOCKED) FAILED_CASES="${FAILED_CASES}${id}: ${verdict}"$'\n' ;;
-      *) MISSING_CASES="${MISSING_CASES}${id} (no PASS / FAIL / N/A verdict on its row)"$'\n' ;;
+      PASS|FAIL|BLOCKED|"N/A") : ;;
+      *)
+        MISSING_CASES="${MISSING_CASES}${id} (no PASS / FAIL / N/A verdict in the Verdict cell -- the row must be a full matrix row, not a mention)"$'\n'
+        continue
+        ;;
     esac
+
+    if [ "$verdict" = "N/A" ] && ! na_permitted_for "$id"; then
+      FAILED_CASES="${FAILED_CASES}${id}: N/A is not permitted for this case (only ${NA_PERMITTED_CASES[*]} may be N/A)"$'\n'
+      continue
+    fi
+
+    if [ "$verdict" = "FAIL" ] || [ "$verdict" = "BLOCKED" ]; then
+      FAILED_CASES="${FAILED_CASES}${id}: ${verdict}"$'\n'
+      continue
+    fi
+
+    running="$(row_cell "$row" "$ROW_CELL_RUNNING")"
+    target="$(row_cell "$row" "$ROW_CELL_TARGET")"
+    sha="$(row_cell "$row" "$ROW_CELL_SHA")"
+    boot="$(row_cell "$row" "$ROW_CELL_BOOT")"
+    missing_fields=""
+    cell_is_filled "$running" || missing_fields="${missing_fields}running slot, "
+    cell_is_filled "$target" || missing_fields="${missing_fields}target slot, "
+    cell_is_filled "$sha" || missing_fields="${missing_fields}image SHA-256, "
+    cell_is_filled "$boot" || missing_fields="${missing_fields}boot result, "
+    if [ -n "$missing_fields" ]; then
+      MISSING_CASES="${MISSING_CASES}${id} (row does not record: ${missing_fields%, } -- write \`-\` where a field genuinely does not apply)"$'\n'
+    fi
   done
+}
+
+# The 7-40 hex value labelled with a given letter on the Build SHAs line.
+# Echoes nothing when that label carries no real hash.
+labelled_build_sha() {
+  # `|| true`: no match is an ordinary answer here, and under `set -o pipefail`
+  # an unmatched grep would otherwise abort the whole script.
+  local found
+  found="$(printf '%s' "$1" \
+    | grep -oiE "(^|[^0-9A-Za-z])$2[[:space:]]*=[[:space:]]*[\`'\"*]*[0-9a-fA-F]{7,40}([^0-9A-Za-z]|$)" \
+    | head -n 1 \
+    | grep -oE '[0-9a-fA-F]{7,40}' \
+    | tail -n 1 \
+    | tr '[:upper:]' '[:lower:]' || true)"
+  printf '%s' "$found"
 }
 
 MISSING_FIELDS=""
 evaluate_fields() {
+  local sha_line sha_a sha_b sha_c
   # Test device: must be named, and must not be blank.
-  if ! grep -qiE '^[[:space:]>|*-]*test[ -]device[[:space:]]*[:|][[:space:]]*[^[:space:]|]' <<<"$EVIDENCE"; then
+  # The value must be a real name: `<model, serial/MAC, ...>` straight out of
+  # the template is an unfilled placeholder, not a designated unit.
+  if ! grep -qiE '^[[:space:]>|*-]*test[ -]device[[:space:]]*[:|][[:space:]]*[^[:space:]|<]' <<<"$EVIDENCE"; then
     MISSING_FIELDS="${MISSING_FIELDS}Test device: <designated unit, never the only working device>"$'\n'
   fi
-  # Build SHAs: the line must exist AND carry at least one 7+ hex commit id, so
-  # a placeholder like "Build SHAs: TBD" does not satisfy it.
-  if ! grep -iE '^[[:space:]>|*-]*build[ -]sha' <<<"$EVIDENCE" | grep -qE '\b[0-9a-fA-F]{7,40}\b'; then
-    MISSING_FIELDS="${MISSING_FIELDS}Build SHAs: <A> <B> <C> (7-40 hex each)"$'\n'
+
+  # Build SHAs: §4 requires THREE builds -- A (known-good baseline), B (the RC)
+  # and C (a third build distinguishable from B, so the app1 -> app0 hop is
+  # tested with an image that is not already resident). All three must be real
+  # hashes and all three must differ; "Build SHAs: TBD", a single hash, or
+  # A=B=C are each a matrix that cannot have been run as documented.
+  sha_line="$(grep -iE '^[[:space:]>|*-]*build[ -]sha' <<<"$EVIDENCE" | head -n 1 || true)"
+  sha_a="$(labelled_build_sha "$sha_line" A)"
+  sha_b="$(labelled_build_sha "$sha_line" B)"
+  sha_c="$(labelled_build_sha "$sha_line" C)"
+  if [ -z "$sha_a" ] || [ -z "$sha_b" ] || [ -z "$sha_c" ]; then
+    MISSING_FIELDS="${MISSING_FIELDS}Build SHAs: A=<commit> B=<commit> C=<commit> (7-40 hex each; all three are required)"$'\n'
+  elif [ "$sha_a" = "$sha_b" ] || [ "$sha_a" = "$sha_c" ] || [ "$sha_b" = "$sha_c" ]; then
+    MISSING_FIELDS="${MISSING_FIELDS}Build SHAs: A, B and C must be THREE DISTINCT builds (C exists so the app1 -> app0 hop uses an image that is not already resident)"$'\n'
   fi
+
   # The matrix block itself must be labelled, so the ids below are demonstrably
   # a transcribed result table and not incidental prose.
   if ! grep -qiE 'survivability[ -]matrix' <<<"$EVIDENCE"; then
@@ -343,33 +603,60 @@ evaluate_fields() {
 }
 
 # --- 4. Verdict --------------------------------------------------------------
-if [ -z "$TOUCHED" ]; then
+GATE_SELF_APPROVAL="none"
+if [ -n "$GATE_SELF_TOUCHED" ]; then
+  GATE_SELF_APPROVAL="$(maintainer_approval_state)"
+fi
+
+if [ -z "$TOUCHED" ] && [ -z "$GATE_SELF_TOUCHED" ]; then
   {
     echo "## Update Survivability Gate"
     echo
-    echo ":white_check_mark: **Not applicable.** This PR touches no firmware update path, boot slot, partition or release file."
+    echo ":white_check_mark: **Not applicable.** This PR touches no firmware update path, boot slot, partition or release file, and does not modify the gate itself."
     echo
     echo "Gate definition: \`$GATE_DOC\`"
   }
   exit 0
 fi
 
-evaluate_fields
-evaluate_matrix
+if [ -n "$TOUCHED" ]; then
+  evaluate_fields
+  evaluate_matrix
+fi
 
+MATRIX_OK=false
 if [ -z "$MISSING_FIELDS" ] && [ -z "$MISSING_CASES" ] && [ -z "$FAILED_CASES" ]; then
+  MATRIX_OK=true
+fi
+SELF_MOD_OK=false
+if [ -z "$GATE_SELF_TOUCHED" ] || [ "$GATE_SELF_APPROVAL" = "approved" ]; then
+  SELF_MOD_OK=true
+fi
+
+if [ "$MATRIX_OK" = true ] && [ "$SELF_MOD_OK" = true ]; then
   {
     echo "## Update Survivability Gate"
     echo
-    echo ":white_check_mark: **Passed.** This PR touches the firmware update path and carries a complete hardware validation report."
+    echo ":white_check_mark: **Passed.**"
     echo
-    echo "### Protected files touched"
-    echo '```'
-    echo "$TOUCHED"
-    echo '```'
-    echo
-    echo "All ${#REQUIRED_CASES[@]} rows of the survivability matrix are recorded with a PASS or N/A verdict. The reviewer still owns judging whether the recorded slots, image SHA-256 values and boot results are real -- this job checks that they were WRITTEN DOWN, not that they are true."
-    echo
+    if [ -n "$TOUCHED" ]; then
+      echo "### Protected files touched"
+      echo '```'
+      echo "$TOUCHED"
+      echo '```'
+      echo
+      echo "All ${#REQUIRED_CASES[@]} rows of the survivability matrix are recorded with a permitted verdict and all four transition fields. The reviewer still owns judging whether the recorded slots, image SHA-256 values and boot results are real -- this job checks that they were WRITTEN DOWN, not that they are true."
+      echo
+    fi
+    if [ -n "$GATE_SELF_TOUCHED" ]; then
+      echo "### Gate self-modification, approved"
+      echo '```'
+      echo "$GATE_SELF_TOUCHED"
+      echo '```'
+      echo
+      echo "Cleared by an APPROVED review from a maintainer (OWNER / MEMBER / COLLABORATOR) recorded against the current head SHA \`$HEAD_SHA\`. Pushing another commit invalidates that approval and re-blocks this gate."
+      echo
+    fi
     echo "Gate definition: \`$GATE_DOC\`"
   }
   exit 0
@@ -378,15 +665,48 @@ fi
 {
   echo "## Update Survivability Gate"
   echo
-  echo ":x: **Blocked.** This PR changes the firmware update path and has no complete hardware validation report."
-  echo
-  echo "### Protected files touched"
-  echo '```'
-  echo "$TOUCHED"
-  echo '```'
+  echo ":x: **Blocked.**"
   echo
 
-  if [ "$RENAME_HIT" = true ]; then
+  if [ "$SELF_MOD_OK" = false ]; then
+    echo "### :lock: This PR modifies the update survivability gate itself"
+    echo
+    echo "Gate files changed by this PR:"
+    echo '```'
+    echo "$GATE_SELF_TOUCHED"
+    echo '```'
+    echo
+    echo "This is a **separate classification** from the hardware matrix, and a hardware matrix does **not** clear it: running US-0..US-11 on a device says nothing about a change to a CI workflow or a shell script."
+    echo
+    echo "**It is also not cleared by anything written in this PR.** A line in the description, a title convention and a label are all text the PR author controls, so none of them is authorization. The only thing that clears it is an **APPROVED GitHub review from a maintainer** -- \`author_association\` of ${MAINTAINER_ASSOCIATIONS[*]} -- recorded against **this PR's current head SHA** (\`$HEAD_SHA\`). Pushing a new commit after approval invalidates it, so an approval can never be carried across a change."
+    echo
+    case "$GATE_SELF_APPROVAL" in
+      stale)
+        echo "Current state: an approving maintainer review exists, but it was given against an **earlier commit**. Re-approve the current head."
+        ;;
+      unauthorized)
+        echo "Current state: an approving review exists, but its \`author_association\` is not one of ${MAINTAINER_ASSOCIATIONS[*]}. GitHub computes that value from the reviewer's permission on this repository; it cannot be set by the PR."
+        ;;
+      *)
+        echo "Current state: no approving maintainer review on the current head SHA."
+        ;;
+    esac
+    echo
+    echo "**This is a visibility control, not a prevention control.** \`pull_request_target\` already guarantees that the BASE branch's copy of the workflow and evaluator is what judges this PR, so nothing changed here can weaken the verdict on this PR. What that property does *not* do is make such a change noticeable: a PR touching only these files matches no protected firmware path, so without this classification the gate would report \"Not applicable\" and an edit that weakens the evaluator for every FUTURE PR would merge behind a green check. The point is that it can never be invisible."
+    echo
+  fi
+
+  if [ -n "$TOUCHED" ] && [ "$MATRIX_OK" = false ]; then
+    echo "### This PR changes the firmware update path and has no complete hardware validation report"
+    echo
+    echo "#### Protected files touched"
+    echo '```'
+    echo "$TOUCHED"
+    echo '```'
+    echo
+  fi
+
+  if [ "$RENAME_HIT" = true ] && [ "$MATRIX_OK" = false ]; then
     echo "### A rename is what put a protected path in this list"
     echo
     echo "One of the entries above is a **rename**, shown as \`source -> destination\`. Both paths of every rename are checked, which is why this gate can block on a path your diff no longer contains:"
@@ -398,7 +718,7 @@ fi
     echo
   fi
 
-  if [ -n "$UI_SIGNAL" ]; then
+  if [ -n "$UI_SIGNAL" ] && [ "$MATRIX_OK" = false ]; then
     echo "### :rotating_light: This PR presents as UI work (detected via: $UI_SIGNAL)"
     echo
     echo "That is the exact shape of the incident this gate exists for: a UI/touch RC that also moved the firmware installation path, shipped after a single successful install, and left the only X4 Pro update-locked. A UI PR that reaches into these files is not a UI PR."
@@ -420,7 +740,7 @@ fi
   if [ -n "$MISSING_CASES" ]; then
     echo "### Missing matrix rows"
     echo
-    echo "Each row needs a \`PASS\`, \`FAIL\` or \`N/A\` verdict:"
+    echo "Each row must be a full matrix row -- running slot, target slot, image SHA-256, boot result and a \`PASS\` / \`FAIL\` / \`N/A\` verdict (\`N/A\` only for ${NA_PERMITTED_CASES[*]}). Write \`-\` where a field genuinely does not apply:"
     echo '```'
     printf '%s' "$MISSING_CASES"
     echo '```'
@@ -437,21 +757,35 @@ fi
     echo
   fi
 
-  echo "### What this gate will NOT accept as a substitute"
-  echo
-  echo "- A green build on all four board environments"
-  echo "- A passing host test suite, however large"
-  echo "- \`cppcheck\`, CodeQL, or a clean CodeRabbit review"
-  echo "- A single successful installation on real hardware"
-  echo
-  echo "All of those passed on the change that bricked the device. None of them runs on hardware AND exercises an install *cycle*. Only a designated test unit completing the two-slot matrix does."
-  echo
+  if [ "$MATRIX_OK" = false ]; then
+    echo "### What this gate will NOT accept as a substitute"
+    echo
+    echo "- A green build on all four board environments"
+    echo "- A passing host test suite, however large"
+    echo "- \`cppcheck\`, CodeQL, or a clean CodeRabbit review"
+    echo "- A single successful installation on real hardware"
+    echo
+    echo "All of those passed on the change that bricked the device. None of them runs on hardware AND exercises an install *cycle*. Only a designated test unit completing the two-slot matrix does."
+    echo
+  fi
+
   echo "### How to unblock"
   echo
-  echo "1. Read **\`$GATE_DOC\`** and run the matrix on a designated test device -- never the only working unit."
-  echo "2. Record running slot, target slot, image SHA-256 and boot result for every transition."
-  echo "3. Paste the filled-in results block from that document into this PR's description, or add the report under \`docs/hardware-validation/\`."
-  echo
+  if [ "$MATRIX_OK" = false ]; then
+    echo "Firmware update path:"
+    echo
+    echo "1. Read **\`$GATE_DOC\`** and run the matrix on a designated test device -- never the only working unit."
+    echo "2. Record running slot, target slot, image SHA-256 and boot result for every transition, per channel (SD and OTA have different erase expectations -- see §4)."
+    echo "3. Paste the filled-in results block from §5 of that document into this PR's description, or add the report under \`docs/hardware-validation/\`."
+    echo
+  fi
+  if [ "$SELF_MOD_OK" = false ]; then
+    echo "Gate self-modification:"
+    echo
+    echo "1. Have a maintainer (${MAINTAINER_ASSOCIATIONS[*]}) review the change to the gate's own files and submit an **Approve** review."
+    echo "2. That review must be recorded against the current head SHA \`$HEAD_SHA\`. If you push again afterwards, it must be re-approved."
+    echo
+  fi
   echo "Gate definition: \`$GATE_DOC\`"
 }
 exit 1

--- a/scripts/update-survivability-gate.sh
+++ b/scripts/update-survivability-gate.sh
@@ -46,10 +46,28 @@
 #         as "nothing to check" is the identical fail-open mistake that
 #         produced the incident this gate exists to prevent.
 #
+# Renames are a first-class hazard, not a detail
+# ----------------------------------------------
+# Classifying only the DESTINATION path of a rename is a complete bypass of
+# this gate: a PR that renames src/network/OtaUpdater.cpp to
+# src/network/Updater.cpp AND rewrites it in the same commit presents a
+# changed-file list that matches no protected pattern at all, so the gate
+# reports "Not applicable" and waves the updater change through with no
+# hardware validation. Both sides of every rename are therefore classified
+# independently -- the same conclusion scripts/thin-fork-guard.sh reached for
+# its security-boundary files, and for the same reason.
+#
 # Usage:
 #   update-survivability-gate.sh CHANGED_FILES EVIDENCE LABELS PR_TITLE
 #
-#   CHANGED_FILES  file, one repo-relative changed path per line
+#   CHANGED_FILES  file, one CHANGED RECORD per line. A record is either a
+#                  bare repo-relative path, or a rename written as
+#                  `destination<TAB>source` -- the field order of the GitHub
+#                  pull-files API, which reports a rename's destination in
+#                  `filename` and its source in `previous_filename`. A line
+#                  with no tab (or an empty second field) is a non-rename
+#                  change, so a plain one-path-per-line list is still valid
+#                  input.
 #   EVIDENCE       file, the PR body concatenated with the content of any
 #                  docs/hardware-validation/*.md the PR adds or edits
 #   LABELS         file, one PR label per line (may be empty)
@@ -165,27 +183,74 @@ EVIDENCE="$(cat "$EVIDENCE_PATH")"
 LABELS="$(cat "$LABELS_PATH")"
 
 # --- 1. Which protected paths does this PR touch? ----------------------------
-TOUCHED=""
-while IFS= read -r changed; do
-  [ -z "$changed" ] && continue
-  excluded=false
+# One path in isolation: protected when it matches PROTECTED_PATTERNS and is
+# not carved out by EXCLUDED_PATTERNS. Exclusions are evaluated per PATH, not
+# per record, so a rename FROM a carved-out path INTO a protected one is still
+# judged on the protected side.
+is_protected_path() {
+  local candidate="$1" pattern
+  [ -z "$candidate" ] && return 1
   for pattern in "${EXCLUDED_PATTERNS[@]}"; do
     # shellcheck disable=SC2053  # deliberate glob match, not a string compare
-    if [[ "$changed" == $pattern ]]; then
-      excluded=true
-      break
+    if [[ "$candidate" == $pattern ]]; then
+      return 1
     fi
   done
-  [ "$excluded" = true ] && continue
   for pattern in "${PROTECTED_PATTERNS[@]}"; do
     # shellcheck disable=SC2053  # deliberate glob match, not a string compare
-    if [[ "$changed" == $pattern ]]; then
-      TOUCHED="${TOUCHED}${changed}"$'\n'
-      break
+    if [[ "$candidate" == $pattern ]]; then
+      return 0
     fi
   done
+  return 1
+}
+
+# Both sides of a rename are classified, and a hit on EITHER side blocks:
+#
+#   protected -> unprotected  a rename AWAY from the update path. The moved
+#                             content is still the updater, and the
+#                             destination matches nothing, so destination-only
+#                             matching sees an ordinary new file. This is the
+#                             reported bypass.
+#   unprotected -> protected  a rename INTO the update path. Whatever content
+#                             lands at src/network/OtaUpdater.cpp IS the OTA
+#                             updater from that commit on, whatever it was
+#                             called yesterday -- functionally a rewrite of a
+#                             protected file, and it must block for exactly
+#                             the reason a modification does.
+#
+# TOUCHED holds display entries, so a rename names BOTH paths and says which
+# direction tripped the gate; an author looking at a diff that no longer
+# contains the protected path needs to be told where it went.
+TOUCHED=""
+RENAME_HIT=false
+while IFS=$'\t' read -r new_path old_path; do
+  old_path="${old_path:-}"
+  [ -z "$new_path" ] && [ -z "$old_path" ] && continue
+
+  new_protected=false
+  old_protected=false
+  if is_protected_path "$new_path"; then new_protected=true; fi
+  if is_protected_path "$old_path"; then old_protected=true; fi
+  if [ "$new_protected" = false ] && [ "$old_protected" = false ]; then
+    continue
+  fi
+
+  if [ -z "$old_path" ]; then
+    TOUCHED="${TOUCHED}${new_path}"$'\n'
+    continue
+  fi
+
+  RENAME_HIT=true
+  if [ "$new_protected" = true ] && [ "$old_protected" = true ]; then
+    TOUCHED="${TOUCHED}${old_path} -> ${new_path}  (RENAMED, both paths protected)"$'\n'
+  elif [ "$old_protected" = true ]; then
+    TOUCHED="${TOUCHED}${old_path} -> ${new_path}  (RENAMED AWAY from a protected path: matched on the SOURCE path -- the destination matches no pattern)"$'\n'
+  else
+    TOUCHED="${TOUCHED}${old_path} -> ${new_path}  (RENAMED INTO a protected path: matched on the DESTINATION path)"$'\n'
+  fi
 done <<<"$CHANGED_FILES"
-TOUCHED="$(printf '%s' "$TOUCHED" | sed '/^$/d')"
+TOUCHED="$(printf '%s' "$TOUCHED" | sed '/^$/d' | awk '!seen[$0]++')"
 
 # --- 2. Does the PR present itself as UI work? -------------------------------
 # Informational only. Used to escalate the failure message for the scope-creep
@@ -207,12 +272,21 @@ ui_presentation() {
     esac
   done <<<"$LABELS"
 
-  # Path heuristic: at least half the diff is UI surface.
-  local total=0 ui=0 changed
-  while IFS= read -r changed; do
-    [ -z "$changed" ] && continue
+  # Path heuristic: at least half the diff is UI surface. Counted per RECORD,
+  # so a rename is one changed file rather than two; either side counting as
+  # UI surface makes the record UI.
+  local total=0 ui=0 new_path old_path
+  while IFS=$'\t' read -r new_path old_path; do
+    old_path="${old_path:-}"
+    [ -z "$new_path" ] && [ -z "$old_path" ] && continue
     total=$((total + 1))
-    case "$changed" in
+    case "$new_path" in
+      src/activities/*|lib/UITheme/*|lib/GfxRenderer/*|lib/I18n/*|lib/EpdFont/*)
+        ui=$((ui + 1))
+        continue
+        ;;
+    esac
+    case "$old_path" in
       src/activities/*|lib/UITheme/*|lib/GfxRenderer/*|lib/I18n/*|lib/EpdFont/*) ui=$((ui + 1)) ;;
     esac
   done <<<"$CHANGED_FILES"
@@ -311,6 +385,18 @@ fi
   echo "$TOUCHED"
   echo '```'
   echo
+
+  if [ "$RENAME_HIT" = true ]; then
+    echo "### A rename is what put a protected path in this list"
+    echo
+    echo "One of the entries above is a **rename**, shown as \`source -> destination\`. Both paths of every rename are checked, which is why this gate can block on a path your diff no longer contains:"
+    echo
+    echo "- **Renamed away from a protected path** -- the file that was the updater still is the updater; it is just called something else now. Its destination matches no pattern, so matching the destination alone would have reported this PR as \"Not applicable\"."
+    echo "- **Renamed into a protected path** -- whatever content now lives at that pathname is the update path from this commit on, regardless of what the file was called before."
+    echo
+    echo "Renaming, splitting or moving these files does not make the change safer to ship; if anything it makes the two-slot matrix more important, because the install path the device runs after this PR is code that has never completed a full install cycle under its new name."
+    echo
+  fi
 
   if [ -n "$UI_SIGNAL" ]; then
     echo "### :rotating_light: This PR presents as UI work (detected via: $UI_SIGNAL)"

--- a/scripts/update-survivability-gate.sh
+++ b/scripts/update-survivability-gate.sh
@@ -515,11 +515,25 @@ evaluate_matrix() {
   for id in "${REQUIRED_CASES[@]}"; do
     # The first cell must be EXACTLY the id, so US-1 can never be satisfied by
     # US-10 or US-11 and prose mentioning an id is never mistaken for a result.
-    row="$(grep -E "^[[:space:]>]*\|[[:space:]]*${id}[[:space:]]*\|" <<<"$EVIDENCE" | head -n 1 || true)"
-    if [ -z "$row" ]; then
+    #
+    # EXACTLY ONE row per id. Taking the first match (`head -n 1`) would let an
+    # earlier PASS -- in the PR body, say -- hide a later FAIL for the same case
+    # in the attached hardware report, which is the precise opposite of the
+    # documented rule that any failed row blocks the RC. Evidence here is the PR
+    # body concatenated with every report the PR touches, so more than one row
+    # for a case is genuinely ambiguous: refuse to pick a winner and say so.
+    rows="$(grep -E "^[[:space:]>]*\|[[:space:]]*${id}[[:space:]]*\|" <<<"$EVIDENCE" || true)"
+    row_count=0
+    [ -n "$rows" ] && row_count="$(printf '%s\n' "$rows" | grep -c . || true)"
+    if [ "$row_count" -eq 0 ]; then
       MISSING_CASES="${MISSING_CASES}${id}"$'\n'
       continue
     fi
+    if [ "$row_count" -gt 1 ]; then
+      FAILED_CASES="${FAILED_CASES}${id}: ${row_count} rows for this case -- exactly one is required. Two rows can disagree, and taking either one silently would let a PASS hide a FAIL. Remove the duplicate so the record is unambiguous."$'\n'
+      continue
+    fi
+    row="$rows"
 
     verdict="$(row_cell "$row" "$ROW_CELL_VERDICT" | tr '[:lower:]' '[:upper:]')"
     case "$verdict" in


### PR DESCRIPTION
Adds a CI gate that blocks any PR touching the firmware update path unless it carries a hardware validation report proving the device can still install a **second** update afterwards.

Two commits, four new files, nothing else:

| File | |
|---|---|
| `docs/update-survivability-gate.md` | the US-0..US-11 matrix a designated test device must complete |
| `.github/workflows/update-survivability-gate.yml` | the CI trigger |
| `scripts/update-survivability-gate.sh` | the verdict logic (mode 100755) |
| `scripts/test-update-survivability-gate.sh` | 31-case self-test (mode 100755) |

`git diff --name-status develop..HEAD` is exactly four `A` lines. No `.cpp`/`.h`, no `partitions.csv`, no `platformio.ini`, no `freeink-sdk` gitlink, no change to `release*.yml` build/publish logic or to the thin-fork guard's files.

> **Rebase note.** This work was originally cut from `release/x4pro-convergence-rc`, which is 76 commits ahead of `develop`. Opening that branch here would have dragged the entire unmerged X4 Pro convergence RC — UI/touch work, the bridge lineage, updater changes, an SDK pin bump — into a governance PR. This branch is cut fresh from `develop` and carries only the two gate commits.

---

## Why this exists

A UI-titled RC also changed the firmware installation path and shipped without a two-slot update test. It installed once; after that the device could never install again. `runningPartitionChipId()` misreads chip identity from the running slot, and both install paths fail closed on that value — `validateImageFile()` returns `BAD_CHIP` (`FirmwareFlasher.cpp`) and `installUpdate()` aborts the transfer (`OtaUpdater.cpp`). The only X4 Pro in the field is update-locked with no working recovery channel.

Four board builds, 512 host tests, cppcheck, CodeQL and a CodeRabbit review all passed on that change. None of them runs on hardware; none exercises an install *cycle*. More checks of that class cannot close the gap — which is why this gate accepts only a real device completing the matrix.

`621752b7` ("feat: make catalog search a row you can see") is a **real historical example of the same pattern** already in this repo's history: a UI-titled commit that modifies `src/network/OtaUpdater.cpp` and `.h`. Run against the gate on this base, it fails as it should (output below).

---

## :warning: Security-sensitive: this uses `pull_request_target`

**Please review this trigger specifically before approving.**

`pull_request_target` runs the **base branch's** copy of the workflow with a token that has repository context — the trigger that, used carelessly, is the classic GitHub Actions privilege-escalation vector.

**Why it is necessary here.** The gate must read PR labels, title and body on PRs that come *from forks*. On the ordinary `pull_request` event those are unavailable with the needed context, and worse, the job would check out and execute the PR's **own** copy of `scripts/update-survivability-gate.sh` — so a PR could simply edit the gate to pass itself. Running the base branch's copy is what makes the gate non-bypassable. Same reasoning as the existing `thin-fork-guard-trusted.yml`.

**What mitigates the risk, concretely:**

- **Read-only permissions.** `contents: read` and `pull-requests: read`, and nothing else. No `statuses: write`, no `checks: write`, no `write-all` — so it cannot spoof the trusted required status. `thin-fork-guard.sh`'s workflow-permission audit (gate 7) audits it like any other workflow; verified clean on this base.
- **No `${{ }}` interpolation inside any `run:` block.** Verified programmatically: **0** occurrences. All untrusted input (`PR_TITLE`, `PR_BODY`, `PR_NUMBER`, `PR_HEAD_SHA`, `REPO`) arrives via `env:`. A PR title and body are attacker-controlled free text; inline interpolation into a shell script is the injection vector this avoids.
- **It never checks out or executes PR head code.** The single `actions/checkout` step pins `ref: ${{ github.event.pull_request.base.sha }}` with `persist-credentials: false`, and the action itself is SHA-pinned. The diff, labels, title and body arrive as inert data through the API and event payload. Nothing from PR HEAD is built, sourced or run.
- **Fails closed.** The script exits 2 when it cannot determine a verdict (unreadable inputs, empty changed-file list) and the workflow treats exit 2 as failure. A truncated API listing must not read as "nothing to check" — fail-open on a value the code could not establish is the same mistake that bricked the device.

**This must not be merged until that `pull_request_target` behaviour has been reviewed and all checks are green. Branch protection must not be changed to accommodate it.**

---

## Design: classification is diff-derived, not label-derived

The trigger is the **changed-file list** alone. A label, a title convention, or a "this is only UI work" claim cannot turn the gate off — there is nothing to remove, mislabel or forget. Label and title *are* read, but only to **escalate** the message when a PR touching these files also presents as UI work, because that is the exact shape of the incident. Stripping the label changes the wording and nothing else.

**Stated bypass residue, deliberately not hidden.** The protected list is a hand-maintained inventory, so a dangerous file matching *none* of its patterns is invisible until a human adds it. Broad trailing patterns (`src/network/Firmware*`, `src/network/Ota*`, `src/Ota*`, `scripts/*sign*`, …) mean a newly written `src/network/FirmwareSignature.cpp` is caught on day one — mitigated, not eliminated. A file that affects updating while matching neither the named nor the broad patterns — for example **a bootloader change routed through `platformio.ini` build flags** — would still slip through. Reviewers own that residue; the gate covers the shape that actually bit us.

### One documented carve-out

`.github/workflows/release-fonts.yml` matches `release*.yml` by name but publishes SD-card font packs — it touches no firmware image, no partition and no boot slot, so no amount of two-slot install testing could say anything about a change to it. Any new exclusion must clear the same bar. The carve-out is exact, not a prefix: `release.yml` still blocks (covered by a test case). A gate that hard-blocks work it has nothing to say about is a gate people learn to route around.

---

## :rotating_light: Deployment caveat

Because `pull_request_target` runs the **base branch's** copy of the workflow, **this gate only protects PRs targeting a branch that already contains it.** It does nothing for PRs aimed at a branch where the file is absent.

So: **land it on `develop` first, then apply it to the *active* release branches.** Merging here does not retroactively protect any release branch. Frozen historical releases should be left alone rather than rewritten.

---

## Verification — every check re-run on this base

`develop` differs from the original RC base by 76 commits, so nothing was assumed to carry over.

| Check | Result |
|---|---|
| `scripts/test-update-survivability-gate.sh` | **31 passed, 0 failed** |
| `scripts/test-thin-fork-guard.sh` | **141 assertions, 0 failed** |
| Workflow permission audit (gate 7), all 12 workflows | **CLEAN** |
| `shellcheck`, both scripts | exit 0, no findings |
| `bash -n`, both scripts | exit 0 |
| `bash -n`, all 3 workflow `run:` blocks | OK |
| `${{ }}` inside `run:` blocks | **0** |
| YAML parse | `['name', True, 'permissions', 'jobs']` |
| `thin-fork-guard.sh` on this branch | **PASS** (113 → 113 conflicting files, no new divergence, no upstream-owned files touched) |
| Script modes | both `100755` |

### Path-matching proof A — real commit `621752b7` must FAIL

Changed files: `lib/OpdsParser/OpdsParser.h`, `src/activities/browser/OpdsBookBrowserActivity.cpp`, `src/network/OtaUpdater.cpp`, `src/network/OtaUpdater.h`

```
## Update Survivability Gate

:x: **Blocked.** This PR changes the firmware update path and has no complete hardware validation report.

### Protected files touched
src/network/OtaUpdater.cpp
src/network/OtaUpdater.h

### :rotating_light: This PR presents as UI work (detected via: label)

That is the exact shape of the incident this gate exists for: a UI/touch RC that also
moved the firmware installation path, shipped after a single successful install, and
left the only X4 Pro update-locked. A UI PR that reaches into these files is not a UI PR.

If the update-path edits are not essential to the UI change, **split them out** --
that is the cheapest way through this gate.

### Missing matrix rows
US-0 US-1 US-2 US-3 US-4 US-5 US-6 US-7 US-8 US-9 US-10 US-11

### What this gate will NOT accept as a substitute
- A green build on all four board environments
- A passing host test suite, however large
- cppcheck, CodeQL, or a clean CodeRabbit review
- A single successful installation on real hardware

EXIT=1
```

### Path-matching proof B — a genuinely UI-only diff must PASS

Changed files: `src/activities/browser/OpdsBookBrowserActivity.cpp`, `src/activities/home/HomeActivity.cpp`, `lib/UITheme/UITheme.cpp`, `lib/I18n/translations/english.yaml`

```
## Update Survivability Gate

:white_check_mark: **Not applicable.** This PR touches no firmware update path,
boot slot, partition or release file.

Gate definition: `docs/update-survivability-gate.md`

EXIT=0
```

---

## What a passing report looks like

The gate accepts only a filled-in matrix from a designated test device — recording running slot, target slot, image SHA-256 and boot result for every transition — pasted into the PR description or added under `docs/hardware-validation/`. It covers both ping-pong directions plus a closing third hop, self-reinstall, wrong-chip, wrong-board, corrupt/truncated, HTTP failure before and during download, power loss at five documented stages, and a previous-slot boot check after every failure.

US-0 is the recovery precondition: before any RC is flashed, one recovery method must be proven on that device — a working ROM-loader USB connection, a tested rollback, or a sacrificial unit with professional flash recovery arranged. And the device rule: **never the owner's only working unit.**

The document states explicitly that a single successful installation is not sufficient evidence — that is exactly what passed on the change that caused this.
