### PR TITLE
DISPOSABLE: gate proof B — protected updater path (do not merge)

### DIFF
--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -312,3 +312,5 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   LOG_INF("OTA", "Update completed");
   return OK;
 }
+
+// Disposable gate-wiring proof B: comment-only, never merged.


### PR DESCRIPTION
Disposable live-wiring proof for the Update Survivability Gate. **Do not merge.** Will be closed and its branch deleted.

A comment-only change to `src/network/OtaUpdater.cpp`, a protected updater path.

Expected: the gate **blocks** and names that path, because it carries no hardware validation report. The change being comment-only is deliberately irrelevant — the gate reads paths, not patch size.